### PR TITLE
Decode transaction action berfore sending

### DIFF
--- a/src/endpoints/transactions/entities/dtos/transaction.decode.dto.ts
+++ b/src/endpoints/transactions/entities/dtos/transaction.decode.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { TransactionAction } from "../../transaction-action/entities/transaction.action";
+
+export class TransactionDecodeDto {
+  @ApiProperty()
+  action: TransactionAction | undefined = new TransactionAction();
+
+  @ApiProperty()
+  data: string = '';
+
+  @ApiProperty()
+  receiver: string = '';
+
+  @ApiProperty()
+  sender: string = '';
+
+  @ApiProperty()
+  value: string = '';
+}

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -9,6 +9,7 @@ import { ParseOptionalBoolPipe } from 'src/utils/pipes/parse.optional.bool.pipe'
 import { ParseOptionalEnumPipe } from 'src/utils/pipes/parse.optional.enum.pipe';
 import { ParseOptionalIntPipe } from 'src/utils/pipes/parse.optional.int.pipe';
 import { ParseTransactionHashPipe } from 'src/utils/pipes/parse.transaction.hash.pipe';
+import { TransactionDecodeDto } from './entities/dtos/transaction.decode.dto';
 import { Transaction } from './entities/transaction';
 import { TransactionCreate } from './entities/transaction.create';
 import { TransactionDetailed } from './entities/transaction.detailed';
@@ -204,11 +205,35 @@ export class TransactionController {
       throw new BadRequestException('Receiver must be provided');
     }
 
+    if (!transaction.signature) {
+      throw new BadRequestException('Signature must be provided');
+    }
+
     const result = await this.transactionService.createTransaction(transaction);
 
     if (typeof result === 'string' || result instanceof String) {
       throw new HttpException(result, HttpStatus.BAD_REQUEST);
     }
+
+    return result;
+  }
+
+  @Post('/transactions/decode')
+  @ApiResponse({
+    status: 201,
+    description: 'Decode a transaction',
+    type: TransactionDecodeDto,
+  })
+  async decodeTransaction(@Body() transaction: TransactionDecodeDto): Promise<TransactionDecodeDto> {
+    if (!transaction.sender) {
+      throw new BadRequestException('Sender must be provided');
+    }
+
+    if (!transaction.receiver) {
+      throw new BadRequestException('Receiver must be provided');
+    }
+
+    const result = await this.transactionService.decodeTransaction(transaction);
 
     return result;
   }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -32,6 +32,7 @@ import { SortOrder } from 'src/common/entities/sort.order';
 import { TransactionUtils } from 'src/utils/transaction.utils';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { TransactionActionService } from './transaction-action/transaction.action.service';
+import { TransactionDecodeDto } from './entities/dtos/transaction.decode.dto';
 
 @Injectable()
 export class TransactionService {
@@ -254,6 +255,13 @@ export class TransactionService {
       senderShard,
       status: 'Pending',
     };
+  }
+
+  async decodeTransaction(transactionDecode: TransactionDecodeDto): Promise<TransactionDecodeDto> {
+    const transaction = ApiUtils.mergeObjects(new Transaction(), { ...transactionDecode });
+    transactionDecode.action = await this.transactionActionService.getTransactionAction(transaction);
+
+    return transactionDecode;
   }
 
   private async getTransactionPrice(transaction: TransactionDetailed): Promise<number | undefined> {


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- No possibility to decode transaction actions before sending.
  
## Proposed Changes
- Create an endpoint to decode transaction and retrieve action before sending to protocol

## How to test
- Create a valid JSON transaction and before applying signature send a POST request to /transactions/decode