### PR TITLE
Account Token not found error

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -262,7 +262,7 @@ export class TokenService {
     const token = tokens[0];
     const esdt = await this.gatewayService.get(`address/${address}/esdt/${identifier}`, GatewayComponentRequest.addressEsdtBalance);
 
-    if (!esdt || !esdt.tokenData) {
+    if (!esdt || !esdt.tokenData || esdt.tokenData.balance === '0') {
       this.logger.log(`Error when fetching token ${identifier} balance for address ${address}`);
       return undefined;
     }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- Proper throw Account NFT not found

## How to test (mainnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqa0fsfshnff4n76jhcye6k7uvd7qacsq42jpsp6shh2/tokens/WEGLD-bd4d79` should return token info
- `/accounts/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqplllst77y4l/tokens/WEGLD-bd4d79` should return 404 not found