### PR TITLE
extend token transfer properties

### DIFF
--- a/src/endpoints/tokens/entities/token.transfer.properties.ts
+++ b/src/endpoints/tokens/entities/token.transfer.properties.ts
@@ -8,4 +8,5 @@ export class TokenTransferProperties {
   ticker: string = '';
   decimals?: number = 0;
   name: string = '';
+  svgUrl: string = '';
 }

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -189,6 +189,7 @@ export class TokenTransferService {
       type: properties.type,
       name: properties.name,
       ticker: assets ? identifier.split('-')[0] : identifier,
+      svgUrl: assets ? assets.svgUrl : '',
     };
 
     if (properties.type === 'FungibleESDT') {


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- There are no informations about token logo in transfers
  
## Proposed Changes
- Extend token transfer properties to use svgUrl for token

## How to test
- Find transactions that are related to mex or esdt interactions
- in trasfer properties should appear token logo url