### PR TITLE
return single nft for an account from gateway

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -237,7 +237,7 @@ export class CollectionService {
   async getCollectionForAddress(address: string, collection: string): Promise<NftCollectionAccount | undefined> {
     const filter: CollectionFilter = { collection };
 
-    const collections = await this.esdtAddressService.getEsdtCollectionsForAddress(address, filter, { from: 0, size: 1 });
+    const collections = await this.esdtAddressService.getCollectionsForAddress(address, filter, { from: 0, size: 1 });
     if (collections.length === 0) {
       return undefined;
     }
@@ -246,13 +246,13 @@ export class CollectionService {
   }
 
   async getCollectionsForAddress(address: string, filter: CollectionFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftCollectionAccount[]> {
-    const collections = await this.esdtAddressService.getEsdtCollectionsForAddress(address, filter, pagination, source);
+    const collections = await this.esdtAddressService.getCollectionsForAddress(address, filter, pagination, source);
 
     return collections;
   }
 
   async getCollectionCountForAddress(address: string, filter: CollectionFilter): Promise<number> {
-    const count = await this.esdtAddressService.getEsdtCollectionsCountForAddressFromElastic(address, filter);
+    const count = await this.esdtAddressService.getCollectionCountForAddressFromElastic(address, filter);
 
     return count;
   }

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -47,48 +47,48 @@ export class EsdtAddressService {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
   }
 
-  async getEsdtsForAddress(address: string, filter: NftFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftAccount[]> {
+  async getNftsForAddress(address: string, filter: NftFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftAccount[]> {
     if (filter.identifiers && filter.identifiers.length === 1) {
-      return await this.getEsdtsForAddressFromGateway(address, filter, pagination);
+      return await this.getNftsForAddressFromGateway(address, filter, pagination);
     }
 
     if (filter.type) {
-      return await this.getEsdtsForAddressWithTypeFilter(address, filter, pagination);
+      return await this.getNftsForAddressWithTypeFilter(address, filter, pagination);
     }
 
     if (source === EsdtDataSource.elastic || AddressUtils.isSmartContractAddress(address)) {
-      return await this.getEsdtsForAddressFromElastic(address, filter, pagination);
+      return await this.getNftsForAddressFromElastic(address, filter, pagination);
     }
 
-    return await this.getEsdtsForAddressFromGateway(address, filter, pagination);
+    return await this.getNftsForAddressFromGateway(address, filter, pagination);
   }
 
-  async getEsdtCollectionsForAddress(address: string, filter: CollectionFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftCollectionAccount[]> {
+  async getCollectionsForAddress(address: string, filter: CollectionFilter, pagination: QueryPagination, source?: EsdtDataSource): Promise<NftCollectionAccount[]> {
     if (source === EsdtDataSource.elastic) {
-      return await this.getEsdtCollectionsForAddressFromElastic(address, filter, pagination);
+      return await this.getCollectionsForAddressFromElastic(address, filter, pagination);
     }
 
-    return await this.getEsdtCollectionsForAddressFromGateway(address, filter, pagination);
+    return await this.getCollectionsForAddressFromGateway(address, filter, pagination);
   }
 
-  private async getEsdtsForAddressWithTypeFilter(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
+  private async getNftsForAddressWithTypeFilter(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
     if (AddressUtils.isSmartContractAddress(address)) {
       const nftType = (filter.type ?? '').split(',');
       filter.type = undefined;
-      let allEsdts = await this.getEsdtsForAddressFromElastic(address, filter, { from: 0, size: 10000 });
+      let allEsdts = await this.getNftsForAddressFromElastic(address, filter, { from: 0, size: 10000 });
       allEsdts = allEsdts.filter(x => nftType.includes(x.type));
       allEsdts = allEsdts.slice(pagination.from, pagination.from + pagination.size);
       return allEsdts;
     }
 
-    const allEsdts = await this.getEsdtsForAddressFromGateway(address, filter, pagination);
+    const allEsdts = await this.getNftsForAddressFromGateway(address, filter, pagination);
     return allEsdts;
   }
 
-  async getEsdtsCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
+  async getNftCountForAddressFromElastic(address: string, filter: NftFilter): Promise<number> {
     // temporary fix until we have type on the accountsesdt elastic collection
     if (filter.type) {
-      const allEsdts = await this.getEsdtsForAddressWithTypeFilter(address, filter, { from: 0, size: 10000 });
+      const allEsdts = await this.getNftsForAddressWithTypeFilter(address, filter, { from: 0, size: 10000 });
       return allEsdts.length;
     }
 
@@ -96,13 +96,13 @@ export class EsdtAddressService {
     return await this.elasticService.getCount('accountsesdt', elasticQuery);
   }
 
-  async getEsdtCollectionsCountForAddressFromElastic(address: string, filter: CollectionFilter): Promise<number> {
+  async getCollectionCountForAddressFromElastic(address: string, filter: CollectionFilter): Promise<number> {
     const elasticQuery = this.collectionService.buildCollectionFilter(filter, address);
 
     return await this.elasticService.getCount('tokens', elasticQuery);
   }
 
-  private async getEsdtsForAddressFromElastic(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
+  private async getNftsForAddressFromElastic(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
     let elasticQuery = this.nftService.buildElasticNftFilter(filter, undefined, address)
       .withPagination(pagination);
 
@@ -142,7 +142,7 @@ export class EsdtAddressService {
     return nftAccounts;
   }
 
-  private async getEsdtCollectionsForAddressFromGateway(address: string, filter: CollectionFilter, pagination: QueryPagination): Promise<NftCollectionAccount[]> {
+  private async getCollectionsForAddressFromGateway(address: string, filter: CollectionFilter, pagination: QueryPagination): Promise<NftCollectionAccount[]> {
     const esdtResult = await this.gatewayService.get(`address/${address}/registered-nfts`, GatewayComponentRequest.addressNfts);
 
     let collectionsIdentifiers = esdtResult.tokens;
@@ -162,12 +162,12 @@ export class EsdtAddressService {
 
     const accountCollectionsWithRoles: NftCollectionAccount[] = await this.applyRolesToAccountCollections(address, accountCollections);
 
-    const filteredColections: NftCollectionAccount[] = this.filterEsdtCollectionsForAddress(accountCollectionsWithRoles, filter, pagination);
+    const filteredColections: NftCollectionAccount[] = this.filterCollectionsForAddress(accountCollectionsWithRoles, filter, pagination);
 
     return filteredColections;
   }
 
-  private async getEsdtCollectionsForAddressFromElastic(address: string, filter: CollectionFilter, pagination: QueryPagination): Promise<NftCollectionAccount[]> {
+  private async getCollectionsForAddressFromElastic(address: string, filter: CollectionFilter, pagination: QueryPagination): Promise<NftCollectionAccount[]> {
     if (filter.canCreate !== undefined || filter.canBurn !== undefined || filter.canAddQuantity !== undefined) {
       throw new BadRequestException('canCreate / canBurn / canAddQuantity filter not supported when fetching account collections from elastic');
     }
@@ -200,7 +200,7 @@ export class EsdtAddressService {
     return accountCollectionsWithRoles;
   }
 
-  private filterEsdtCollectionsForAddress(collections: NftCollectionAccount[], filter: CollectionFilter, pagination: QueryPagination): NftCollectionAccount[] {
+  private filterCollectionsForAddress(collections: NftCollectionAccount[], filter: CollectionFilter, pagination: QueryPagination): NftCollectionAccount[] {
     if (filter.type !== undefined) {
       collections = collections.filter(x => x.type === filter.type);
     }
@@ -263,7 +263,7 @@ export class EsdtAddressService {
     return nftCollections;
   }
 
-  private async getEsdtsForAddressFromGateway(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
+  private async getNftsForAddressFromGateway(address: string, filter: NftFilter, pagination: QueryPagination): Promise<NftAccount[]> {
     let esdts: Record<string, any> = {};
 
     if (filter.identifiers && filter.identifiers.length === 1) {

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -393,7 +393,7 @@ export class NftService {
   }
 
   async getNftsForAddress(address: string, queryPagination: QueryPagination, filter: NftFilter, queryOptions?: NftQueryOptions, source?: EsdtDataSource): Promise<NftAccount[]> {
-    const nfts = await this.esdtAddressService.getEsdtsForAddress(address, filter, queryPagination, source);
+    const nfts = await this.esdtAddressService.getNftsForAddress(address, filter, queryPagination, source);
 
     for (const nft of nfts) {
       await this.applyAssetsAndTicker(nft);
@@ -409,7 +409,7 @@ export class NftService {
   }
 
   async getNftCountForAddress(address: string, filter: NftFilter): Promise<number> {
-    const count = await this.esdtAddressService.getEsdtsCountForAddressFromElastic(address, filter);
+    const count = await this.esdtAddressService.getNftCountForAddressFromElastic(address, filter);
 
     return count;
   }
@@ -418,7 +418,7 @@ export class NftService {
     const filter = new NftFilter();
     filter.identifiers = [identifier];
 
-    const nfts = await this.esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 1 });
+    const nfts = await this.esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 1 });
     if (nfts.length === 0) {
       return undefined;
     }

--- a/src/test/integration/esdt.address.e2e-spec.ts
+++ b/src/test/integration/esdt.address.e2e-spec.ts
@@ -25,7 +25,7 @@ describe('EsdtAddressService', () => {
       const address: string = 'erd1qqqqqqqqqqqqqpgqhe8t5jewej70zupmh44jurgn29psua5l2jps3ntjj3';
       const filter = new NftFilter();
       filter.identifiers = ['EGLDMEXF-5bcc57-0b63a1'];
-      const results = await esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 1 }, EsdtDataSource.gateway);
+      const results = await esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 1 }, EsdtDataSource.gateway);
 
       expect(results).toHaveLength(1);
       expect(results).toBeInstanceOf(Array);
@@ -41,7 +41,7 @@ describe('EsdtAddressService', () => {
     const address: string = 'erd1qqqqqqqqqqqqqpgqhe8t5jewej70zupmh44jurgn29psua5l2jps3ntjj3';
     const filter = new NftFilter();
     filter.identifiers = ['EGLDMEXF-5bcc57-0b63a1'];
-    const results = await esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 1 }, EsdtDataSource.elastic);
+    const results = await esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 1 }, EsdtDataSource.elastic);
 
     expect(results).toHaveLength(1);
     expect(results).toBeInstanceOf(Array);
@@ -57,8 +57,8 @@ describe('EsdtAddressService', () => {
     const filter = new NftFilter();
     filter.identifiers = ['EGLDMEXF-5bcc57-0b63a1'];
 
-    const elasticResults = await esdtAddressService.getEsdtsForAddress(address, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.gateway);
-    const gatewayResults = await esdtAddressService.getEsdtsForAddress(address, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.elastic);
+    const elasticResults = await esdtAddressService.getNftsForAddress(address, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.gateway);
+    const gatewayResults = await esdtAddressService.getNftsForAddress(address, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.elastic);
 
     expect(elasticResults).toStrictEqual(gatewayResults);
   });
@@ -68,7 +68,7 @@ describe('EsdtAddressService', () => {
     const filter = new NftFilter();
     filter.isWhitelistedStorage = false;
 
-    const results = await esdtAddressService.getEsdtsForAddress(address, new NftFilter(), { from: 0, size: 2 }, EsdtDataSource.gateway);
+    const results = await esdtAddressService.getNftsForAddress(address, new NftFilter(), { from: 0, size: 2 }, EsdtDataSource.gateway);
     expect(results).toHaveLength(2);
 
     for (const result of results) {
@@ -81,7 +81,7 @@ describe('EsdtAddressService', () => {
       const address: string = 'erd1qqqqqqqqqqqqqpgqhe8t5jewej70zupmh44jurgn29psua5l2jps3ntjj3';
       const filter = new NftFilter();
       filter.identifiers = ['EGLDMEXF-5bcc57-0b63a1'];
-      const count = await esdtAddressService.getEsdtsCountForAddressFromElastic(address, filter);
+      const count = await esdtAddressService.getNftCountForAddressFromElastic(address, filter);
 
       expect(typeof count).toBe('number');
     });
@@ -93,7 +93,7 @@ describe('EsdtAddressService', () => {
       const collectionFilter = new CollectionFilter();
       collectionFilter.collection = 'HMORGOTH-ecd5fb';
 
-      const collections: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getEsdtCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.elastic);
+      const collections: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.elastic);
 
       expect(collections).toHaveLength(1);
       expect(collections).toBeInstanceOf(Object);
@@ -117,7 +117,7 @@ describe('EsdtAddressService', () => {
       const collectionFilter = new CollectionFilter();
       collectionFilter.collection = 'HMORGOTH-ecd5fb';
 
-      const collectionEsdtGateway: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getEsdtCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.gateway);
+      const collectionEsdtGateway: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.gateway);
 
       for (const collection of collectionEsdtGateway) {
         expect(collection).toBeInstanceOf(Object);
@@ -132,7 +132,7 @@ describe('EsdtAddressService', () => {
       const address: string = 'erd1yt24jpcm58k2734lf53ws96lqtkzy46vlxwnjud7ce3vl02eahmsele6j8';
       const filter = new NftFilter();
       filter.collection = 'HMORGOTH-ecd5fb';
-      const count = await esdtAddressService.getEsdtCollectionsCountForAddressFromElastic(address, filter);
+      const count = await esdtAddressService.getCollectionCountForAddressFromElastic(address, filter);
 
       expect(typeof count).toBe('number');
     });
@@ -142,7 +142,7 @@ describe('EsdtAddressService', () => {
       const filter = new NftFilter();
       filter.collection = 'HMORGOTH-ecd5fb';
       filter.type = NftType.NonFungibleESDT;
-      const results = await esdtAddressService.getEsdtCollectionsForAddress(address, filter, { from: 0, size: 1 });
+      const results = await esdtAddressService.getCollectionsForAddress(address, filter, { from: 0, size: 1 });
 
       for (const result of results) {
         expect(result).toBeInstanceOf(Object);

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -29,7 +29,7 @@ describe('ESDT Service', () => {
       const address: string = "erd1k3wtee6vzk47halxwm7qud3mrdjrlw4fyjvuhamtzy4hjhe6htcsv9jcgs";
       const filter = new NftFilter();
       filter.type = NftType.MetaESDT;
-      const results = await esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 2 });
+      const results = await esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 2 });
 
       expect(results).toHaveLength(2);
 
@@ -43,7 +43,7 @@ describe('ESDT Service', () => {
       const filter = new NftFilter();
       filter.type = NftType.SemiFungibleESDT;
 
-      const results = await esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 2 });
+      const results = await esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 2 });
 
       expect(results).toHaveLength(2);
 
@@ -57,7 +57,7 @@ describe('ESDT Service', () => {
       const filter = new NftFilter();
       filter.type = NftType.NonFungibleESDT;
 
-      const results = await esdtAddressService.getEsdtsForAddress(address, filter, { from: 0, size: 2 });
+      const results = await esdtAddressService.getNftsForAddress(address, filter, { from: 0, size: 2 });
 
       expect(results).toHaveLength(2);
 
@@ -68,8 +68,8 @@ describe('ESDT Service', () => {
 
     it("should return esdts of type NonFungibleESDT and SemiFungibleESDT", async () => {
       const address: string = "erd1k3wtee6vzk47halxwm7qud3mrdjrlw4fyjvuhamtzy4hjhe6htcsv9jcgs";
-      const resultNft = await esdtAddressService.getEsdtsForAddress(address, { type: NftType.NonFungibleESDT }, { from: 0, size: 100 });
-      const resultSft = await esdtAddressService.getEsdtsForAddress(address, { type: NftType.SemiFungibleESDT }, { from: 0, size: 100 });
+      const resultNft = await esdtAddressService.getNftsForAddress(address, { type: NftType.NonFungibleESDT }, { from: 0, size: 100 });
+      const resultSft = await esdtAddressService.getNftsForAddress(address, { type: NftType.SemiFungibleESDT }, { from: 0, size: 100 });
 
       for (const result of resultNft) {
         expect(result.type).toStrictEqual("NonFungibleESDT");
@@ -83,8 +83,8 @@ describe('ESDT Service', () => {
     it('gateway & elastic esdts of address should be the same', async () => {
       const esdtAddress: string = 'erd1qqqqqqqqqqqqqpgqhe8t5jewej70zupmh44jurgn29psua5l2jps3ntjj3';
 
-      const gatewayNfts = await esdtAddressService.getEsdtsForAddress(esdtAddress, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.gateway);
-      const elasticNfts = await esdtAddressService.getEsdtsForAddress(esdtAddress, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.elastic);
+      const gatewayNfts = await esdtAddressService.getNftsForAddress(esdtAddress, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.gateway);
+      const elasticNfts = await esdtAddressService.getNftsForAddress(esdtAddress, new NftFilter(), { from: 0, size: 25 }, EsdtDataSource.elastic);
 
       expect(gatewayNfts).toStrictEqual(elasticNfts);
     });


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Since account balances should be always taken from the gateway, we try to fetch data from it as much as possible
- Because the `/address/:address/esdt/` endpoint is not optimal in the case of smart contracts, we fetch the list of nfts for a smart contract from the elasticsearch
- Because the `/address/:address/nft/:collection/nonce/:nonce` endpoint does not have performance issues, we prefer this one regardless of whether the address is a smart contract or not
  
## Proposed Changes
- Use gateway endpoint if fetching single nft for an address

## How to test (mainnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl/nfts/EGLDMEXFL-ef2065-027157` endpoint should fetch data from gateway, not elastic