### PR TITLE
Token numeric circulating supply

### DIFF
--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -27,5 +27,5 @@ export class TokenDetailed extends Token {
   supply: string | undefined = undefined;
 
   @ApiProperty()
-  circulatingSupply: string | undefined = undefined;
+  circulatingSupply: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -24,7 +24,7 @@ export class TokenDetailed extends Token {
   canWipe: boolean = false;
 
   @ApiProperty()
-  supply: string | undefined = undefined;
+  supply: number | undefined = undefined;
 
   @ApiProperty()
   circulatingSupply: number | undefined = undefined;

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -21,6 +21,7 @@ import { TransactionService } from "../transactions/transaction.service";
 import { RecordUtils } from "src/utils/record.utils";
 import { EsdtSupply } from "../esdt/entities/esdt.supply";
 import { TokenType } from "./entities/token.type";
+import { NumberUtils } from "src/utils/number.utils";
 
 @Injectable()
 export class TokenService {
@@ -285,7 +286,7 @@ export class TokenService {
     const { totalSupply, circulatingSupply } = await this.esdtService.getTokenSupply(token.identifier);
 
     token.supply = totalSupply;
-    token.circulatingSupply = circulatingSupply;
+    token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply));
   }
 
   async getTokenSupply(identifier: string): Promise<EsdtSupply | undefined> {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -285,7 +285,7 @@ export class TokenService {
   async applySupply(token: TokenDetailed): Promise<void> {
     const { totalSupply, circulatingSupply } = await this.esdtService.getTokenSupply(token.identifier);
 
-    token.supply = totalSupply;
+    token.supply = NumberUtils.denominate(BigInt(totalSupply));
     token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply));
   }
 


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- token circulating supply available as string, although usually it is a numeric amount
  
## Proposed Changes
- change `supply` and `circulatingSupply` for token to denominated numeric value

## How to test (mainnet)
- `tokens/RIDE-7d18e9?fields=supply,circulatingSupply` should return two numeric values