### PR TITLE
early exit if account is not creator for any collection

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -81,6 +81,10 @@ export class CollectionService {
   async getNftCollections(pagination: QueryPagination, filter: CollectionFilter): Promise<NftCollection[]> {
     if (filter.creator) {
       const creatorResult = await this.gatewayService.get(`address/${filter.creator}/esdts-with-role/ESDTRoleNFTCreate`, GatewayComponentRequest.addressEsdtWithRole);
+      if (creatorResult.tokens.length === 0) {
+        return [];
+      }
+
       filter.identifiers = creatorResult.tokens;
     }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- early exit if account is not creator for any collection

## How to test (testnet)
- `collections?creator=erd1qqqqqqqqqqqqqpgqmqq78c5htmdnws8hm5u4suvags36eq092jpsaxv3e7` should return empty array