### PR TITLE
Fixed collections by creator count

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -196,6 +196,11 @@ export class CollectionService {
 
 
   async getNftCollectionCount(filter: CollectionFilter): Promise<number> {
+    if (filter.creator) {
+      const creatorResult = await this.gatewayService.get(`address/${filter.creator}/esdts-with-role/ESDTRoleNFTCreate`, GatewayComponentRequest.addressEsdtWithRole);
+      return creatorResult.tokens.length;
+    }
+
     const elasticQuery = this.buildCollectionFilter(filter);
 
     return await this.elasticService.getCount('tokens', elasticQuery);


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Performance improvement

## Proposed Changes
- Return correct collections by creator count

## How to test (mainnet)
- `/collections/count?creator=erd1qqqqqqqqqqqqqpgqmqq78c5htmdnws8hm5u4suvags36eq092jpsaxv3e7` should return 1 (not ~4800)