### PR TITLE
support for numeric supply in token endpoint

### DIFF
--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -24,8 +24,8 @@ export class TokenDetailed extends Token {
   canWipe: boolean = false;
 
   @ApiProperty()
-  supply: number | undefined = undefined;
+  supply: string | undefined = undefined;
 
   @ApiProperty()
-  circulatingSupply: number | undefined = undefined;
+  circulatingSupply: string | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -24,7 +24,7 @@ export class TokenDetailed extends Token {
   canWipe: boolean = false;
 
   @ApiProperty()
-  supply: string | undefined = undefined;
+  supply: number | undefined = undefined;
 
   @ApiProperty()
   circulatingSupply: number | undefined = undefined;

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -108,13 +108,13 @@ export class TokenController {
     status: 404,
     description: 'Token not found',
   })
-  async getTokenSupply(@Param('identifier') identifier: string): Promise<{ supply: string, circulatingSupply: string }> {
+  async getTokenSupply(@Param('identifier') identifier: string): Promise<{ supply: number, circulatingSupply: number }> {
     const getSupplyResult = await this.tokenService.getTokenSupply(identifier);
     if (!getSupplyResult) {
       throw new NotFoundException();
     }
 
-    return { supply: getSupplyResult.totalSupply, circulatingSupply: getSupplyResult.circulatingSupply };
+    return getSupplyResult;
   }
 
   @Get("/tokens/:identifier/accounts")

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -108,7 +108,7 @@ export class TokenController {
     status: 404,
     description: 'Token not found',
   })
-  async getTokenSupply(@Param('identifier') identifier: string): Promise<{ supply: number, circulatingSupply: number }> {
+  async getTokenSupply(@Param('identifier') identifier: string): Promise<{ supply: string, circulatingSupply: string }> {
     const getSupplyResult = await this.tokenService.getTokenSupply(identifier);
     if (!getSupplyResult) {
       throw new NotFoundException();

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -284,11 +284,11 @@ export class TokenService {
   async applySupply(token: TokenDetailed): Promise<void> {
     const { totalSupply, circulatingSupply } = await this.esdtService.getTokenSupply(token.identifier);
 
-    token.supply = NumberUtils.denominate(BigInt(totalSupply), token.decimals);
-    token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply), token.decimals);
+    token.supply = NumberUtils.denominate(BigInt(totalSupply), token.decimals).toFixed();
+    token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply), token.decimals).toFixed();
   }
 
-  async getTokenSupply(identifier: string): Promise<{ supply: number, circulatingSupply: number } | undefined> {
+  async getTokenSupply(identifier: string): Promise<{ supply: string, circulatingSupply: string } | undefined> {
     if (identifier.split('-').length !== 2) {
       return undefined;
     }
@@ -305,8 +305,8 @@ export class TokenService {
     const result = await this.esdtService.getTokenSupply(identifier);
 
     return {
-      supply: NumberUtils.denominateString(result.totalSupply, properties.decimals),
-      circulatingSupply: NumberUtils.denominateString(result.circulatingSupply, properties.decimals),
+      supply: NumberUtils.denominateString(result.totalSupply, properties.decimals).toFixed(),
+      circulatingSupply: NumberUtils.denominateString(result.circulatingSupply, properties.decimals).toFixed(),
     };
   }
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -19,7 +19,6 @@ import { CachingService } from "src/common/caching/caching.service";
 import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { TransactionService } from "../transactions/transaction.service";
 import { RecordUtils } from "src/utils/record.utils";
-import { EsdtSupply } from "../esdt/entities/esdt.supply";
 import { TokenType } from "./entities/token.type";
 import { NumberUtils } from "src/utils/number.utils";
 
@@ -285,11 +284,11 @@ export class TokenService {
   async applySupply(token: TokenDetailed): Promise<void> {
     const { totalSupply, circulatingSupply } = await this.esdtService.getTokenSupply(token.identifier);
 
-    token.supply = totalSupply;
-    token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply));
+    token.supply = NumberUtils.denominate(BigInt(totalSupply), token.decimals);
+    token.circulatingSupply = NumberUtils.denominate(BigInt(circulatingSupply), token.decimals);
   }
 
-  async getTokenSupply(identifier: string): Promise<EsdtSupply | undefined> {
+  async getTokenSupply(identifier: string): Promise<{ supply: number, circulatingSupply: number } | undefined> {
     if (identifier.split('-').length !== 2) {
       return undefined;
     }
@@ -303,6 +302,11 @@ export class TokenService {
       return undefined;
     }
 
-    return await this.esdtService.getTokenSupply(identifier);
+    const result = await this.esdtService.getTokenSupply(identifier);
+
+    return {
+      supply: NumberUtils.denominateString(result.totalSupply, properties.decimals),
+      circulatingSupply: NumberUtils.denominateString(result.circulatingSupply, properties.decimals),
+    };
   }
 }

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -6,7 +6,6 @@ import { Constants } from 'src/utils/constants';
 import { TokenFilter } from 'src/endpoints/tokens/entities/token.filter';
 import { TokenWithBalance } from "../../endpoints/tokens/entities/token.with.balance";
 import { TokenDetailed } from "../../endpoints/tokens/entities/token.detailed";
-import { EsdtSupply } from "../../endpoints/esdt/entities/esdt.supply";
 import { TokenAccount } from "../../endpoints/tokens/entities/token.account";
 import { TokenAddressRoles } from 'src/endpoints/tokens/entities/token.address.roles';
 import tokenDetails from '../data/esdt/token/token.example';
@@ -183,9 +182,16 @@ describe('Token Service', () => {
   describe('Get Token Supply', () => {
     it(`should return token supply`, async () => {
       const supply = await tokenService.getTokenSupply(tokenDetails.identifier);
-      expect(supply).toHaveStructure(Object.keys(new EsdtSupply()));
 
+      if(!supply){
+        throw new Error('Properties not defined');
+      }
+
+      expect(typeof supply).toBe('object');
+      expect(supply.hasOwnProperty('supply')).toBe(true);
+      expect(supply.hasOwnProperty('circulatingSupply')).toBe(true);
     });
+
     it(`should return undefined if identifier token is invalid`, async () => {
       const invalidIdentifier = 'invalidIdentifier';
       const supply = await tokenService.getTokenSupply(invalidIdentifier);

--- a/src/utils/number.utils.ts
+++ b/src/utils/number.utils.ts
@@ -1,11 +1,11 @@
 import BigNumber from 'bignumber.js';
 export class NumberUtils {
-  static denominate(value: BigInt): number {
-    return Number(value.valueOf() / BigInt(Math.pow(10, 18)));
+  static denominate(value: BigInt, decimals: number = 18): number {
+    return Number(value.valueOf() / BigInt(Math.pow(10, decimals)));
   }
 
-  static denominateString(value: string): number {
-    return NumberUtils.denominate(BigInt(value));
+  static denominateString(value: string, decimals: number = 18): number {
+    return NumberUtils.denominate(BigInt(value), decimals);
   }
 
   static toDenominatedString(amount: BigInt, decimals: number = 18): string {


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Proposed Changes
- supply as numeric both in token details and token supply details

## How to test (mainnet)
- `/tokens/RIDE-7d18e9?fields=supply,circulatingSupply` should have both fields `supply` and `circulatingSupply` of type numeric, denominated
- `/tokens/RIDE-7d18e9/supply` should have both fields `supply` and `circulatingSupply` of type numeric, denominated