### PR TITLE
Token balance incoherency fix

### DIFF
--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -135,45 +135,6 @@ export class ElasticService {
     return result;
   }
 
-  async getAccountEsdtByAddress(address: string, from: number, size: number, token: string | undefined) {
-    const queries = [
-      QueryType.Match('address', address),
-      QueryType.Exists('identifier'),
-    ];
-
-    if (token) {
-      queries.push(
-        QueryType.Match('token', token, QueryOperator.AND)
-      );
-    }
-
-    const elasticQuery = ElasticQuery.create()
-      .withPagination({ from, size })
-      .withCondition(QueryConditionOptions.must, queries)
-      .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')]);
-
-    const documents = await this.getDocuments('accountsesdt', elasticQuery.toJson());
-
-    return documents.map((document: any) => this.formatItem(document, 'identifier'));
-  }
-
-  async getAccountEsdtByAddressAndIdentifier(address: string, identifier: string) {
-    const queries = [
-      QueryType.Match('address', address),
-      QueryType.Match('token', identifier, QueryOperator.AND),
-    ];
-
-    const elasticQuery = ElasticQuery.create()
-      .withPagination({ from: 0, size: 1 })
-      .withCondition(QueryConditionOptions.must, queries)
-      .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')]);
-
-
-    const documents = await this.getDocuments('accountsesdt', elasticQuery.toJson());
-
-    return documents.map((document: any) => this.formatItem(document, 'identifier'))[0];
-  }
-
   async getAccountEsdtByAddressCount(address: string) {
     const queries = [
       QueryType.Match('address', address),

--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -149,7 +149,8 @@ export class ElasticService {
 
     const elasticQuery = ElasticQuery.create()
       .withPagination({ from, size })
-      .withCondition(QueryConditionOptions.must, queries);
+      .withCondition(QueryConditionOptions.must, queries)
+      .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')]);
 
     const documents = await this.getDocuments('accountsesdt', elasticQuery.toJson());
 
@@ -164,7 +165,9 @@ export class ElasticService {
 
     const elasticQuery = ElasticQuery.create()
       .withPagination({ from: 0, size: 1 })
-      .withCondition(QueryConditionOptions.must, queries);
+      .withCondition(QueryConditionOptions.must, queries)
+      .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')]);
+
 
     const documents = await this.getDocuments('accountsesdt', elasticQuery.toJson());
 

--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -6,6 +6,7 @@ export enum GatewayComponentRequest {
   networkTotalStaked = 'networkTotalStaked',
   addressDetails = 'addressDetails',
   addressEsdt = 'addressEsdt',
+  addressEsdtBalance = 'addressEsdtBalance',
   addressNfts = 'addressNfts',
   nodeHeartbeat = 'nodeHeartbeat',
   validatorStatistics = 'validatorStatistics',


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Incoherency in esdt balance details for address
  
## Proposed Changes
- Always get esdt token balance from gateway

## How to test
- Take this request on devnet accounts/erd1spyavw0956vq68xj8y4tenjpq2wd5a9p2c6j8gsz7ztyrnpxrruqzu66jx/tokens/CHIP-cecd4c
- Make sure that the balance shown on list is the same with balance shown on details