### PR TITLE
adjust page size to number of addresses

### DIFF
--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -98,7 +98,7 @@ export class ElasticService {
     }
 
     const elasticQuery = ElasticQuery.create()
-      .withPagination({ from: 0, size: 25 })
+      .withPagination({ from: 0, size: addresses.length })
       .withCondition(QueryConditionOptions.mustNot, [QueryType.Match("address", "pending-")])
       .withCondition(QueryConditionOptions.must, [QueryType.Match('token', identifier, QueryOperator.AND)])
       .withFilter([new RangeQuery("balanceNum", undefined, 0)])


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- balances for at most 25 locked accounts were fetched
  
## Proposed Changes
- adjust length of result to number of requested addresses