### PR TITLE
decode smart contract attributes using binary values

### DIFF
--- a/src/test/unit/utils/address.utils.spec.ts
+++ b/src/test/unit/utils/address.utils.spec.ts
@@ -32,14 +32,54 @@ describe('Address utils', () => {
     }
   });
 
-  it('Decode smart contract attributes', () => {
+  it('Decode smart contract attribute "UPGRADEABLE"', () => {
     const attributesBase64 = 'BQI=';
 
     const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
 
-    expect(properties?.isUpgradeable).toBeTruthy();
-    expect(properties?.isReadable).toBeTruthy();
-    expect(properties?.isPayable).toBeTruthy();
-    expect(properties?.isPayableBySmartContract).toBeFalsy();
+    if (properties) {
+      expect(properties.isUpgradeable).toBeTruthy();
+      expect(properties.isReadable).toBeTruthy();
+      expect(properties.isPayable).toBeTruthy();
+      expect(properties.isPayableBySmartContract).toBeFalsy();
+    }
+  });
+
+  it('Decode smart contract attribute "READABLE"', () => {
+    const attributesBase64 = 'BAA=';
+
+    const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
+
+    if (properties) {
+      expect(properties.isReadable).toBeTruthy();
+      expect(properties.isUpgradeable).toBeFalsy();
+      expect(properties.isPayable).toBeFalsy();
+      expect(properties.isPayableBySmartContract).toBeFalsy();
+    }
+  });
+
+  it('Decode smart contract attributes "PAYABLE"', () => {
+    const attributesBase64 = 'AAI=';
+
+    const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
+    if (properties) {
+      expect(properties.isPayable).toBeTruthy();
+      expect(properties.isUpgradeable).toBeFalsy();
+      expect(properties.isReadable).toBeFalsy();
+      expect(properties.isPayableBySmartContract).toBeFalsy();
+    }
+  });
+
+  it('Decode smart contract attributes "PAYABLE_BY_SC"', () => {
+    const attributesBase64 = 'AAQ=';
+
+    const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
+
+    if (properties) {
+      expect(properties.isPayableBySmartContract).toBeTruthy();
+      expect(properties.isUpgradeable).toBeFalsy();
+      expect(properties.isReadable).toBeFalsy();
+      expect(properties.isPayable).toBeFalsy();
+    }
   });
 });

--- a/src/test/unit/utils/address.utils.spec.ts
+++ b/src/test/unit/utils/address.utils.spec.ts
@@ -31,4 +31,15 @@ describe('Address utils', () => {
       expect(address).toBeFalsy();
     }
   });
+
+  it('Decode smart contract attributes', () => {
+    const attributesBase64 = 'BQI=';
+
+    const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
+
+    expect(properties?.isUpgradeable).toBeTruthy();
+    expect(properties?.isReadable).toBeTruthy();
+    expect(properties?.isPayable).toBeTruthy();
+    expect(properties?.isPayableBySmartContract).toBeFalsy();
+  });
 });

--- a/src/test/unit/utils/address.utils.spec.ts
+++ b/src/test/unit/utils/address.utils.spec.ts
@@ -11,8 +11,8 @@ describe('Address utils', () => {
   });
 
   it('is smart contract address', () => {
-    expect(AddressUtils.isSmartContractAddress('erd1rf4hv70arudgzus0ymnnsnc4pml0jkywg2xjvzslg0mz4nn2tg7q7k0t6p')).toBeFalsy();
-    expect(AddressUtils.isSmartContractAddress('erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l')).toBeTruthy();
+    expect(AddressUtils.isSmartContractAddress('erd1rf4hv70arudgzus0ymnnsnc4pml0jkywg2xjvzslg0mz4nn2tg7q7k0t6p')).toStrictEqual(false);
+    expect(AddressUtils.isSmartContractAddress('erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l')).toStrictEqual(true);
   });
 
   it('compute shard for address', () => {
@@ -22,13 +22,13 @@ describe('Address utils', () => {
   });
 
   it('check if address is valid, return true', () => {
-    expect(AddressUtils.isAddressValid('erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l')).toBeTruthy();
+    expect(AddressUtils.isAddressValid('erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l')).toStrictEqual(true);
   });
 
   it('check if address is not valid', () => {
     const address = AddressUtils.isAddressValid('erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l');
     if (!address) {
-      expect(address).toBeFalsy();
+      expect(address).toStrictEqual(false);
     }
   });
 
@@ -38,10 +38,10 @@ describe('Address utils', () => {
     const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
 
     if (properties) {
-      expect(properties.isUpgradeable).toBeTruthy();
-      expect(properties.isReadable).toBeTruthy();
-      expect(properties.isPayable).toBeTruthy();
-      expect(properties.isPayableBySmartContract).toBeFalsy();
+      expect(properties.isUpgradeable).toStrictEqual(true);
+      expect(properties.isReadable).toStrictEqual(true);
+      expect(properties.isPayable).toStrictEqual(true);
+      expect(properties.isPayableBySmartContract).toStrictEqual(false);
     }
   });
 
@@ -51,10 +51,10 @@ describe('Address utils', () => {
     const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
 
     if (properties) {
-      expect(properties.isReadable).toBeTruthy();
-      expect(properties.isUpgradeable).toBeFalsy();
-      expect(properties.isPayable).toBeFalsy();
-      expect(properties.isPayableBySmartContract).toBeFalsy();
+      expect(properties.isReadable).toStrictEqual(true);
+      expect(properties.isUpgradeable).toStrictEqual(false);
+      expect(properties.isPayable).toStrictEqual(false);
+      expect(properties.isPayableBySmartContract).toStrictEqual(false);
     }
   });
 
@@ -63,10 +63,10 @@ describe('Address utils', () => {
 
     const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
     if (properties) {
-      expect(properties.isPayable).toBeTruthy();
-      expect(properties.isUpgradeable).toBeFalsy();
-      expect(properties.isReadable).toBeFalsy();
-      expect(properties.isPayableBySmartContract).toBeFalsy();
+      expect(properties.isPayable).toStrictEqual(true);
+      expect(properties.isUpgradeable).toStrictEqual(false);
+      expect(properties.isReadable).toStrictEqual(false);
+      expect(properties.isPayableBySmartContract).toStrictEqual(false);
     }
   });
 
@@ -76,10 +76,10 @@ describe('Address utils', () => {
     const properties = AddressUtils.decodeCodeMetadata(attributesBase64);
 
     if (properties) {
-      expect(properties.isPayableBySmartContract).toBeTruthy();
-      expect(properties.isUpgradeable).toBeFalsy();
-      expect(properties.isReadable).toBeFalsy();
-      expect(properties.isPayable).toBeFalsy();
+      expect(properties.isPayableBySmartContract).toStrictEqual(true);
+      expect(properties.isUpgradeable).toStrictEqual(false);
+      expect(properties.isReadable).toStrictEqual(false);
+      expect(properties.isPayable).toStrictEqual(false);
     }
   });
 });

--- a/src/utils/address.utils.ts
+++ b/src/utils/address.utils.ts
@@ -85,10 +85,13 @@ export class AddressUtils {
       return undefined;
     }
 
-    const isUpgradeable = codeHex[1] === '1';
-    const isReadable = codeHex[1] === '4';
-    const isPayable = codeHex[3] === '2';
-    const isPayableBySmartContract = codeHex[3] === '4';
+    const firstOctet = parseInt(codeHex.slice(0, 2), 16).toString(2).padStart(4, '0');
+    const isUpgradeable = firstOctet.charAt(3) === '1';
+    const isReadable = firstOctet.charAt(1) === '1';
+
+    const secondOctet = parseInt(codeHex.slice(2), 16).toString(2).padStart(4, '0');
+    const isPayable = secondOctet.charAt(2) === '1';
+    const isPayableBySmartContract = secondOctet.charAt(1) === '1';
 
     return { isUpgradeable, isReadable, isPayable, isPayableBySmartContract };
   }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Every byte of value is responsible for one attribute
  
## Proposed Changes
- Use binary value and check every byte

## How to test
- Find smart contracts that are (readable and upgradable/payable and payable by sc)