### PR TITLE
Validate token in account history

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -931,12 +931,17 @@ export class AccountController {
     status: 404,
     description: 'Token balance history not found for this account',
   })
-  getAccountTokenHistory(
+  async getAccountTokenHistory(
     @Param('address', ParseAddressPipe) address: string,
     @Param('tokenIdentifier') tokenIdentifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<AccountEsdtHistory[]> {
-    return this.accountService.getAccountTokenHistory(address, tokenIdentifier, { from, size });
+    const history = await this.accountService.getAccountTokenHistory(address, tokenIdentifier, { from, size });
+    if (!history) {
+      throw new NotFoundException(`Token '${tokenIdentifier}' not found`);
+    }
+
+    return history;
   }
 }

--- a/src/endpoints/accounts/account.module.ts
+++ b/src/endpoints/accounts/account.module.ts
@@ -25,6 +25,7 @@ import { AccountService } from "./account.service";
     forwardRef(() => CollectionModule),
     forwardRef(() => PluginModule),
     TransferModule,
+    forwardRef(() => TokenModule),
   ],
   providers: [
     AccountService,

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { Token } from "./entities/token";
 import { TokenWithBalance } from "./entities/token.with.balance";
 import { TokenDetailed } from "./entities/token.detailed";
@@ -33,6 +33,7 @@ export class TokenService {
     private readonly esdtService: EsdtService,
     private readonly elasticService: ElasticService,
     private readonly cachingService: CachingService,
+    @Inject(forwardRef(() => TransactionService))
     private readonly transactionService: TransactionService,
     private readonly esdtAddressService: EsdtAddressService,
     private readonly gatewayService: GatewayService

--- a/src/test/integration/accounts.e2e-spec.ts
+++ b/src/test/integration/accounts.e2e-spec.ts
@@ -109,14 +109,16 @@ describe('Account Service', () => {
       const accountTokens = await tokensService.getTokensForAddressFromGateway(address, { from: 0, size: 1 }, {});
 
       if (accountTokens.length) {
-        const accountTokenHistories = await accountService.getAccountTokenHistory(address,
-          accountTokens[0].identifier, { from: 0, size: 1 });
+        const accountTokenHistories = await accountService.getAccountTokenHistory(address, accountTokens[0].identifier, { from: 0, size: 1 });
+        expect(accountTokenHistories).toBeDefined();
 
-        for (const account of accountTokenHistories) {
-          expect(account).toHaveProperty('address');
-          expect(account).toHaveProperty('balance');
-          expect(account).toHaveProperty('timestamp');
-          expect(account).toHaveProperty('token');
+        if (accountTokenHistories) {
+          for (const account of accountTokenHistories) {
+            expect(account).toHaveProperty('address');
+            expect(account).toHaveProperty('balance');
+            expect(account).toHaveProperty('timestamp');
+            expect(account).toHaveProperty('token');
+          }
         }
       }
     });


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- validate whether token exists in account history endpoint

## How to test (mainnet)
- `https://api.elrond.com/accounts/erd1qqqqqqqqqqqqqpgqmqq78c5htmdnws8hm5u4suvags36eq092jpsaxv3e7/history/RIDE-7d18e9` should return values
- `https://api.elrond.com/accounts/erd1qqqqqqqqqqqqqpgqmqq78c5htmdnws8hm5u4suvags36eq092jpsaxv3e7/history/RIDE-7d18e9TEST` should return 404 not found