### PR TITLE
use canBeIgnored flag to exclude gas refunds / double scrs

### DIFF
--- a/src/common/elastic/entities/must.query.ts
+++ b/src/common/elastic/entities/must.query.ts
@@ -1,7 +1,10 @@
 import { AbstractQuery } from "./abstract.query";
 
 export class MustQuery extends AbstractQuery {
-  constructor(private readonly queries: AbstractQuery[]) {
+  constructor(
+    private readonly queries: AbstractQuery[],
+    private readonly mustNotQueries: AbstractQuery[] = []
+  ) {
     super();
   }
 
@@ -9,6 +12,7 @@ export class MustQuery extends AbstractQuery {
     return {
       bool: {
         must: this.queries.map(query => query.getQuery()),
+        must_not: this.mustNotQueries.map(query => query.getQuery()),
       },
     };
   }

--- a/src/common/elastic/entities/query.type.ts
+++ b/src/common/elastic/entities/query.type.ts
@@ -33,7 +33,7 @@ export class QueryType {
     return new ShouldQuery(queries);
   };
 
-  static Must = (queries: AbstractQuery[]): MustQuery => {
-    return new MustQuery(queries);
+  static Must = (queries: AbstractQuery[], mustNotQueries: AbstractQuery[] = []): MustQuery => {
+    return new MustQuery(queries, mustNotQueries);
   };
 }

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -27,11 +27,12 @@ export class TransferService {
     let elasticQuery = ElasticQuery.create()
       .withCondition(QueryConditionOptions.should, QueryType.Must([
         QueryType.Match('type', 'unsigned'),
-        QueryType.Match('nonce', 0),
         QueryType.Should([
           QueryType.Match('receiver', address),
           QueryType.Match('receivers', address),
         ]),
+      ], [
+        QueryType.Exists('canBeIgnored'),
       ]))
       .withCondition(QueryConditionOptions.should, QueryType.Must([
         QueryType.Match('type', 'normal'),


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- use `canBeIgnored` flag when fetching scrs from operations

## How to test (testnet)
- `/accounts/erd17pupr269rd980g0pu7f7xhdmswyr7hxhds8yt8dm7pg903pyy69strr5up/transfers` should contain scr with hash `90205fe40e8390dad2eb105df7c143e56e9421f374c009a63640455772140f7c`