### PR TITLE
Add IPFS whitelisted gateway

### DIFF
--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -14,6 +14,7 @@ export class TokenUtils {
 
   static computeNftUri(uri: string, prefix: string) {
     uri = ApiUtils.replaceUri(uri, 'https://ipfs.io/ipfs', prefix);
+    uri = ApiUtils.replaceUri(uri, 'https://gateway.ipfs.io/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'https://gateway.pinata.cloud/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'https://dweb.link/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'ipfs:/', prefix);


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Performance improvement

## Proposed Changes
- add https://gateway.ipfs.io/ipfs as whitelisted gateway

## How to test (devnet)
- `/nfts/BEAK-739294-04` should return `"isWhitelistedStorage": true`