### PR TITLE
SCResults miniBlockHash support

### DIFF
--- a/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.filter.ts
@@ -1,0 +1,3 @@
+export class SmartContractResultFilter {
+  miniBlockHash?: string;
+}

--- a/src/endpoints/sc-results/entities/smart.contract.result.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.ts
@@ -41,6 +41,9 @@ export class SmartContractResult {
     @ApiProperty()
     callType: string = '';
 
+    @ApiProperty()
+    miniBlockHash: string | undefined = undefined;
+
     @ApiProperty({ type: TransactionLog })
     logs: TransactionLog | undefined = undefined;
 

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -11,6 +11,7 @@ export class SmartContractResultController {
 
   @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'miniBlockHash', description: 'The hash of the parent miniBlock', required: false })
   @Get("/sc-results")
   @ApiResponse({
     status: 200,
@@ -20,8 +21,9 @@ export class SmartContractResultController {
   getScResults(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('miniBlockHash') miniBlockHash?: string,
   ): Promise<SmartContractResult[]> {
-    return this.scResultService.getScResults({ from, size });
+    return this.scResultService.getScResults({ from, size }, { miniBlockHash });
   }
 
   @Get("/sc-results/count")

--- a/src/endpoints/sc-results/scresult.service.ts
+++ b/src/endpoints/sc-results/scresult.service.ts
@@ -8,6 +8,7 @@ import { QueryType } from "src/common/elastic/entities/query.type";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { ApiUtils } from "src/utils/api.utils";
 import { SmartContractResult } from "./entities/smart.contract.result";
+import { SmartContractResultFilter } from "./entities/smart.contract.result.filter";
 
 @Injectable()
 export class SmartContractResultService {
@@ -31,8 +32,14 @@ export class SmartContractResultService {
     return elasticQuery;
   }
 
-  async getScResults(pagination: QueryPagination): Promise<SmartContractResult[]> {
-    const elasticResult = await this.elasticService.getList('scresults', 'hash', ElasticQuery.create().withPagination(pagination));
+  async getScResults(pagination: QueryPagination, filter: SmartContractResultFilter): Promise<SmartContractResult[]> {
+    let query = ElasticQuery.create().withPagination(pagination);
+
+    if (filter.miniBlockHash) {
+      query = query.withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlockHash', filter.miniBlockHash)]);
+    }
+
+    const elasticResult = await this.elasticService.getList('scresults', 'hash', query);
 
     return elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
   }

--- a/src/test/integration/scresults.e2e-spec.ts
+++ b/src/test/integration/scresults.e2e-spec.ts
@@ -4,6 +4,7 @@ import Initializer from './e2e-init';
 import { Constants } from 'src/utils/constants';
 import { SmartContractResultService } from 'src/endpoints/sc-results/scresult.service';
 import { SmartContractResult } from 'src/endpoints/sc-results/entities/smart.contract.result';
+import { SmartContractResultFilter } from 'src/endpoints/sc-results/entities/smart.contract.result.filter';
 
 describe('Scresults Service', () => {
   let scresultsService: SmartContractResultService;
@@ -18,7 +19,7 @@ describe('Scresults Service', () => {
 
     scresultsService = moduleRef.get<SmartContractResultService>(SmartContractResultService);
 
-    const scresults = await scresultsService.getScResults({ from: 0, size: 1 });
+    const scresults = await scresultsService.getScResults({ from: 0, size: 1 }, new SmartContractResultFilter());
     expect(scresults).toHaveLength(1);
 
     const scResult = scresults[0];
@@ -31,7 +32,7 @@ describe('Scresults Service', () => {
       const scresultsList = await scresultsService.getScResults({
         from: 0,
         size: 25,
-      });
+      }, new SmartContractResultFilter());
       for (const scresult of scresultsList) {
         expect(scresult).toHaveProperty('hash');
         expect(scresult).toHaveProperty('nonce');
@@ -43,7 +44,7 @@ describe('Scresults Service', () => {
       const scresultsList = await scresultsService.getScResults({
         from: 0,
         size: 25,
-      });
+      }, new SmartContractResultFilter());
 
       expect(scresultsList).toBeInstanceOf(Array);
       expect(scresultsList).toHaveLength(25);
@@ -59,7 +60,7 @@ describe('Scresults Service', () => {
       const scresultsList = await scresultsService.getScResults({
         from: 0,
         size: 50,
-      });
+      }, new SmartContractResultFilter());
       expect(scresultsList).toBeInstanceOf(Array);
       expect(scresultsList).toHaveLength(50);
 


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- sc-results endpoint does not have support for filtering by miniBlockHash
  
## Proposed Changes
- add miniBlockHash attribute in SmartContractResult class
- add miniBlockHash filter in sc-results endpoint

## How to test (Devnet)
- `/sc-results` endpoint must return values with attribute `miniBlockHash`
- `/sc-results?miniBlockHash=19adca4e23efc4ffb9d42a58aad2bfd7578bd63ff55ad84939b6d8c512a06dde` should return one scr