### PR TITLE
Keybase pub less parallel requests

### DIFF
--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -109,7 +109,7 @@ export class KeybaseService {
     const distinctIdentities = allKeybases.map(x => x.identity ?? '').filter(x => x !== '').distinct();
 
     await asyncPool(
-      10,
+      1,
       distinctIdentities,
       identity => this.confirmKeybasesAgainstKeybasePubForIdentity(identity)
     );


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Keybase.pub gives error when too many requests are performed against it
  
## Proposed Changes
- reduce degree of parallelizing to 1, since it will be handled in ~2m30s anyway, and is executed every 30 minutes in the cache warmer