### PR TITLE
Legacy elastic support

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { forwardRef, HttpStatus, Inject, Injectable, Logger } from '@nestjs/common';
 import { AccountDetailed } from './entities/account.detailed';
 import { Account } from './entities/account';
 import { CachingService } from 'src/common/caching/caching.service';
@@ -120,7 +120,16 @@ export class AccountService {
       return 0;
     }
 
-    return await this.elasticService.getCount('scresults', query);
+    try {
+      return await this.elasticService.getCount('scresults', query);
+    } catch (error) {
+      // @ts-ignore
+      if (error.response.status === HttpStatus.NOT_FOUND) {
+        return 0;
+      }
+
+      throw error;
+    }
   }
 
   async getAccountDeployedAt(address: string): Promise<number | null> {


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
  
## Proposed Changes
- Make sure account details works with legacy indexers even if `useLegacyElastic` flag is set to `false`

## How to test
- set indexer url to `http://104.248.103.160`
- set `useLegacyElastic` flag to `false`
- try `accounts/:account` route and make sure it does not crash