### PR TITLE
Nft metadata refresh fixes

### DIFF
--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -118,7 +118,6 @@ export class TransactionProcessorService {
       const processSettings = new ProcessNftSettings();
       processSettings.forceRefreshMetadata = true;
       await this.nftWorkerService.addProcessNftQueueJob(nft, processSettings);
-      this.clientProxy.emit('deleteCacheKeys', [CacheInfo.NftMetadata(nft.identifier).key]);
     } catch (error) {
       this.logger.error(`Unexpected error when handling NFT update metadata for transaction with hash '${transaction.hash}'`);
       this.logger.error(error);

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -33,7 +33,6 @@ export class NftWorkerService {
 
     const message = new NftMessage();
     message.identifier = nft.identifier;
-    message.nft = nft;
     message.settings = settings;
 
     this.client.send({ cmd: 'api-process-nfts' }, message).subscribe();

--- a/src/queue.worker/nft.worker/queue/entities/nft.message.ts
+++ b/src/queue.worker/nft.worker/queue/entities/nft.message.ts
@@ -1,8 +1,6 @@
-import { Nft } from "src/endpoints/nfts/entities/nft";
 import { ProcessNftSettings } from "src/endpoints/process-nfts/entities/process.nft.settings";
 
 export class NftMessage {
   identifier: string = '';
-  nft: Nft = new Nft();
   settings: ProcessNftSettings = new ProcessNftSettings();
 }

--- a/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
@@ -66,7 +66,7 @@ export class NftMetadataService {
     }
 
     try {
-      this.logger.log(`Started fetching metadata for nft with identifier '${nft.identifier}'`);
+      this.logger.log(`Started fetching metadata for nft with identifier '${nft.identifier}' and attributes '${nft.attributes}'`);
       const nftMetadata = await this.nftExtendedAttributesService.tryGetExtendedAttributesFromBase64EncodedAttributes(nft.attributes);
       this.logger.log(`Completed fetching metadata for nft with identifier '${nft.identifier}'`);
       return nftMetadata ?? null;

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Logger } from "@nestjs/common";
-import { Ctx, MessagePattern, Payload, RmqContext } from "@nestjs/microservices";
+import { Controller, Inject, Logger } from "@nestjs/common";
+import { ClientProxy, Ctx, MessagePattern, Payload, RmqContext } from "@nestjs/microservices";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
+import { NftService } from "src/endpoints/nfts/nft.service";
 import { NftMessage } from "./entities/nft.message";
 import { NftMediaService } from "./job-services/media/nft.media.service";
 import { NftMetadataService } from "./job-services/metadata/nft.metadata.service";
@@ -18,6 +20,8 @@ export class NftQueueController {
     private readonly nftMetadataService: NftMetadataService,
     private readonly nftMediaService: NftMediaService,
     private readonly nftThumbnailService: NftThumbnailService,
+    private readonly nftService: NftService,
+    @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
     apiConfigService: ApiConfigService,
   ) {
     this.logger = new Logger(NftQueueController.name);
@@ -53,12 +57,27 @@ export class NftQueueController {
     this.logger.log({ type: 'consumer start', identifier: data.identifier, attempt });
 
     try {
-      const nft = data.nft;
+      const nft = await this.nftService.getSingleNft(data.identifier);
+      if (!nft) {
+        throw new Error(`Could not fetch details for NFT with identifier '${data.identifier}'`);
+      }
+
       const settings = data.settings;
 
       nft.metadata = await this.nftMetadataService.getMetadata(nft);
 
-      if (settings.forceRefreshMetadata || !nft.metadata) {
+      if (nft.metadata && settings.forceRefreshMetadata) {
+        const oldMetadata = nft.metadata;
+        nft.metadata = await this.nftMetadataService.refreshMetadata(nft);
+        const newMetadata = nft.metadata;
+        if (newMetadata) {
+          this.logger.log(`Refreshed NFT metadata. Old: '${JSON.stringify(oldMetadata)}', New: '${JSON.stringify(newMetadata)}'`);
+        } else {
+          this.logger.log(`Refreshed NFT metadata. Old: '${JSON.stringify(oldMetadata)}', New is empty`);
+        }
+
+        this.clientProxy.emit('deleteCacheKeys', [CacheInfo.NftMetadata(nft.identifier).key]);
+      } else if (!nft.metadata) {
         nft.metadata = await this.nftMetadataService.refreshMetadata(nft);
       }
 

--- a/src/queue.worker/nft.worker/queue/nft.queue.module.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.module.ts
@@ -2,11 +2,36 @@ import { Module } from '@nestjs/common';
 import { NftQueueController } from './nft.queue.controller';
 import { NftJobProcessorModule } from './job-services/nft.job.processor.module';
 import { NftCronModule } from 'src/crons/nft/nft.cron.module';
+import { NftModule } from 'src/endpoints/nfts/nft.module';
+import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { ClientOptions, ClientProxyFactory, Transport } from '@nestjs/microservices';
 
 @Module({
   imports: [
     NftJobProcessorModule,
     NftCronModule,
+    NftModule,
+  ],
+  providers: [
+    {
+      provide: 'PUBSUB_SERVICE',
+      useFactory: (apiConfigService: ApiConfigService) => {
+        const clientOptions: ClientOptions = {
+          transport: Transport.REDIS,
+          options: {
+            url: `redis://${apiConfigService.getRedisUrl()}:6379`,
+            retryDelay: 1000,
+            retryAttempts: 10,
+            retry_strategy: function (_: any) {
+              return 1000;
+            },
+          },
+        };
+
+        return ClientProxyFactory.create(clientOptions);
+      },
+      inject: [ApiConfigService],
+    },
   ],
   controllers: [NftQueueController],
   exports: [],


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Problem setting
- NFT metadata was not refreshed when a `ESDTNFTUpdateAttributes` transaction was triggerred
  
## Proposed Changes
- Use account endpoint to fetch NFT attributes
- Implement a more robust and stateless queue information passing system

## How to test
- Create NFT with a certain description (e.g. `before`)
- Update attributes with another description (e.g. `after`)
- The updated description should be available in the nft details