### PR TITLE
special querying of nft accounts if type filter set

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -48,6 +48,10 @@ export class EsdtAddressService {
   }
 
   async getEsdtsForAddress(address: string, filter: NftFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftAccount[]> {
+    if (filter.type) {
+      return await this.getEsdtsForAddressWithTypeFilter(address, filter, pagination);
+    }
+
     if (source === EsdtDataSource.elastic || AddressUtils.isSmartContractAddress(address)) {
       return await this.getEsdtsForAddressFromElastic(address, filter, pagination);
     }
@@ -63,10 +67,24 @@ export class EsdtAddressService {
     return await this.getEsdtCollectionsForAddressFromGateway(address, filter, pagination);
   }
 
+  private async getEsdtsForAddressWithTypeFilter(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
+    if (AddressUtils.isSmartContractAddress(address)) {
+      const nftType = filter.type;
+      filter.type = undefined;
+      let allEsdts = await this.getEsdtsForAddressFromElastic(address, filter, { from: 0, size: 10000 });
+      allEsdts = allEsdts.filter(x => x.type === nftType);
+      allEsdts = allEsdts.slice(pagination.from, pagination.from + pagination.size);
+      return allEsdts;
+    }
+
+    const allEsdts = await this.getEsdtsForAddressFromGateway(address, filter, pagination);
+    return allEsdts;
+  }
+
   async getEsdtsCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
     // temporary fix until we have type on the accountsesdt elastic collection
-    if (filter.type && !AddressUtils.isSmartContractAddress(address)) {
-      const allEsdts = await this.getEsdtsForAddressFromGateway(address, filter, { from: 0, size: 10000 });
+    if (filter.type) {
+      const allEsdts = await this.getEsdtsForAddressWithTypeFilter(address, filter, { from: 0, size: 10000 });
       return allEsdts.length;
     }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- account NFTs & account NFT count with type filter will be handled on a separate route

## How to test
- `accounts/erd1qqqqqqqqqqqqqpgqr8z5hkwek0pmytcvla86qjusn4hkufjlrp8s7hhkjk/nfts/count?type=MetaESDT` should return > 0
- `accounts/erd1qqqqqqqqqqqqqpgqr8z5hkwek0pmytcvla86qjusn4hkufjlrp8s7hhkjk/nfts?type=MetaESDT` should return a few elements