### PR TITLE
Account NFTs performance improvement

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -443,7 +443,7 @@ export class NftService {
   }
 
   async getNftCountForAddress(address: string, filter: NftFilter): Promise<number> {
-    const nfts = await this.getNftsForAddressInternal(address, filter);
+    const nfts = await this.getNftsForAddressInternal(address, filter, false);
 
     return nfts.length;
   }
@@ -524,10 +524,13 @@ export class NftService {
     return Object.values(esdts).map(x => x as any).filter(x => x.tokenIdentifier.split('-').length === 3);
   }
 
-  async getNftsForAddressInternal(address: string, filter: NftFilter): Promise<NftAccount[]> {
+  async getNftsForAddressInternal(address: string, filter: NftFilter, sort: boolean = true): Promise<NftAccount[]> {
     const gatewayNfts = await this.getGatewayNfts(address, filter);
 
-    gatewayNfts.sort((a: GatewayNft, b: GatewayNft) => a.tokenIdentifier.localeCompare(b.tokenIdentifier, 'en', { sensitivity: 'base' }));
+    if (sort) {
+      const collator = new Intl.Collator('en', { numeric: true, sensitivity: 'base' });
+      gatewayNfts.sort((a: GatewayNft, b: GatewayNft) => collator.compare(a.tokenIdentifier, b.tokenIdentifier));
+    }
 
     let nfts: NftAccount[] = [];
 


### PR DESCRIPTION
## Type
- [ ] Bug
- [ ] Feature  
- [x] Performance improvement

## Problem setting
- endpoint `/accounts/:account/nfts` very slow when many NFTs inside the account
  
## Proposed Changes
- use optimized sort function when sorting NFTs by identifier
- do not sort when called from `/accounts/:account/nfts/count`

## How to test (mainnet)
- `accounts/erd1qqqqqqqqqqqqqpgqd9rvv2n378e27jcts8vfwynpx0gfl5ufz6hqhfy0u0/nfts?search=ECYBORGX-f0a8cf` should return data faster