### PR TITLE
fixed timestamp field for account nft

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -101,7 +101,7 @@ export class EsdtAddressService {
         nft.royalties = esdt.data?.royalties;
         nft.tokenIdentifier = esdt.identifier;
         nft.uris = esdt.data?.uris;
-        nft.timestamp = esdt.data?.timestamp;
+        nft.timestamp = esdt.timestamp;
       }
 
       gatewayNfts.push(nft);


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- fetch correctly timestamp field

## How to test (testnet)
- `accounts/erd1smke9ndlng4t60qqf5descwyjneffasx0zm99n6m7vxvzhuz06rqywql34/nfts?source=elastic` should have timestamp in the result set