### PR TITLE
Elastic profile get item

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,9 +6,14 @@
 ## Problem setting
 - 
 - 
--
+- 
   
 ## Proposed Changes
--
--
--
+- 
+- 
+- 
+
+## How to test
+- 
+- 
+- 

--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -43,7 +43,13 @@ export class ElasticService {
 
   async getItem(collection: string, key: string, identifier: string) {
     const url = `${this.url}/${collection}/_search?q=_id:${identifier}`;
+
+    const profiler = new PerformanceProfiler();
+
     const result = await this.get(url);
+
+    profiler.stop();
+    this.metricsService.setElasticDuration(collection, profiler.duration);
 
     const hits = result.data?.hits?.hits;
     if (hits && hits.length > 0) {

--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -10,6 +10,7 @@ import { QueryOperator } from "./entities/query.operator";
 import { QueryConditionOptions } from "./entities/query.condition.options";
 import { QueryPagination } from "../entities/query.pagination";
 import { ElasticSortOrder } from "./entities/elastic.sort.order";
+import { ElasticMetricType } from "../metrics/entities/elastic.metric.type";
 
 @Injectable()
 export class ElasticService {
@@ -34,7 +35,7 @@ export class ElasticService {
 
     profiler.stop();
 
-    this.metricsService.setElasticDuration(collection, profiler.duration);
+    this.metricsService.setElasticDuration(collection, ElasticMetricType.count, profiler.duration);
 
     const count = result.data.count;
 
@@ -49,7 +50,7 @@ export class ElasticService {
     const result = await this.get(url);
 
     profiler.stop();
-    this.metricsService.setElasticDuration(collection, profiler.duration);
+    this.metricsService.setElasticDuration(collection, ElasticMetricType.item, profiler.duration);
 
     const hits = result.data?.hits?.hits;
     if (hits && hits.length > 0) {
@@ -78,12 +79,7 @@ export class ElasticService {
 
     profiler.stop();
 
-    this.metricsService.setElasticDuration(collection, profiler.duration);
-
-    const took = result.data.took;
-    if (!isNaN(took)) {
-      this.metricsService.setElasticTook(collection, took);
-    }
+    this.metricsService.setElasticDuration(collection, ElasticMetricType.list, profiler.duration);
 
     const documents = result.data.hits.hits;
     return documents.map((document: any) => this.formatItem(document, key));
@@ -187,12 +183,7 @@ export class ElasticService {
 
     profiler.stop();
 
-    this.metricsService.setElasticDuration(collection, profiler.duration);
-
-    const took = result.data.tookn;
-    if (!isNaN(took)) {
-      this.metricsService.setElasticTook(collection, took);
-    }
+    this.metricsService.setElasticDuration(collection, ElasticMetricType.list, profiler.duration);
 
     return result.data.hits.hits;
   }
@@ -212,7 +203,7 @@ export class ElasticService {
 
     profiler.stop();
 
-    this.metricsService.setElasticDuration(collection, profiler.duration);
+    this.metricsService.setElasticDuration(collection, ElasticMetricType.count, profiler.duration);
 
     return value;
   }

--- a/src/common/metrics/entities/elastic.metric.type.ts
+++ b/src/common/metrics/entities/elastic.metric.type.ts
@@ -1,0 +1,5 @@
+export enum ElasticMetricType {
+  list = 'list',
+  item = 'item',
+  count = 'count'
+}

--- a/src/common/metrics/metrics.service.ts
+++ b/src/common/metrics/metrics.service.ts
@@ -4,6 +4,7 @@ import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { GatewayComponentRequest } from "../gateway/entities/gateway.component.request";
 import { GatewayService } from "../gateway/gateway.service";
 import { ProtocolService } from "../protocol/protocol.service";
+import { ElasticMetricType } from "./entities/elastic.metric.type";
 
 @Injectable()
 export class MetricsService {
@@ -66,7 +67,7 @@ export class MetricsService {
       MetricsService.elasticDurationHistogram = new Histogram({
         name: 'elastic_duration',
         help: 'Elastic Duration',
-        labelNames: ['index'],
+        labelNames: ['type', 'index'],
         buckets: [],
       });
     }
@@ -152,16 +153,12 @@ export class MetricsService {
     MetricsService.externalCallsHistogram.labels(system).observe(duration);
   }
 
-  setElasticDuration(index: string, duration: number) {
-    MetricsService.elasticDurationHistogram.labels(index).observe(duration);
+  setElasticDuration(collection: string, type: ElasticMetricType, duration: number) {
+    MetricsService.elasticDurationHistogram.labels(type, collection).observe(duration);
   }
 
   setGatewayDuration(name: string, duration: number) {
     MetricsService.gatewayDurationHistogram.labels(name).observe(duration);
-  }
-
-  setElasticTook(index: string, took: number) {
-    MetricsService.elasticTookHistogram.labels(index).observe(took);
   }
 
   setRedisDuration(action: string, duration: number) {


### PR DESCRIPTION
## Type
- [x] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- Elastic search metrics are not reported when individual items are requested
  
## Proposed Changes
- Add metric for item request
- Remove took metric since it's not used any more
- Added elastic metric type to distinguish between list/item/count requests

## How to test
- perform various requests on endpoints that fetch data from elastic, such as /transactions or /blocks as list, item and count
- request metrics using http://localhost:4001/metrics and watch the correct buckets go up