### PR TITLE
get nfts details one by one from db to log unexpected errors

### DIFF
--- a/src/common/persistence/database/database.service.ts
+++ b/src/common/persistence/database/database.service.ts
@@ -35,9 +35,16 @@ export class DatabaseService implements PersistenceInterface {
   }
 
   async batchGetMetadata(identifiers: string[]): Promise<Record<string, any>> {
-    const metadatasDb = await this.nftMetadataRepository.findByIds(identifiers);
+    try {
+      const metadatasDb = await this.nftMetadataRepository.findByIds(identifiers);
 
-    return metadatasDb.toRecord(metadata => metadata.id, metadata => metadata.content);
+      return metadatasDb.toRecord(metadata => metadata.id, metadata => metadata.content);
+    } catch (error) {
+      this.logger.log(`Error when getting metadata from DB for batch '${identifiers}'`);
+      this.logger.error(error);
+
+      return {};
+    }
   }
 
   async setMetadata(identifier: string, content: any): Promise<void> {
@@ -73,9 +80,16 @@ export class DatabaseService implements PersistenceInterface {
   }
 
   async batchGetMedia(identifiers: string[]): Promise<Record<string, NftMedia[]>> {
-    const mediasDb = await this.nftMediaRepository.findByIds(identifiers);
+    try {
+      const mediasDb = await this.nftMediaRepository.findByIds(identifiers);
 
-    return mediasDb.toRecord(media => media.id ?? '', media => media.content);
+      return mediasDb.toRecord(media => media.id ?? '', media => media.content);
+    } catch (error) {
+      this.logger.log(`Error when getting media from DB for batch '${identifiers}'`);
+      this.logger.error(error);
+
+      return {};
+    }
   }
 
   async setMedia(identifier: string, media: NftMedia[]): Promise<void> {

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -200,8 +200,8 @@ export class NftService {
       async nfts => {
         const record: { [key: string]: any } = {};
         for (const nft of nfts) {
-          const nftMetadata = await this.persistenceService.getMedia(nft.identifier);
-          record[nft.identifier] = nftMetadata;
+          const nftMedia = await this.persistenceService.getMedia(nft.identifier);
+          record[nft.identifier] = nftMedia;
 
         }
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -198,9 +198,14 @@ export class NftService {
       nfts,
       nft => CacheInfo.NftMedia(nft.identifier).key,
       async nfts => {
-        const getMediaResults = await this.persistenceService.batchGetMedia(nfts.map(x => x.identifier));
+        const record: { [key: string]: any } = {};
+        for (const nft of nfts) {
+          const nftMetadata = await this.persistenceService.getMedia(nft.identifier);
+          record[nft.identifier] = nftMetadata;
 
-        return RecordUtils.mapKeys(getMediaResults, identifier => CacheInfo.NftMedia(identifier).key);
+        }
+
+        return RecordUtils.mapKeys(record, identifier => CacheInfo.NftMedia(identifier).key);
       },
       (nft, media) => nft.media = media,
       CacheInfo.NftMedia('').ttl,
@@ -218,9 +223,14 @@ export class NftService {
       nfts,
       nft => CacheInfo.NftMetadata(nft.identifier).key,
       async nfts => {
-        const getMetadataResults = await this.persistenceService.batchGetMetadata(nfts.map(x => x.identifier));
+        const record: { [key: string]: any } = {};
+        for (const nft of nfts) {
+          const nftMetadata = await this.persistenceService.getMetadata(nft.identifier);
+          record[nft.identifier] = nftMetadata;
 
-        return RecordUtils.mapKeys(getMetadataResults, identifier => CacheInfo.NftMetadata(identifier).key);
+        }
+
+        return RecordUtils.mapKeys(record, identifier => CacheInfo.NftMetadata(identifier).key);
       },
       (nft, metadata) => nft.metadata = metadata,
       CacheInfo.NftMetadata('').ttl

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -198,14 +198,9 @@ export class NftService {
       nfts,
       nft => CacheInfo.NftMedia(nft.identifier).key,
       async nfts => {
-        const record: { [key: string]: any } = {};
-        for (const nft of nfts) {
-          const nftMedia = await this.persistenceService.getMedia(nft.identifier);
-          record[nft.identifier] = nftMedia;
+        const getMediaResults = await this.persistenceService.batchGetMedia(nfts.map((nft) => nft.identifier));
 
-        }
-
-        return RecordUtils.mapKeys(record, identifier => CacheInfo.NftMedia(identifier).key);
+        return RecordUtils.mapKeys(getMediaResults, identifier => CacheInfo.NftMedia(identifier).key);
       },
       (nft, media) => nft.media = media,
       CacheInfo.NftMedia('').ttl,
@@ -223,14 +218,9 @@ export class NftService {
       nfts,
       nft => CacheInfo.NftMetadata(nft.identifier).key,
       async nfts => {
-        const record: { [key: string]: any } = {};
-        for (const nft of nfts) {
-          const nftMetadata = await this.persistenceService.getMetadata(nft.identifier);
-          record[nft.identifier] = nftMetadata;
+        const getMetadataResults = await this.persistenceService.batchGetMetadata(nfts.map((nft) => nft.identifier));
 
-        }
-
-        return RecordUtils.mapKeys(record, identifier => CacheInfo.NftMetadata(identifier).key);
+        return RecordUtils.mapKeys(getMetadataResults, identifier => CacheInfo.NftMetadata(identifier).key);
       },
       (nft, metadata) => nft.metadata = metadata,
       CacheInfo.NftMetadata('').ttl


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- A problem for one nft will return an empty array result
  
## Proposed Changes
- Get nft metadata and media one by one to log unexpected error for each nft