### PR TITLE
check if transaction is scresult before returning

### DIFF
--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -167,12 +167,13 @@ export class TransactionGetService {
         return null;
       }
 
-      if (transactionResult.miniblockType === 'SmartContractResultBlock') {
+      const transaction = transactionResult.transaction;
+
+      if (!transaction) {
         return null;
       }
 
-      const transaction = transactionResult.transaction;
-      if (!transaction) {
+      if (transaction.miniblockType === 'SmartContractResultBlock') {
         return null;
       }
 

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -167,6 +167,10 @@ export class TransactionGetService {
         return null;
       }
 
+      if (transactionResult.miniblockType === 'SmartContractResultBlock') {
+        return null;
+      }
+
       const transaction = transactionResult.transaction;
       if (!transaction) {
         return null;


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Scresults are recognized as transactions
  
## Proposed Changes
- Check if transaction returned from gateway is a sc result

## How to test
- /transactions/c39f65da9751bce38b28290dd19cbd8193584d06ed9927d382366fe64b62f1bc should return 'Transaction not found'