### PR TITLE
filter collections by identifiers

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -5,6 +5,7 @@ import { NftCollection } from "./entities/nft.collection";
 import { NftType } from "../nfts/entities/nft.type";
 import { CollectionService } from "./collection.service";
 import { ParseAddressPipe } from "src/utils/pipes/parse.address.pipe";
+import { ParseArrayPipe } from "src/utils/pipes/parse.array.pipe";
 
 @Controller()
 @ApiTags('collections')
@@ -23,16 +24,18 @@ export class CollectionController {
   @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
+  @ApiQuery({ name: 'identifiers', description: 'Search by collection identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'type', description: 'Filter by type (NonFungibleESDT/SemiFungibleESDT/MetaESDT)', required: false })
   @ApiQuery({ name: 'creator', description: 'Filter NFTs where the given address has a creator role', required: false })
   async getNftCollections(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search: string | undefined,
+    @Query('identifiers', ParseArrayPipe) identifiers: string[] | undefined,
     @Query('type', new ParseOptionalEnumPipe(NftType)) type: NftType | undefined,
     @Query('creator', ParseAddressPipe) creator: string | undefined,
   ): Promise<NftCollection[]> {
-    return await this.collectionService.getNftCollections({ from, size }, { search, type, creator });
+    return await this.collectionService.getNftCollections({ from, size }, { search, type, creator, identifiers });
   }
 
   @Get("/collections/count")


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- There is no possible way to search collections by identifiers on list
  
## Proposed Changes
- Add 'identifiers' query param and apply filter to ES