### PR TITLE
use await to fetch token supply

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -43,7 +43,7 @@ export class TokenService {
 
     await this.applyTickerFromAssets(token);
 
-    this.applySupply(token);
+    await this.applySupply(token);
 
     await this.processToken(token);
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- token supply & circulatingSupply not returned when fetching details
  
## Proposed Changes
- use await to wait for supply to be attached to token