### PR TITLE
limit array size for ParseArrayPipe

### DIFF
--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -23,7 +23,7 @@ export class SmartContractResultController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('miniBlockHash') miniBlockHash?: string,
-    @Query('originalTxHashes', ParseArrayPipe) originalTxHashes?: string[],
+    @Query('originalTxHashes', new ParseArrayPipe(64)) originalTxHashes?: string[],
   ): Promise<SmartContractResult[]> {
     return this.scResultService.getScResults({ from, size }, { miniBlockHash, originalTxHashes });
   }

--- a/src/utils/pipes/parse.array.pipe.ts
+++ b/src/utils/pipes/parse.array.pipe.ts
@@ -2,7 +2,11 @@ import { ArgumentMetadata, HttpException, HttpStatus, PipeTransform } from "@nes
 
 
 export class ParseArrayPipe implements PipeTransform<string | undefined, Promise<string[] | undefined>> {
-  private MAX_ARRAY_SIZE = 1024;
+  private readonly maxArraySize;
+
+  constructor(maxArraySize: number = 1024) {
+    this.maxArraySize = maxArraySize;
+  }
 
   transform(value: string | undefined, _: ArgumentMetadata): Promise<string[] | undefined> {
     return new Promise(resolve => {
@@ -12,11 +16,13 @@ export class ParseArrayPipe implements PipeTransform<string | undefined, Promise
 
       const valueArray = value.split(',');
 
-      if (valueArray.length > this.MAX_ARRAY_SIZE) {
-        throw new HttpException(`Validation failed (less than ${this.MAX_ARRAY_SIZE} comma separated values expected)`, HttpStatus.BAD_REQUEST);
+      if (valueArray.length > this.maxArraySize) {
+        throw new HttpException(`Validation failed (less than ${this.maxArraySize} comma separated values expected)`, HttpStatus.BAD_REQUEST);
       }
 
-      resolve(valueArray);
+      const distinctValueArray = valueArray.distinct();
+
+      resolve(distinctValueArray);
     });
   }
 }


### PR DESCRIPTION
## Type
- [ ] Bug
- [X] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Limit array size for `ParseArrayPipe` and filter distinct values