### PR TITLE
Token accounts fixes

### DIFF
--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -119,9 +119,7 @@ export class ElasticService {
     let elasticQuery = ElasticQuery.create();
 
     if (pagination) {
-      elasticQuery = elasticQuery.withPagination({ from: 0, size: pagination.size });
-    } else {
-      elasticQuery = elasticQuery.withPagination({ from: 0, size: 100 });
+      elasticQuery = elasticQuery.withPagination(pagination);
     }
 
     elasticQuery = elasticQuery

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -83,7 +83,7 @@ export class EsdtService {
 
       token.accounts = await this.cachingService.getOrSetCache(
         CacheInfo.TokenAccounts(token.identifier).key,
-        async () => await this.getTokenAccountsCount(token.identifier),
+        async () => await this.getEsdtAccountsCount(token.identifier),
         CacheInfo.TokenAccounts(token.identifier).ttl
       );
     }
@@ -93,7 +93,7 @@ export class EsdtService {
     return tokens;
   }
 
-  async getTokenAccountsCount(identifier: string): Promise<number> {
+  async getEsdtAccountsCount(identifier: string): Promise<number> {
     const elasticQuery: ElasticQuery = ElasticQuery.create()
       .withCondition(QueryConditionOptions.must, [QueryType.Match("token", identifier, QueryOperator.AND)]);
 

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -1,5 +1,5 @@
 import { BadRequestException, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, ParseIntPipe, Query } from "@nestjs/common";
-import { ApiExcludeEndpoint, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiExcludeEndpoint, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { ParseAddressPipe } from "src/utils/pipes/parse.address.pipe";
 import { ParseArrayPipe } from "src/utils/pipes/parse.array.pipe";
 import { ParseOptionalBoolPipe } from "src/utils/pipes/parse.optional.bool.pipe";
@@ -141,6 +141,7 @@ export class NftController {
   }
 
   @Get('/nfts/:identifier/owners')
+  @ApiOperation({ deprecated: true })
   @ApiResponse({
     status: 200,
     description: 'Non-fungible / semi-fungible token owners',
@@ -158,7 +159,6 @@ export class NftController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<NftOwner[]> {
     const owners = await this.nftService.getNftOwners(identifier, { from, size });
-
     if (owners === undefined) {
       throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
     }
@@ -167,6 +167,7 @@ export class NftController {
   }
 
   @Get('/nfts/:identifier/owners/count')
+  @ApiOperation({ deprecated: true })
   @ApiResponse({
     status: 200,
     description: 'Non-fungible / semi-fungible token owners count',
@@ -174,6 +175,49 @@ export class NftController {
   })
   async getNftOwnersCount(@Param('identifier') identifier: string): Promise<number> {
     const ownersCount = await this.nftService.getNftOwnersCount(identifier);
+    if (ownersCount === undefined) {
+      throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
+    }
+
+    return ownersCount;
+  }
+
+  @Get('/nfts/:identifier/accounts')
+  @ApiResponse({
+    status: 200,
+    description: 'Non-fungible / semi-fungible token owners',
+    type: NftOwner,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Token not found',
+  })
+  @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  async getNftAccounts(
+    @Param('identifier') identifier: string,
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+  ): Promise<NftOwner[]> {
+    const owners = await this.nftService.getNftOwners(identifier, { from, size });
+    if (owners === undefined) {
+      throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
+    }
+
+    return owners;
+  }
+
+  @Get('/nfts/:identifier/accounts/count')
+  @ApiResponse({
+    status: 200,
+    description: 'Non-fungible / semi-fungible token owners count',
+    type: Number,
+  })
+  async getNftAccountsCount(@Param('identifier') identifier: string): Promise<number> {
+    const ownersCount = await this.nftService.getNftOwnersCount(identifier);
+    if (ownersCount === undefined) {
+      throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
+    }
 
     return ownersCount;
   }

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -265,7 +265,7 @@ describe("NFT Controller", () => {
       .expect(200);
   });
 
-  it("/nfts/count?{identifiers} - should return 200 status code and nft details based on identifier", async () => {
+  it("/nfts/:identifier - should return 200 status code and nft details based on identifier", async () => {
     const identifier: string = "GCC-6b08ed-34";
 
     await request(app.getHttpServer())
@@ -273,7 +273,7 @@ describe("NFT Controller", () => {
       .expect(200);
   });
 
-  it("/nfts/count?{identifiers} - should return 404 status code Error: Not Found", async () => {
+  it("/nfts/:identifier - should return 404 status code Error: Not Found", async () => {
     const identifier: string = "GCC-6b08ed-34Test";
 
     await request(app.getHttpServer())
@@ -284,7 +284,7 @@ describe("NFT Controller", () => {
       });
   });
 
-  it("/nfts/count?{identifiers}/supply - should return 200 status code and nft details supply", async () => {
+  it("/nfts/:identifier/supply - should return 200 status code and nft details supply", async () => {
     const identifier: string = "GCC-6b08ed-34";
 
     await request(app.getHttpServer())
@@ -292,16 +292,16 @@ describe("NFT Controller", () => {
       .expect(200);
   });
 
-  it("/nfts/count?{identifiers}/owners - should return 200 status code and nft owners details", async () => {
-    const identifier: string = "MOS-b9b4b2";
+  it("/nfts/:identifier/owners - should return 200 status code and nft owners details", async () => {
+    const identifier: string = "LKMEX-aab910-04";
 
     await request(app.getHttpServer())
       .get(route + "/" + identifier + "/owners")
       .expect(200);
   });
 
-  it("/nfts/count?{identifiers}/owners - should return 200 status code and nft owners details", async () => {
-    const identifier: string = "MOS-b9b4b2";
+  it("/nfts/:identifier/owners - should return 200 status code and nft owners details", async () => {
+    const identifier: string = "LKMEX-aab910-04";
     const params = new URLSearchParams({
       'from': '0',
       'size': '10',
@@ -312,8 +312,8 @@ describe("NFT Controller", () => {
       .expect(200);
   });
 
-  it("/nfts/count?{identifiers}/owners/count - should return 200 status code and nft owners count", async () => {
-    const identifier: string = "MOS-b9b4b2";
+  it("/nfts/:identifier/owners/count - should return 200 status code and nft owners count", async () => {
+    const identifier: string = "LKMEX-aab910-04";
 
     await request(app.getHttpServer())
       .get(route + "/" + identifier + "/owners/count")

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -188,7 +188,7 @@ describe('ESDT Service', () => {
   describe('Get Token Account Count', () => {
     it('return token account count', async () => {
       const tokenIdentifier: string = "EGLDMEX-0be9e5";
-      const result = await esdtService.getTokenAccountsCount(tokenIdentifier);
+      const result = await esdtService.getEsdtAccountsCount(tokenIdentifier);
 
       expect(typeof result).toStrictEqual('number');
     });

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -232,10 +232,13 @@ describe('Token Service', () => {
       const identifier: string = "RIDE-7d18e9";
       const results = await tokenService.getTokenAccounts({ from: 0, size: 10 }, identifier);
 
+      expect(results).toBeDefined();
       expect(results).toHaveLength(10);
 
-      for (const result of results) {
-        expect(result).toHaveStructure(Object.keys(new TokenAccount()));
+      if (results) {
+        for (const result of results) {
+          expect(result).toHaveStructure(Object.keys(new TokenAccount()));
+        }
       }
     });
 


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Added Nft accounts endpoint 
- Deprecated Nft owners endpoint
- Collection nfts endpoint
- Fix pagination for nft accounts endpoint
- Validate whether nft exists in nft accounts endpoint
- Validate whether token exists in token accounts endpoint

## How to test
- `/nfts/LKMEX-aab910-04/accounts?from=0` and `/nfts/LKMEX-aab910-04/accounts?from=1` should return results from different offsets
- `/nfts/LKMEX-aab910-04/owners?from=0` and `/nfts/LKMEX-aab910-04/owners?from=1` should return results from different offsets
- NFT owners endpoint should be marked as deprecated in swaggerdoc
- `/collections/KROGAN-54c361/nfts` should return array of nfts of collection KROGAN-54c361
- `/nfts/KROGAN-54c361/owners` should return 404
- `/tokens/blabla/accounts` should return 404