### PR TITLE
fix spelling in swagger documentation file

### DIFF
--- a/docs/swagger.md
+++ b/docs/swagger.md
@@ -1,4 +1,4 @@
-## Welcome the the Elrond API
+## Welcome to the Elrond API
 
 The API is built to allow you to create apps or integrations quickly and easily.
 


### PR DESCRIPTION
Fixed spelling in the first h2 element that appears in API URLs (E.g.: https://api.elrond.com/ ).

@tanghel 