### PR TITLE
Economics locked tokens update

### DIFF
--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -102,7 +102,7 @@ export class NetworkService {
   }
 
   async getEconomicsRaw(): Promise<Economics> {
-    const locked = 2660000;
+    const locked = 1330000;
     const [
       {
         account: { balance },


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Proposed Changes
- update locked tokens from 2.660.000 to 1.330.000