### PR TITLE
Mex settings cache warm

### DIFF
--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -124,6 +124,11 @@ export class CacheInfo {
     ttl: Constants.oneDay(),
   };
 
+  static MexSettings: CacheInfo = {
+    key: 'mex:settings',
+    ttl: Constants.oneDay(),
+  };
+
   static TokenTransferProperties(identifier: string): CacheInfo {
     return {
       key: `token:transfer:properties:v2:${identifier}`,

--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -6,6 +6,7 @@ import { PluginModule } from 'src/plugins/plugin.module';
 import { KeybaseModule } from 'src/common/keybase/keybase.module';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { ClientOptions, ClientProxyFactory, Transport } from '@nestjs/microservices';
+import { MexSettingsModule } from 'src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { ClientOptions, ClientProxyFactory, Transport } from '@nestjs/microservi
     EndpointsServicesModule,
     PluginModule,
     KeybaseModule,
+    MexSettingsModule,
   ],
   providers: [
     {

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -209,7 +209,7 @@ export class CacheWarmerService {
     await this.pluginService.handleEveryMinuteCron();
   }
 
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_10_MINUTES)
   async handleMexSettings() {
     await Locker.lock('Mex settings invalidations', async () => {
       const settings = await this.mexSettingsService.getSettingsRaw();

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -213,7 +213,9 @@ export class CacheWarmerService {
   async handleMexSettings() {
     await Locker.lock('Mex settings invalidations', async () => {
       const settings = await this.mexSettingsService.getSettingsRaw();
-      await this.invalidateKey(CacheInfo.MexSettings.key, settings, CacheInfo.MexSettings.ttl);
+      if (settings) {
+        await this.invalidateKey(CacheInfo.MexSettings.key, settings, CacheInfo.MexSettings.ttl);
+      }
     });
   }
 

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.module.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { MexSettingsService } from "./mex.settings.service";
+
+@Module({
+  imports: [
+    ConfigModule,
+  ],
+  providers: [
+    MexSettingsService,
+  ],
+  exports: [
+    MexSettingsService,
+  ],
+})
+export class MexSettingsModule { }

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import { CachingService } from "src/common/caching/caching.service";
 import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { ApiService } from "src/common/network/api.service";
+import { Constants } from "src/utils/constants";
 import { TransactionMetadata } from "../../entities/transaction.metadata";
 import { TransactionMetadataTransfer } from "../../entities/transaction.metadata.transfer";
 import { MexSettings } from "./entities/mex.settings";
@@ -37,7 +38,8 @@ export class MexSettingsService {
       settings = await this.cachingService.getOrSetCache(
         CacheInfo.MexSettings.key,
         async () => await this.getSettingsRaw(),
-        CacheInfo.MexSettings.ttl
+        CacheInfo.MexSettings.ttl,
+        Constants.oneMinute() * 10,
       );
 
       this.settings = settings;

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
@@ -76,7 +76,7 @@ export class MexSettingsService {
         "offset": 0,
         "limit": 500,
       },
-      "query": "query ($offset: Int, $limit: Int) {\r\n  pairs(offset: $offset, limit: $limit) {\r\n    address\r\n    firstToken {\r\n      name\r\n      identifier\r\n      decimals\r\n      __typename\r\n    }\r\n    secondToken {\r\n      name\r\n      identifier\r\n      decimals\r\n      __typename\r\n    } }\r\n  proxy {\r\n    address\r\n  }\r\n  farms {\r\n    address\r\n  }\r\n  wrappingInfo {\r\n    address\r\n    shard\r\n  }\r\n  distribution {\r\n    address\r\n  }\r\n  lockedAssetFactory {\r\n    address\r\n  }\r\n  stakingFarms {\r\n    address\r\n  }\r\n  stakingProxies {\r\n    address\r\n  }\r\n}\r\n",
+      "query": "query ($offset: Int, $limit: Int) {\r\n  pairs(offset: $offset, limit: $limit) {\r\n    state\r\n     address\r\n    firstToken {\r\n      name\r\n      identifier\r\n      decimals\r\n      __typename\r\n    }\r\n    secondToken {\r\n      name\r\n      identifier\r\n      decimals\r\n      __typename\r\n    } }\r\n  proxy {\r\n    address\r\n  }\r\n  farms {\r\n    state\r\n    address\r\n  }\r\n  wrappingInfo {\r\n    address\r\n    shard\r\n  }\r\n  distribution {\r\n    address\r\n  }\r\n  lockedAssetFactory {\r\n    address\r\n  }\r\n  stakingFarms {\r\n    state\r\n    address\r\n  }\r\n  stakingProxies {\r\n    address\r\n  }\r\n}\r\n",
     };
 
     const result = await this.apiCall(params);
@@ -86,13 +86,13 @@ export class MexSettingsService {
 
     const settings = new MexSettings();
     settings.farmContracts = [
-      ...result.farms.map((x: any) => x.address),
-      ...result.stakingFarms.map((x: any) => x.address),
+      ...result.farms.filter((x: any) => ['Active', 'Migrate'].includes(x.state)).map((x: any) => x.address),
+      ...result.stakingFarms.filter((x: any) => x.state === 'Active').map((x: any) => x.address),
       ...result.stakingProxies.map((x: any) => x.address),
       result.proxy.address,
     ];
     settings.pairContracts = [
-      ...result.pairs.map((x: any) => x.address),
+      ...result.pairs.filter((x: any) => x.state === 'Active').map((x: any) => x.address),
       result.proxy.address,
     ];
     settings.wrapContracts = result.wrappingInfo.map((x: any) => x.address);

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.settings.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { CachingService } from "src/common/caching/caching.service";
+import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { ApiService } from "src/common/network/api.service";
-import { Constants } from "src/utils/constants";
 import { TransactionMetadata } from "../../entities/transaction.metadata";
 import { TransactionMetadataTransfer } from "../../entities/transaction.metadata.transfer";
 import { MexSettings } from "./entities/mex.settings";
@@ -35,9 +35,9 @@ export class MexSettingsService {
     let settings = this.settings;
     if (settings === undefined) {
       settings = await this.cachingService.getOrSetCache(
-        'mex:settings:v3',
+        CacheInfo.MexSettings.key,
         async () => await this.getSettingsRaw(),
-        Constants.oneDay()
+        CacheInfo.MexSettings.ttl
       );
 
       this.settings = settings;
@@ -70,7 +70,7 @@ export class MexSettingsService {
     return mexContracts;
   }
 
-  private async getSettingsRaw(): Promise<MexSettings | null> {
+  public async getSettingsRaw(): Promise<MexSettings | null> {
     const params = {
       "variables": {
         "offset": 0,

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.module.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/transaction.action.mex.recognizer.module.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Module } from "@nestjs/common";
-import { ConfigModule } from "@nestjs/config";
 import { TokenModule } from "src/endpoints/tokens/token.module";
 import { MexFarmActionRecognizerService } from "./mex.farm.action.recognizer.service";
 import { MexPairActionRecognizerService } from "./mex.pair.action.recognizer.service";
@@ -8,17 +7,16 @@ import { MexWrapActionRecognizerService } from "./mex.wrap.action.recognizer.ser
 import { MexDistributionActionRecognizerService } from "./mex.distribution.action.recognizer.service";
 import { TransactionActionModule } from "../../transaction.action.module";
 import { MexLockedAssetActionRecognizerService } from "./mex.locked.asset.action.recognizer.service";
-import { MexSettingsService } from "./mex.settings.service";
+import { MexSettingsModule } from "./mex.settings.module";
 
 @Module({
   imports: [
     forwardRef(() => TokenModule),
-    ConfigModule,
     forwardRef(() => TransactionActionModule),
+    MexSettingsModule,
   ],
   providers: [
     TransactionActionMexRecognizerService,
-    MexSettingsService,
     MexPairActionRecognizerService,
     MexFarmActionRecognizerService,
     MexWrapActionRecognizerService,


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- cache warm mex settings, to refresh farms more often
- provide mex settings endpoint for debugging purposes

## How to test
- `/mex-pairs` should only return active pairs