### PR TITLE
NFT Thumbnail fix

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -147,7 +147,8 @@ export class NftThumbnailService {
 
     let hasThumbnail = true;
     await this.apiService.head(url, { skipRedirects: true }, async (error) => {
-      if (error.response?.status === HttpStatus.NOT_FOUND || error.response?.status === HttpStatus.FOUND) {
+      const status = error.response?.status;
+      if ([HttpStatus.FOUND, HttpStatus.NOT_FOUND, HttpStatus.FORBIDDEN].includes(status)) {
         hasThumbnail = false;
         return true;
       }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- NFT Thumbnails could not be generated since when checking for existence of file was returning 403 Forbidden, and only 404 Not Found was handled
  
## Proposed Changes
- handle also 403 Forbidden in list of returned http statuses