### PR TITLE
NFT buy fix

### DIFF
--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -169,7 +169,7 @@ export class TransactionProcessorService {
         }
       }
 
-      const nftIdentifier = transactionDetailed.operations[0].identifier;
+      const nftIdentifier = transactionDetailed.operations.find(x => x.action === 'create' && x.type === 'nft')?.identifier;
       if (!nftIdentifier) {
         this.logger.error(`NFT create: could not fetch nft identifier from operation of transaction with hash '${transaction.hash}'`);
         return;


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- instead of search nft create operation by position, find it by action & type

## How to test (mainnet)
- Transaction `6579e143ec1e177b27c9193aac1733685f027ce6d01f2646c44768a00b1bc57c` should be properly recognized as a nft create transaction