### PR TITLE
extract tx count / scr count from transfers

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -865,7 +865,6 @@ export class AccountController {
   @ApiResponse({
     status: 200,
     description: 'The count of all smart contract results for a given account',
-    type: SmartContractResult,
   })
   @ApiResponse({
     status: 404,
@@ -873,7 +872,7 @@ export class AccountController {
   })
   getAccountScResultsCount(
     @Param('address', ParseAddressPipe) address: string,
-  ): Promise<SmartContractResult[]> {
+  ): Promise<number> {
     return this.scResultService.getAccountScResultsCount(address);
   }
 

--- a/src/endpoints/accounts/account.module.ts
+++ b/src/endpoints/accounts/account.module.ts
@@ -24,7 +24,7 @@ import { AccountService } from "./account.service";
     SmartContractResultModule,
     forwardRef(() => CollectionModule),
     forwardRef(() => PluginModule),
-    TransferModule,
+    forwardRef(() => TransferModule),
     forwardRef(() => TokenModule),
   ],
   providers: [

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, HttpStatus, Inject, Injectable, Logger } from '@nestjs/common';
+import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
 import { AccountDetailed } from './entities/account.detailed';
 import { Account } from './entities/account';
 import { CachingService } from 'src/common/caching/caching.service';
@@ -27,6 +27,9 @@ import { AccountHistory } from "./entities/account.history";
 import { QueryOperator } from 'src/common/elastic/entities/query.operator';
 import { TokenService } from '../tokens/token.service';
 import { StakeService } from '../stake/stake.service';
+import { TransferService } from '../transfers/transfer.service';
+import { SmartContractResultService } from '../sc-results/scresult.service';
+import { TransactionType } from '../transactions/entities/transaction.type';
 
 @Injectable()
 export class AccountService {
@@ -46,6 +49,10 @@ export class AccountService {
     private readonly tokenService: TokenService,
     @Inject(forwardRef(() => StakeService))
     private readonly stakeService: StakeService,
+    @Inject(forwardRef(() => TransferService))
+    private readonly transferService: TransferService,
+    @Inject(forwardRef(() => SmartContractResultService))
+    private readonly smartContractResultService: SmartContractResultService,
   ) {
     this.logger = new Logger(AccountService.name);
   }
@@ -80,14 +87,6 @@ export class AccountService {
       return null;
     }
 
-    const queries = [
-      QueryType.Match('sender', address),
-      QueryType.Match('receiver', address),
-    ];
-
-    const elasticQuery: ElasticQuery = ElasticQuery.create()
-      .withCondition(QueryConditionOptions.should, queries);
-
     try {
       const [
         txCount,
@@ -96,8 +95,8 @@ export class AccountService {
           account: { nonce, balance, code, codeHash, rootHash, username, developerReward, ownerAddress, codeMetadata },
         },
       ] = await Promise.all([
-        this.transactionService.getTransactionCountForAddress(address),
-        this.getAccountScResults(elasticQuery),
+        this.getAccountTxCount(address),
+        this.getAccountScResults(address),
         this.gatewayService.get(`address/${address}`, GatewayComponentRequest.addressDetails),
       ]);
 
@@ -125,21 +124,24 @@ export class AccountService {
     }
   }
 
-  private async getAccountScResults(query: ElasticQuery): Promise<number> {
+  private async getAccountTxCount(address: string): Promise<number> {
+    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
+      return this.transactionService.getTransactionCountForAddress(address);
+    }
+
+    return await this.transferService.getTransfersCount({ type: TransactionType.Transaction }, address);
+  }
+
+  private async getAccountScResults(address: string): Promise<number> {
     if (this.apiConfigService.getUseLegacyElastic()) {
       return 0;
     }
 
-    try {
-      return await this.elasticService.getCount('scresults', query);
-    } catch (error) {
-      // @ts-ignore
-      if (error.response.status === HttpStatus.NOT_FOUND) {
-        return 0;
-      }
-
-      throw error;
+    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
+      return await this.smartContractResultService.getAccountScResultsCount(address);
     }
+
+    return await this.transferService.getTransfersCount({ type: TransactionType.SmartContractResult }, address);
   }
 
   async getAccountDeployedAt(address: string): Promise<number | null> {

--- a/src/endpoints/sc-results/scresult.service.ts
+++ b/src/endpoints/sc-results/scresult.service.ts
@@ -79,7 +79,7 @@ export class SmartContractResultService {
     return elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
   }
 
-  async getAccountScResultsCount(address: string): Promise<SmartContractResult[]> {
+  async getAccountScResultsCount(address: string): Promise<number> {
     const elasticQuery: ElasticQuery = this.buildSmartContractResultFilterQuery(address);
 
     return await this.elasticService.getCount('scresults', elasticQuery);

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -1,6 +1,7 @@
 import { QueryConditionOptions } from "src/common/elastic/entities/query.condition.options";
 import { SortOrder } from "src/common/entities/sort.order";
 import { TransactionStatus } from "./transaction.status";
+import { TransactionType } from "./transaction.type";
 
 export class TransactionFilter {
     sender?: string;
@@ -17,4 +18,5 @@ export class TransactionFilter {
     after?: number;
     condition?: QueryConditionOptions;
     order?: SortOrder;
+    type?: TransactionType;
 }

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { ElasticService } from "src/common/elastic/elastic.service";
 import { ElasticQuery } from "src/common/elastic/entities/elastic.query";
@@ -21,6 +21,7 @@ export class TransferService {
   constructor(
     private readonly apiConfigService: ApiConfigService,
     private readonly elasticService: ElasticService,
+    @Inject(forwardRef(() => TransactionService))
     private readonly transactionService: TransactionService,
   ) { }
 
@@ -49,6 +50,10 @@ export class TransferService {
           QueryType.Match('receivers', address),
         ]),
       ]));
+
+    if (filter.type) {
+      elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('type', filter.type === TransactionType.Transaction ? 'normal' : 'unsigned'));
+    }
 
     if (filter.sender) {
       elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('sender', filter.sender));


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Instead of fetching from multiple data sources, use the unified transfers collection to fetch both transfers count and scr count

## How to test (testnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqq70j7ldp55mq9gzzaxt354lsv2h0j8qxpr9s9tcg9d` should have `txCount` + `scrCount` equal to `/accounts/erd1qqqqqqqqqqqqqpgqq70j7ldp55mq9gzzaxt354lsv2h0j8qxpr9s9tcg9d/transfers/count`