### PR TITLE
Token transfer properties fix

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -161,11 +161,14 @@ export class TokenTransferService {
   }
 
   async getTokenTransferProperties(identifier: string, nonce?: string): Promise<TokenTransferProperties | null> {
-    const properties = await this.cachingService.getOrSetCache(
+    let properties = await this.cachingService.getOrSetCache(
       CacheInfo.TokenTransferProperties(identifier).key,
       async () => await this.getTokenTransferPropertiesRaw(identifier),
       Constants.oneDay()
     );
+
+    // we clone it since we alter the resulting object 
+    properties = JSON.parse(JSON.stringify(properties));
 
     if (properties && nonce) {
       properties.identifier = `${identifier}-${nonce}`;


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- when multiple NFTs of the same collection were transferred in the same transaction but with difference nonces, the same nonce was found in all transfers
  
## Proposed Changes
- clone the resulting object to avoid one change to affect all others

## How to test
- tx hash `8f094c86b528625e4f1bd2f7326ee008ed96207ad6fe159c55fbdb203297f58c` (mainnet)