### PR TITLE
Calculate market cap instead of fetching it from data.elrond.com

### DIFF
--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -112,7 +112,6 @@ export class NetworkService {
       },
       [, totalWaitingStakeBase64],
       priceValue,
-      marketCapValue,
     ] = await Promise.all([
       this.gatewayService.get(
         `address/${this.apiConfigService.getAuctionContractAddress()}`,
@@ -124,7 +123,6 @@ export class NetworkService {
         'getTotalStakeByType',
       ),
       this.dataApiService.getQuotesHistoricalLatest(DataQuoteType.price),
-      this.dataApiService.getQuotesHistoricalLatest(DataQuoteType.marketCap),
     ]);
 
     const totalWaitingStakeHex = Buffer.from(
@@ -139,6 +137,8 @@ export class NetworkService {
     const totalSupply = parseInt(erd_total_supply.slice(0, -18));
 
     const circulatingSupply = totalSupply - locked;
+    const price = priceValue ? parseFloat(priceValue.toFixed(2)) : undefined;
+    const marketCap = price ? Math.round(price * circulatingSupply) : undefined;
 
     const aprInfo = await this.getApr();
 
@@ -146,10 +146,8 @@ export class NetworkService {
       totalSupply,
       circulatingSupply,
       staked,
-      price: priceValue ? parseFloat(priceValue.toFixed(2)) : undefined,
-      marketCap: marketCapValue
-        ? parseInt(marketCapValue.toFixed(0))
-        : undefined,
+      price,
+      marketCap,
       apr: aprInfo.apr ? aprInfo.apr.toRounded(6) : 0,
       topUpApr: aprInfo.topUpApr ? aprInfo.topUpApr.toRounded(6) : 0,
       baseApr: aprInfo.baseApr ? aprInfo.baseApr.toRounded(6) : 0,


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Market cap invalid from data.elrond.com, which in turn fetches data from coinmarketcap
  
## Proposed Changes
- calculate market cap as price * circulatingSupply

## How to test (mainnet)
- /economics should return market cap of 4.2 billion instead of 4.0 billion