### PR TITLE
Proper throw Account NFT not found 

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -273,8 +273,7 @@ export class EsdtAddressService {
       const nonceNumeric = BinaryUtils.hexToNumber(nonceHex);
 
       const result = await this.gatewayService.get(`address/${address}/nft/${collection}/nonce/${nonceNumeric}`, GatewayComponentRequest.addressNftByNonce);
-
-      if (!result || !result.tokenData) {
+      if (!result || !result.tokenData || result.tokenData.balance === '0') {
         return [];
       }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- Account NFT was not returning 404 error
  
## Proposed Changes
- add balance check when fetching nft from gateway

## How to test (devnet)
- `/accounts/erd1qqqqqqqqqqqqqpgq7epdy2nss28tr3966gr9pcxr0w5xvgjpu00s3xhh7y/nfts/NATIONAL-91e064-08` should return data
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l/nfts/NATIONAL-91e064-08` should return 404 not found