### PR TITLE
add NodeStatus: new

### DIFF
--- a/src/endpoints/nodes/entities/node.status.ts
+++ b/src/endpoints/nodes/entities/node.status.ts
@@ -1,4 +1,5 @@
 export enum NodeStatus {
+    new = 'new',
     unknown = 'unknown',
     waiting = 'waiting',
     eligible = 'eligible',


### PR DESCRIPTION
Node status "New" is not present in  Node Status Array:

Required for this query: 
https://explorer.elrond.com/nodes?online=false&status=new