### PR TITLE
Identity filter improvement

### DIFF
--- a/src/endpoints/identities/identities.service.ts
+++ b/src/endpoints/identities/identities.service.ts
@@ -234,7 +234,7 @@ export class IdentitiesService {
     });
 
     identities = identities
-      .filter((identity) => identity && identity.locked !== '0');
+      .filter((identity) => identity && (identity.validators ?? 0) > 0);
 
     identities.sort((a, b) => {
       const aSort = a && a.locked && a.locked !== '0' ? parseInt(a.locked.slice(0, -18)) : 0;

--- a/src/endpoints/providers/provider.service.ts
+++ b/src/endpoints/providers/provider.service.ts
@@ -117,7 +117,7 @@ export class ProviderService {
       return bSort - aSort;
     });
 
-    providers = providers.filter(provider => provider.numNodes > 0 && provider.stake !== '0' && this.isIdentityFormattedCorrectly(provider.identity ?? ''));
+    providers = providers.filter(provider => provider.numNodes > 0 && this.isIdentityFormattedCorrectly(provider.identity ?? ''));
 
     return providers;
   }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Identities and providers were not shown if they had valid nodes that are leaving
  
## Proposed Changes
- change filter from `lockedAmount > 0` to `nodesCount > 0`

## How to test
- `/identities/nethus` should return http 200
- `/providers/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqslllllsq4a3pq` should return http 200