### PR TITLE
fetch count from gateway nfts if filtered by type

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -64,8 +64,12 @@ export class EsdtAddressService {
   }
 
   async getEsdtsCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
-    const elasticQuery = this.nftService.buildElasticNftFilter(filter, undefined, address);
+    if (filter.type) {
+      const allEsdts = await this.getEsdtsForAddressFromGateway(address, filter, { from: 0, size: 10000 });
+      return allEsdts.length;
+    }
 
+    const elasticQuery = this.nftService.buildElasticNftFilter(filter, undefined, address);
     return await this.elasticService.getCount('accountsesdt', elasticQuery);
   }
 

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -64,7 +64,8 @@ export class EsdtAddressService {
   }
 
   async getEsdtsCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
-    if (filter.type) {
+    // temporary fix until we have type on the accountsesdt elastic collection
+    if (filter.type && !AddressUtils.isSmartContractAddress(address)) {
       const allEsdts = await this.getEsdtsForAddressFromGateway(address, filter, { from: 0, size: 10000 });
       return allEsdts.length;
     }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Account NFT count filtered by type returns always 0
  
## Proposed Changes
- if account nft count uses `type` filter and address is not smart contract, count gateway nfts instead of fetching count from elastic search

## How to test (mainnet)
- `accounts/erd1kcx0ha7j206tu4lke6vudq3h4dk88dz06pwugjf3q2rp2jd6rp8swmzjzu/nfts/count` should return 7