### PR TITLE
Transactions withScResults / withOperations limit

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Logger, NotFoundException, Param, ParseIntPipe, Query } from '@nestjs/common';
+import { BadRequestException, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Logger, NotFoundException, Param, ParseIntPipe, Query } from '@nestjs/common';
 import { ApiExcludeEndpoint, ApiQuery, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { AccountService } from './account.service';
 import { AccountDetailed } from './entities/account.detailed';
@@ -597,6 +597,10 @@ export class AccountController {
     @Query('withScResults', new ParseOptionalBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseOptionalBoolPipe) withOperations?: boolean,
   ) {
+    if ((withScResults === true || withOperations === true) && size > 50) {
+      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults' or 'withOperations'`);
+    }
+
     try {
       return await this.transactionService.getTransactions({
         sender,

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -64,6 +64,10 @@ export class TransactionController {
     @Query('withScResults', new ParseOptionalBoolPipe) withScResults: boolean | undefined,
     @Query('withOperations', new ParseOptionalBoolPipe) withOperations: boolean | undefined,
   ): Promise<Transaction[]> {
+    if ((withScResults === true || withOperations === true) && size > 50) {
+      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults' or 'withOperations'`);
+    }
+
     return this.transactionService.getTransactions({
       sender,
       receiver,


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- when fetching transaction list and withScResults / withOperations parameter is set and a large size is requested, the underlying elasticsearch instance can receive up to 1000 queries, thus potentially bringing the API / Elasticsearch instance down
  
## Proposed Changes
- if withScResults / withOperations parameter is set, limit size to max 50