### PR TITLE
remove ESDT pending balances

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -249,7 +249,8 @@ export class TokenService {
     const elasticQuery: ElasticQuery = ElasticQuery.create()
       .withPagination(pagination)
       .withSort([{ name: "balanceNum", order: ElasticSortOrder.descending }])
-      .withCondition(QueryConditionOptions.must, [QueryType.Match("token", identifier, QueryOperator.AND)]);
+      .withCondition(QueryConditionOptions.must, [QueryType.Match("token", identifier, QueryOperator.AND)])
+      .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')]);
 
     const tokenAccounts = await this.elasticService.getList("accountsesdt", identifier, elasticQuery);
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Pending balances shows in ESDT token accounts
  
## Proposed Changes
-  remove pending balances from ESDT token accounts

## How to test
-  Make requests to '/tokens/:identifier/accounts', it should not show any `pending-` in front of addresses