### PR TITLE
fixed account nft pagination

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -416,9 +416,7 @@ export class EsdtAddressService {
 
     const { from, size } = pagination;
 
-    if (nfts.length > from + size) {
-      nfts = nfts.slice(from, from + size);
-    }
+    nfts = nfts.slice(from, from + size);
 
     return nfts;
   }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- proper use of pagination logic

## How to test (devnet)
- `/accounts/erd109avvnrttdpm3m2ua59tnz4y8zjqfcqzxdkr74q8qcgm8vxfplzqg24vux/nfts?size=1000&from=0` should return 3 items
- `/accounts/erd109avvnrttdpm3m2ua59tnz4y8zjqfcqzxdkr74q8qcgm8vxfplzqg24vux/nfts?size=1000&from=2` should return 1 item