### PR TITLE
sort branded tokens by holders

### DIFF
--- a/src/common/caching/caching.service.ts
+++ b/src/common/caching/caching.service.ts
@@ -321,12 +321,12 @@ export class CachingService {
 
     for (const key of Object.keys(batchGetResult)) {
       const value = batchGetResult[key];
-      if (!value) {
+      if (value === undefined) {
         continue;
       }
 
       const element = indexedElements[key];
-      if (!element) {
+      if (element === undefined) {
         continue;
       }
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -3,6 +3,7 @@ import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { ElasticService } from "src/common/elastic/elastic.service";
 import { ElasticQuery } from "src/common/elastic/entities/elastic.query";
 import { QueryConditionOptions } from "src/common/elastic/entities/query.condition.options";
+import { QueryOperator } from "src/common/elastic/entities/query.operator";
 import { QueryType } from "src/common/elastic/entities/query.type";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { MetricsService } from "src/common/metrics/metrics.service";
@@ -168,7 +169,32 @@ export class EsdtService {
       true
     );
 
-    return tokensProperties.zip(tokensAssets, (first, second) => ApiUtils.mergeObjects(new TokenDetailed, { ...first, assets: second }));
+    let tokens = tokensProperties.zip(tokensAssets, (first, second) => ApiUtils.mergeObjects(new TokenDetailed, { ...first, assets: second }));
+
+    for (const token of tokens) {
+      if (!token.assets) {
+        continue;
+      }
+
+      token.accounts = await this.cachingService.getOrSetCache(
+        CacheInfo.TokenAccounts(token.identifier).key,
+        async () => await this.getTokenAccountsCount(token.identifier),
+        CacheInfo.TokenAccounts(token.identifier).ttl
+      );
+    }
+
+    tokens = tokens.sortedDescending(token => token.accounts ?? 0);
+
+    return tokens;
+  }
+
+  async getTokenAccountsCount(identifier: string): Promise<number> {
+    const elasticQuery: ElasticQuery = ElasticQuery.create()
+      .withCondition(QueryConditionOptions.must, [QueryType.Match("token", identifier, QueryOperator.AND)]);
+
+    const count = await this.elasticService.getCount("accountsesdt", elasticQuery);
+
+    return count;
   }
 
   async getEsdtTokenAssetsRaw(identifier: string): Promise<TokenAssets | undefined> {

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -7,6 +7,7 @@ import { ParseBlockHashPipe } from "src/utils/pipes/parse.block.hash.pipe";
 import { ParseOptionalBoolPipe } from "src/utils/pipes/parse.optional.bool.pipe";
 import { ParseOptionalEnumPipe } from "src/utils/pipes/parse.optional.enum.pipe";
 import { ParseOptionalIntPipe } from "src/utils/pipes/parse.optional.int.pipe";
+import { EsdtService } from "../esdt/esdt.service";
 import { TransactionStatus } from "../transactions/entities/transaction.status";
 import { TransactionService } from "../transactions/transaction.service";
 import { TokenAccount } from "./entities/token.account";
@@ -21,6 +22,7 @@ export class TokenController {
   constructor(
     private readonly tokenService: TokenService,
     private readonly transactionService: TransactionService,
+    private readonly esdtService: EsdtService,
   ) {
     this.logger = new Logger(TokenController.name);
   }
@@ -130,7 +132,7 @@ export class TokenController {
   getTokenAccountsCount(
     @Param('identifier') identifier: string,
   ): Promise<number> {
-    return this.tokenService.getTokenAccountsCount(identifier);
+    return this.esdtService.getTokenAccountsCount(identifier);
   }
 
   @Get("/tokens/:identifier/transactions")

--- a/src/test/unit/utils/array.extensions.spec.ts
+++ b/src/test/unit/utils/array.extensions.spec.ts
@@ -178,4 +178,54 @@ describe('Array Extensions', () => {
       },
     ]);
   });
+
+  describe('Sorted', () => {
+    it('simple', () => {
+      const actual = [2, 1, 3].sorted();
+      const expected = [1, 2, 3];
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('complex', () => {
+      const actual = [
+        { id: 2 },
+        { id: 1 },
+        { id: 3 },
+      ].sorted(x => x.id);
+
+      const expected = [
+        { id: 1 },
+        { id: 2 },
+        { id: 3 },
+      ];
+
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  describe('Sorted descending', () => {
+    it('simple', () => {
+      const actual = [2, 1, 3].sortedDescending();
+      const expected = [3, 2, 1];
+
+      expect(actual).toEqual(expected);
+    });
+
+    it('complex', () => {
+      const actual = [
+        { id: 2 },
+        { id: 1 },
+        { id: 3 },
+      ].sortedDescending(x => x.id);
+
+      const expected = [
+        { id: 3 },
+        { id: 2 },
+        { id: 1 },
+      ];
+
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/utils/batch.utils.ts
+++ b/src/utils/batch.utils.ts
@@ -63,7 +63,7 @@ export class BatchUtils {
         const identifier = identifierFunc(inputElement);
         const outputElement = outputElements[identifier];
 
-        if (outputElement) {
+        if (outputElement !== undefined) {
           found[identifier] = outputElement;
         } else {
           remaining.push(inputElement);

--- a/src/utils/extensions/array.extensions.ts
+++ b/src/utils/extensions/array.extensions.ts
@@ -100,6 +100,26 @@ Array.prototype.toRecord = function <TIN, TOUT>(keyPredicate: (item: TIN) => str
   return result;
 };
 
+Array.prototype.sorted = function <T>(predicate?: (item: T) => number): T[] {
+  const cloned = [...this];
+
+  if (predicate) {
+    cloned.sort((a, b) => predicate(a) - predicate(b));
+  } else {
+    cloned.sort((a, b) => a - b);
+  }
+
+  return cloned;
+};
+
+Array.prototype.sortedDescending = function <T>(predicate?: (item: T) => number): T[] {
+  const sorted = this.sorted(predicate);
+
+  sorted.reverse();
+
+  return sorted;
+};
+
 declare interface Array<T> {
   groupBy(predicate: (item: T) => any): any;
   selectMany<TOUT>(predicate: (item: T) => TOUT[]): TOUT[];
@@ -110,5 +130,7 @@ declare interface Array<T> {
   distinct(): T[];
   distinctBy<TResult>(predicate: (element: T) => TResult): T[];
   all(predicate: (item: T) => boolean): boolean;
+  sorted(predicate?: (element: T) => number): T[];
+  sortedDescending(predicate?: (element: T) => number): T[];
   toRecord<TOUT>(keyPredicate: (item: T) => string, valuePredicate?: (item: T) => TOUT): Record<string, TOUT>;
 }


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- Currently branded tokens are displayed in random order.
  
## Proposed Changes
- Sort branded tokens by number of holders