### PR TITLE
verify distribution only if at least one value inside

### DIFF
--- a/src/test/integration/identities.e2e-spec.ts
+++ b/src/test/integration/identities.e2e-spec.ts
@@ -54,13 +54,16 @@ describe('Identities Service', () => {
 
     it('should distribution sum be 1', async () => {
       for (const identity of identities) {
-        if (identity.distribution && Object.keys(identity.distribution).length > 0) {
-          let sum = 0;
-          for (const distribution of Object.values(identity.distribution)) {
-            sum += distribution;
-          }
+        if (identity.distribution) {
+          const distributionValues = Object.values(identity.distribution).filter(x => x !== null);
+          if (distributionValues.length > 0) {
+            let sum = 0;
+            for (const distribution of distributionValues) {
+              sum += distribution;
+            }
 
-          expect(sum).toStrictEqual(1);
+            expect(sum).toStrictEqual(1);
+          }
         }
       }
     });

--- a/src/test/integration/identities.e2e-spec.ts
+++ b/src/test/integration/identities.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Identities Service', () => {
 
     it('should distribution sum be 1', async () => {
       for (const identity of identities) {
-        if (identity.distribution) {
+        if (identity.distribution && Object.keys(identity.distribution).length > 0) {
           let sum = 0;
           for (const distribution of Object.values(identity.distribution)) {
             sum += distribution;


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- identities test was failing because distribution object was empty
  
## Proposed Changes
- check sum equals 1 only if distribution contains at least one key