### PR TITLE
Account tokens from Elasticsearch if Smart Contract

### DIFF
--- a/src/common/elastic/entities/elastic.query.ts
+++ b/src/common/elastic/entities/elastic.query.ts
@@ -42,6 +42,10 @@ export class ElasticQuery {
     return this.withCondition(QueryConditionOptions.must, queries);
   }
 
+  withMustNotCondition(queries: AbstractQuery[] | AbstractQuery): ElasticQuery {
+    return this.withCondition(QueryConditionOptions.mustNot, queries);
+  }
+
   withShouldCondition(queries: AbstractQuery[] | AbstractQuery): ElasticQuery {
     return this.withCondition(QueryConditionOptions.should, queries);
   }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -170,6 +170,22 @@ export class TokenService {
   }
 
   async getTokenCountForAddress(address: string): Promise<number> {
+    if (AddressUtils.isSmartContractAddress(address)) {
+      return await this.getTokenCountForAddressFromElastic(address);
+    }
+
+    return await this.getTokenCountForAddressFromGateway(address);
+  }
+
+  async getTokenCountForAddressFromElastic(address: string): Promise<number> {
+    const query = ElasticQuery.create()
+      .withMustNotCondition(QueryType.Exists('identifier'))
+      .withMustCondition(QueryType.Match('address', address));
+
+    return await this.elasticService.getCount('accountsesdt', query);
+  }
+
+  async getTokenCountForAddressFromGateway(address: string): Promise<number> {
     const tokens = await this.getAllTokensForAddress(address, new TokenFilter());
     return tokens.length;
   }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -24,6 +24,7 @@ import { NumberUtils } from "src/utils/number.utils";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
+import { AddressUtils } from "src/utils/address.utils";
 
 @Injectable()
 export class TokenService {
@@ -174,6 +175,55 @@ export class TokenService {
   }
 
   async getTokensForAddress(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
+    if (AddressUtils.isSmartContractAddress(address)) {
+      return await this.getTokensForAddressFromElastic(address, queryPagination, filter);
+    }
+
+    return await this.getTokensForAddressFromGateway(address, queryPagination, filter);
+  }
+
+  async getTokensForAddressFromElastic(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
+    let query = ElasticQuery.create()
+      .withMustNotCondition(QueryType.Exists('identifier'))
+      .withMustCondition(QueryType.Match('address', address))
+      .withPagination({ from: queryPagination.from, size: queryPagination.size });
+
+    if (filter.identifier) {
+      query = query.withMustCondition(QueryType.Match('token', filter.identifier));
+    }
+
+    if (filter.identifiers) {
+      query = query.withShouldCondition(filter.identifiers.map(identifier => QueryType.Match('token', identifier)));
+    }
+
+    if (filter.name) {
+      query = query.withMustCondition(QueryType.Nested('data.name', filter.name));
+    }
+
+    if (filter.search) {
+      query = query.withMustCondition(QueryType.Nested('data.name', filter.search));
+    }
+
+    const elasticTokens = await this.elasticService.getList('accountsesdt', 'token', query);
+
+    const elasticTokensWithBalance = elasticTokens.toRecord(token => token.token, token => token.balance);
+
+    const allTokens = await this.esdtService.getAllEsdtTokens();
+
+    const result: TokenWithBalance[] = [];
+    for (const token of allTokens) {
+      if (elasticTokensWithBalance[token.identifier]) {
+        result.push({
+          ...token,
+          balance: elasticTokensWithBalance[token.identifier],
+        });
+      }
+    }
+
+    return result;
+  }
+
+  async getTokensForAddressFromGateway(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     let tokens = await this.getAllTokensForAddress(address, filter);
 
     tokens = tokens.slice(queryPagination.from, queryPagination.from + queryPagination.size);

--- a/src/test/integration/accounts.e2e-spec.ts
+++ b/src/test/integration/accounts.e2e-spec.ts
@@ -106,7 +106,7 @@ describe('Account Service', () => {
   describe('Account Token balance history', () => {
     it('should return the token EGLD balance history ', async () => {
       const address: string = "erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97";
-      const accountTokens = await tokensService.getTokensForAddress(address, { from: 0, size: 1 }, {});
+      const accountTokens = await tokensService.getTokensForAddressFromGateway(address, { from: 0, size: 1 }, {});
 
       if (accountTokens.length) {
         const accountTokenHistories = await accountService.getAccountTokenHistory(address,

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -256,7 +256,7 @@ describe('Token Service', () => {
       const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
       const filter = new TokenFilter();
       filter.identifier = "RIDE-7d18e9";
-      const results = await tokenService.getTokensForAddress(address, { from: 0, size: 1 }, filter);
+      const results = await tokenService.getTokensForAddressFromGateway(address, { from: 0, size: 1 }, filter);
 
       expect(results).toHaveLength(1);
 
@@ -270,7 +270,7 @@ describe('Token Service', () => {
       const address: string = "erd19w6f7jqnf4nqrdmq0m548crrc4v3dmrxtn7u3dngep2r078v30aqzzu6nc";
       const filter = new TokenFilter();
       filter.name = "holoride";
-      const results = await tokenService.getTokensForAddress(address, { from: 0, size: 1 }, filter);
+      const results = await tokenService.getTokensForAddressFromGateway(address, { from: 0, size: 1 }, filter);
 
       expect(results).toHaveLength(1);
 
@@ -286,7 +286,7 @@ describe('Token Service', () => {
       const filter = new TokenFilter();
       filter.identifiers = ["RIDE-7d18e9", "MEX-455c57"];
 
-      const results = await tokenService.getTokensForAddress(address, { from: 0, size: 1 }, filter);
+      const results = await tokenService.getTokensForAddressFromGateway(address, { from: 0, size: 1 }, filter);
       const nftsIdentifiers = results.map((nft) => nft.identifier);
 
       expect(nftsIdentifiers.includes('RIDE-7d18e9')).toStrictEqual(true);


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Problem setting
- /esdt endpoint very heavy for smart contracts and was called in `/accounts/:account/tokens` & `/accounts/:account/tokens/count` endpoint
  
## Proposed Changes
- if smart contract, fetch token list information from elasticsearch

## How to test (mainnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl/tokens` should not time out
- `/accounts/erd1qqqqqqqqqqqqqpgqrc4pg2xarca9z34njcxeur622qmfjp8w2jps89fxnl/tokens/count` should not time out