### PR TITLE
Add query filter on sort only if node has property

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -135,7 +135,7 @@ export class NodeService {
         return false;
       }
 
-      if(query.sort && !node.hasOwnProperty(query.sort)){
+      if(query.sort && !(query.sort in node)){
         return false;
       }
 

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -135,6 +135,10 @@ export class NodeService {
         return false;
       }
 
+      if(query.sort && !node.hasOwnProperty(query.sort)){
+        return false;
+      }
+
       return true;
     });
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
When sorting by validatorIgnoredSignatures the array was not sorting the nodes array.
  
## Proposed Changes
In case of sorting, ignore the nodes that not have the wanted filtered property.

## How to test
https://api.elrond.com/nodes?from=0&size=25&sort=validatorIgnoredSignatures&order=desc 

The fix will be also pushed on ElrondScan.