### PR TITLE
Token roles fix

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -246,7 +246,7 @@ export class CollectionService {
     return collection;
   }
 
-  private async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoles[]> {
+  async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoles[]> {
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       return await this.getNftCollectionRolesFromEsdtContract(elasticCollection.token);
     }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -23,7 +23,7 @@ import { RecordUtils } from "src/utils/record.utils";
 import { TokenAssets } from "../tokens/entities/token.assets";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { EsdtDataSource } from "../esdt/entities/esdt.data.source";
-import { CollectionRoleForAddress } from "../tokens/entities/collection.role.for.address";
+import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { TokenUtils } from "src/utils/token.utils";
 import { QueryConditionOptions } from "src/common/elastic/entities/query.condition.options";
 
@@ -246,7 +246,7 @@ export class CollectionService {
     return collection;
   }
 
-  private async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoleForAddress[]> {
+  private async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoles[]> {
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       return await this.getNftCollectionRolesFromEsdtContract(elasticCollection.token);
     }
@@ -254,12 +254,12 @@ export class CollectionService {
     return this.getNftCollectionRolesFromElasticResponse(elasticCollection);
   }
 
-  private getNftCollectionRolesFromElasticResponse(elasticCollection: any): CollectionRoleForAddress[] {
+  private getNftCollectionRolesFromElasticResponse(elasticCollection: any): CollectionRoles[] {
     if (!elasticCollection.roles) {
       return [];
     }
 
-    const allRoles: CollectionRoleForAddress[] = [];
+    const allRoles: CollectionRoles[] = [];
     for (const role of Object.keys(elasticCollection.roles)) {
       const addresses = elasticCollection.roles[role].distinct();
 
@@ -270,7 +270,7 @@ export class CollectionService {
           continue;
         }
 
-        const addressRole = new CollectionRoleForAddress();
+        const addressRole = new CollectionRoles();
         addressRole.address = address;
         TokenUtils.setCollectionRole(addressRole, role);
 
@@ -281,7 +281,7 @@ export class CollectionService {
     return allRoles;
   }
 
-  private async getNftCollectionRolesFromEsdtContract(identifier: string): Promise<CollectionRoleForAddress[]> {
+  private async getNftCollectionRolesFromEsdtContract(identifier: string): Promise<CollectionRoles[]> {
     const collectionRolesEncoded = await this.vmQueryService.vmQuery(
       this.apiConfigService.getEsdtContractAddress(),
       'getSpecialRoles',
@@ -293,13 +293,13 @@ export class CollectionService {
       return [];
     }
 
-    const allRoles: CollectionRoleForAddress[] = [];
+    const allRoles: CollectionRoles[] = [];
 
     for (const rolesForAddressEncoded of collectionRolesEncoded) {
       const rolesForAddressDecoded = BinaryUtils.base64Decode(rolesForAddressEncoded);
       const components = rolesForAddressDecoded.split(':');
 
-      const roleForAddress = new CollectionRoleForAddress();
+      const roleForAddress = new CollectionRoles();
       roleForAddress.address = components[0];
       const roles = components[1].split(',');
       for (const role of roles) {

--- a/src/endpoints/collections/entities/nft.collection.ts
+++ b/src/endpoints/collections/entities/nft.collection.ts
@@ -1,7 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { TokenAssets } from "src/endpoints/tokens/entities/token.assets";
 import { NftType } from "../../nfts/entities/nft.type";
-import { CollectionRoleForAddress } from "src/endpoints/tokens/entities/collection.role.for.address";
+import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 
 export class NftCollection {
   @ApiProperty()
@@ -41,5 +41,5 @@ export class NftCollection {
   assets: TokenAssets | undefined = undefined;
 
   @ApiProperty()
-  roles: CollectionRoleForAddress[] = [];
+  roles: CollectionRoles[] = [];
 }

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -23,7 +23,7 @@ import { CollectionService } from "../collections/collection.service";
 import { NftCollection } from "../collections/entities/nft.collection";
 import { CollectionFilter } from "../collections/entities/collection.filter";
 import { AddressUtils } from "src/utils/address.utils";
-import { CollectionRoleForAddress } from "../tokens/entities/collection.role.for.address";
+import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { ApiUtils } from "src/utils/api.utils";
 
 @Injectable()
@@ -195,7 +195,7 @@ export class EsdtAddressService {
         accountCollection.timestamp = indexedCollection.timestamp;
 
         if (indexedCollection.roles) {
-          const addressRoles: CollectionRoleForAddress = new CollectionRoleForAddress();
+          const addressRoles: CollectionRoles = new CollectionRoles();
           addressRoles.address = address;
 
           for (const role of Object.keys(indexedCollection.roles)) {
@@ -213,7 +213,7 @@ export class EsdtAddressService {
     if (this.apiConfigService.getIsIndexerV3FlagActive()) {
       const nftAccountCollections: NftCollectionAccount[] = [];
       for (const collection of accountCollections) {
-        const role = collection.roles.find(x => x.address === address) ?? new CollectionRoleForAddress();
+        const role = collection.roles.find(x => x.address === address) ?? new CollectionRoles();
 
         if (collection.type === NftType.NonFungibleESDT) {
           //@ts-ignore

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -16,9 +16,9 @@ import { TokenUtils } from "src/utils/token.utils";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { CachingService } from "../../common/caching/caching.service";
 import { GatewayService } from "../../common/gateway/gateway.service";
-import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { TokenAssets } from "../tokens/entities/token.assets";
 import { TokenDetailed } from "../tokens/entities/token.detailed";
+import { TokenRoles } from "../tokens/entities/token.roles";
 import { TokenAssetService } from "../tokens/token.asset.service";
 import { EsdtSupply } from "./entities/esdt.supply";
 
@@ -200,7 +200,7 @@ export class EsdtService {
     return tokenProps;
   }
 
-  async getEsdtAddressesRoles(identifier: string): Promise<CollectionRoles[] | undefined> {
+  async getEsdtAddressesRoles(identifier: string): Promise<TokenRoles[] | undefined> {
     const addressesRoles = await this.cachingService.getOrSetCache(
       CacheInfo.EsdtAddressesRoles(identifier).key,
       async () => await this.getEsdtAddressesRolesRaw(identifier),
@@ -215,7 +215,7 @@ export class EsdtService {
     return addressesRoles;
   }
 
-  async getEsdtAddressesRolesRaw(identifier: string): Promise<CollectionRoles[] | null> {
+  async getEsdtAddressesRolesRaw(identifier: string): Promise<TokenRoles[] | null> {
     const arg = BinaryUtils.stringToHex(identifier);
 
     const tokenAddressesAndRolesEncoded = await this.vmQueryService.vmQuery(
@@ -231,8 +231,8 @@ export class EsdtService {
       return [];
     }
 
-    const tokenAddressesAndRoles: CollectionRoles[] = [];
-    let currentAddressRoles = new CollectionRoles();
+    const tokenAddressesAndRoles: TokenRoles[] = [];
+    let currentAddressRoles = new TokenRoles();
     for (const valueEncoded of tokenAddressesAndRolesEncoded) {
       const address = BinaryUtils.tryBase64ToAddress(valueEncoded);
       if (address) {
@@ -240,14 +240,14 @@ export class EsdtService {
           tokenAddressesAndRoles.push(currentAddressRoles);
         }
 
-        currentAddressRoles = new CollectionRoles();
+        currentAddressRoles = new TokenRoles();
         currentAddressRoles.address = address;
 
         continue;
       }
 
       const role = BinaryUtils.base64Decode(valueEncoded);
-      TokenUtils.setCollectionRole(currentAddressRoles, role);
+      TokenUtils.setTokenRole(currentAddressRoles, role);
     }
 
     if (currentAddressRoles.address) {

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -16,7 +16,7 @@ import { TokenUtils } from "src/utils/token.utils";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { CachingService } from "../../common/caching/caching.service";
 import { GatewayService } from "../../common/gateway/gateway.service";
-import { CollectionRoleForAddress } from "../tokens/entities/collection.role.for.address";
+import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { TokenAssets } from "../tokens/entities/token.assets";
 import { TokenDetailed } from "../tokens/entities/token.detailed";
 import { TokenAssetService } from "../tokens/token.asset.service";
@@ -200,7 +200,7 @@ export class EsdtService {
     return tokenProps;
   }
 
-  async getEsdtAddressesRoles(identifier: string): Promise<CollectionRoleForAddress[] | undefined> {
+  async getEsdtAddressesRoles(identifier: string): Promise<CollectionRoles[] | undefined> {
     const addressesRoles = await this.cachingService.getOrSetCache(
       CacheInfo.EsdtAddressesRoles(identifier).key,
       async () => await this.getEsdtAddressesRolesRaw(identifier),
@@ -215,7 +215,7 @@ export class EsdtService {
     return addressesRoles;
   }
 
-  async getEsdtAddressesRolesRaw(identifier: string): Promise<CollectionRoleForAddress[] | null> {
+  async getEsdtAddressesRolesRaw(identifier: string): Promise<CollectionRoles[] | null> {
     const arg = BinaryUtils.stringToHex(identifier);
 
     const tokenAddressesAndRolesEncoded = await this.vmQueryService.vmQuery(
@@ -231,8 +231,8 @@ export class EsdtService {
       return [];
     }
 
-    const tokenAddressesAndRoles: CollectionRoleForAddress[] = [];
-    let currentAddressRoles = new CollectionRoleForAddress();
+    const tokenAddressesAndRoles: CollectionRoles[] = [];
+    let currentAddressRoles = new CollectionRoles();
     for (const valueEncoded of tokenAddressesAndRolesEncoded) {
       const address = BinaryUtils.tryBase64ToAddress(valueEncoded);
       if (address) {
@@ -240,7 +240,7 @@ export class EsdtService {
           tokenAddressesAndRoles.push(currentAddressRoles);
         }
 
-        currentAddressRoles = new CollectionRoleForAddress();
+        currentAddressRoles = new CollectionRoles();
         currentAddressRoles.address = address;
 
         continue;

--- a/src/endpoints/tokens/entities/collection.role.for.address.ts
+++ b/src/endpoints/tokens/entities/collection.role.for.address.ts
@@ -1,5 +1,0 @@
-import { CollectionRoles as CollectionRole } from "./collection.role";
-
-export class CollectionRoleForAddress extends CollectionRole {
-  address: string | undefined = undefined;
-}

--- a/src/endpoints/tokens/entities/collection.roles.ts
+++ b/src/endpoints/tokens/entities/collection.roles.ts
@@ -6,4 +6,5 @@ export class CollectionRoles {
   canUpdateAttributes: boolean = false;
   canAddUri: boolean = false;
   canTransferRole: boolean = false;
+  roles: string[] = [];
 }

--- a/src/endpoints/tokens/entities/collection.roles.ts
+++ b/src/endpoints/tokens/entities/collection.roles.ts
@@ -1,4 +1,5 @@
 export class CollectionRoles {
+  address: string | undefined = undefined;
   canCreate: boolean = false;
   canBurn: boolean = false;
   canAddQuantity: boolean = false;

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { Token } from "./token";
+import { TokenRoles } from "./token.roles";
 
 export class TokenDetailed extends Token {
   @ApiProperty()
@@ -28,4 +29,7 @@ export class TokenDetailed extends Token {
 
   @ApiProperty()
   circulatingSupply: string | undefined = undefined;
+
+  @ApiProperty()
+  roles: TokenRoles[] | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.roles.ts
+++ b/src/endpoints/tokens/entities/token.roles.ts
@@ -1,0 +1,6 @@
+export class TokenRoles {
+  address: string = '';
+  canMint: boolean = false;
+  canBurn: boolean = false;
+  roles: string[] = [];
+}

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -299,10 +299,14 @@ export class TokenController {
   async getTokenRoles(
     @Param('identifier') identifier: string,
   ): Promise<TokenRoles[]> {
-    const roles = await this.tokenService.getTokenRoles(identifier);
-
-    if (!roles) {
+    const token = await this.getToken(identifier);
+    if (!token) {
       throw new HttpException('Token not found', HttpStatus.NOT_FOUND);
+    }
+
+    const roles = await this.tokenService.getTokenRoles(identifier);
+    if (!roles) {
+      throw new HttpException('Token roles not found', HttpStatus.NOT_FOUND);
     }
 
     return roles;

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -10,9 +10,9 @@ import { ParseOptionalIntPipe } from "src/utils/pipes/parse.optional.int.pipe";
 import { TransactionStatus } from "../transactions/entities/transaction.status";
 import { TransactionService } from "../transactions/transaction.service";
 import { TokenAccount } from "./entities/token.account";
-import { CollectionRoles } from "./entities/collection.roles";
 import { TokenDetailed } from "./entities/token.detailed";
 import { TokenService } from "./token.service";
+import { TokenRoles } from "./entities/token.roles";
 
 @Controller()
 @ApiTags('tokens')
@@ -298,7 +298,7 @@ export class TokenController {
   })
   async getTokenRoles(
     @Param('identifier') identifier: string,
-  ): Promise<CollectionRoles[]> {
+  ): Promise<TokenRoles[]> {
     const roles = await this.tokenService.getTokenRoles(identifier);
 
     if (!roles) {
@@ -320,7 +320,7 @@ export class TokenController {
   async getTokenRolesForAddress(
     @Param('identifier') identifier: string,
     @Param('address') address: string,
-  ): Promise<CollectionRoles> {
+  ): Promise<TokenRoles> {
     const roles = await this.tokenService.getTokenRolesForAddress(identifier, address);
 
     if (!roles) {

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -10,7 +10,7 @@ import { ParseOptionalIntPipe } from "src/utils/pipes/parse.optional.int.pipe";
 import { TransactionStatus } from "../transactions/entities/transaction.status";
 import { TransactionService } from "../transactions/transaction.service";
 import { TokenAccount } from "./entities/token.account";
-import { CollectionRoleForAddress } from "./entities/collection.role.for.address";
+import { CollectionRoles } from "./entities/collection.roles";
 import { TokenDetailed } from "./entities/token.detailed";
 import { TokenService } from "./token.service";
 
@@ -298,7 +298,7 @@ export class TokenController {
   })
   async getTokenRoles(
     @Param('identifier') identifier: string,
-  ): Promise<CollectionRoleForAddress[]> {
+  ): Promise<CollectionRoles[]> {
     const roles = await this.tokenService.getTokenRoles(identifier);
 
     if (!roles) {
@@ -320,7 +320,7 @@ export class TokenController {
   async getTokenRolesForAddress(
     @Param('identifier') identifier: string,
     @Param('address') address: string,
-  ): Promise<CollectionRoleForAddress> {
+  ): Promise<CollectionRoles> {
     const roles = await this.tokenService.getTokenRolesForAddress(identifier, address);
 
     if (!roles) {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -391,11 +391,6 @@ export class TokenService {
   }
 
   async getTokenRoles(identifier: string): Promise<TokenRoles[] | undefined> {
-    const token = await this.getToken(identifier);
-    if (!token) {
-      return undefined;
-    }
-
     if (this.apiConfigService.getIsIndexerV3FlagActive()) {
       return await this.getTokenRolesFromElastic(identifier);
     }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -59,6 +59,8 @@ export class TokenService {
 
     await this.processToken(token);
 
+    token.roles = await this.getTokenRoles(identifier);
+
     return token;
   }
 

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -9,6 +9,7 @@ import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { EsdtDataSource } from 'src/endpoints/esdt/entities/esdt.data.source';
 import '../../utils/extensions/jest.extensions';
+import { TokenRoles } from 'src/endpoints/tokens/entities/token.roles';
 
 describe('ESDT Service', () => {
   let esdtService: EsdtService;
@@ -155,7 +156,7 @@ describe('ESDT Service', () => {
       }
 
       for (const result of results) {
-        expect(result).toHaveStructure(Object.keys(new CollectionRoles()));
+        expect(result).toHaveStructure(Object.keys(new TokenRoles()));
       }
     });
   });
@@ -170,7 +171,7 @@ describe('ESDT Service', () => {
       }
 
       for (const result of results) {
-        expect(result).toHaveStructure(Object.keys(new CollectionRoles()));
+        expect(result).toHaveStructure(Object.keys(new TokenRoles()));
       }
     });
   });

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -3,7 +3,7 @@ import { Test } from "@nestjs/testing";
 import { EsdtService } from "../../endpoints/esdt/esdt.service";
 import { PublicAppModule } from "src/public.app.module";
 import { CachingService } from "src/common/caching/caching.service";
-import { CollectionRoleForAddress } from "src/endpoints/tokens/entities/collection.role.for.address";
+import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 import { EsdtSupply } from "src/endpoints/esdt/entities/esdt.supply";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
@@ -155,7 +155,7 @@ describe('ESDT Service', () => {
       }
 
       for (const result of results) {
-        expect(result).toHaveStructure(Object.keys(new CollectionRoleForAddress()));
+        expect(result).toHaveStructure(Object.keys(new CollectionRoles()));
       }
     });
   });
@@ -170,7 +170,7 @@ describe('ESDT Service', () => {
       }
 
       for (const result of results) {
-        expect(result).toHaveStructure(Object.keys(new CollectionRoleForAddress()));
+        expect(result).toHaveStructure(Object.keys(new CollectionRoles()));
       }
     });
   });

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -3,7 +3,6 @@ import { Test } from "@nestjs/testing";
 import { EsdtService } from "../../endpoints/esdt/esdt.service";
 import { PublicAppModule } from "src/public.app.module";
 import { CachingService } from "src/common/caching/caching.service";
-import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 import { EsdtSupply } from "src/endpoints/esdt/entities/esdt.supply";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -659,11 +659,21 @@ describe('Token Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (_identifier: string) => [{
           address: "erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8",
-          roles: ["ESDTRoleLocalMint", "ESDTRoleLocalBurn", "ESDTRoleLocalTransfer"],
+          canCreate: true,
+          canBurn: true,
+          canAddQuantity: false,
+          canUpdateAttributes: false,
+          canAddUri: false,
+          canTransferRole: false,
         },
         {
           address: 'erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy',
-          roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'],
+          canCreate: true,
+          canBurn: true,
+          canAddQuantity: false,
+          canUpdateAttributes: false,
+          canAddUri: false,
+          canTransferRole: false,
         },
         ]));
 
@@ -671,8 +681,22 @@ describe('Token Service', () => {
 
       expect(results).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ roles: ["ESDTRoleLocalMint", "ESDTRoleLocalBurn", "ESDTRoleLocalTransfer"] }),
-          expect.objectContaining({ roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'] }),
+          expect.objectContaining({
+            canCreate: true,
+            canBurn: true,
+            canAddQuantity: false,
+            canUpdateAttributes: false,
+            canAddUri: false,
+            canTransferRole: false,
+          }),
+          expect.objectContaining({
+            canCreate: true,
+            canBurn: true,
+            canAddQuantity: false,
+            canUpdateAttributes: false,
+            canAddUri: false,
+            canTransferRole: false,
+          }),
         ])
       );
     });
@@ -701,13 +725,25 @@ describe('Token Service', () => {
         .mockImplementation(jest.fn(async (_identifier: string) => [
           {
             address: 'erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy',
-            roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'],
+            canCreate: true,
+            canBurn: true,
+            canAddQuantity: false,
+            canUpdateAttributes: false,
+            canAddUri: false,
+            canTransferRole: false,
           },
         ]));
 
       const results = await tokenService.getTokenRolesForAddress(identifier, address);
 
-      expect(results).toEqual(expect.objectContaining({ roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'] }));
+      expect(results).toEqual(expect.objectContaining({
+        canCreate: true,
+        canBurn: true,
+        canAddQuantity: false,
+        canUpdateAttributes: false,
+        canAddUri: false,
+        canTransferRole: false,
+      }));
 
     });
 

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -691,7 +691,7 @@ describe('Token Service', () => {
 
     it("should return undefined because test simulates that roles are not defined for token", async () => {
       const results = await tokenService.getTokenRoles('UNKNOWN');
-      expect(results).toBeUndefined();
+      expect(results).toStrictEqual([]);
     });
   });
 

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -659,21 +659,15 @@ describe('Token Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (_identifier: string) => [{
           address: "erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8",
-          canCreate: true,
+          canMint: true,
           canBurn: true,
-          canAddQuantity: false,
-          canUpdateAttributes: false,
-          canAddUri: false,
-          canTransferRole: false,
+          roles: [],
         },
         {
           address: 'erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy',
-          canCreate: true,
+          canMint: true,
           canBurn: true,
-          canAddQuantity: false,
-          canUpdateAttributes: false,
-          canAddUri: false,
-          canTransferRole: false,
+          roles: [],
         },
         ]));
 
@@ -725,24 +719,18 @@ describe('Token Service', () => {
         .mockImplementation(jest.fn(async (_identifier: string) => [
           {
             address: 'erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy',
-            canCreate: true,
+            canMint: true,
             canBurn: true,
-            canAddQuantity: false,
-            canUpdateAttributes: false,
-            canAddUri: false,
-            canTransferRole: false,
+            roles: [],
           },
         ]));
 
       const results = await tokenService.getTokenRolesForAddress(identifier, address);
 
       expect(results).toEqual(expect.objectContaining({
-        canCreate: true,
+        canMint: true,
         canBurn: true,
-        canAddQuantity: false,
-        canUpdateAttributes: false,
-        canAddUri: false,
-        canTransferRole: false,
+        roles: [],
       }));
 
     });

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -690,14 +690,7 @@ describe('Token Service', () => {
     });
 
     it("should return undefined because test simulates that roles are not defined for token", async () => {
-      const identifier: string = token.identifier;
-
-      jest
-        .spyOn(TokenService.prototype, 'getToken')
-        // eslint-disable-next-line require-await
-        .mockImplementation(jest.fn(async (_identifier: string) => undefined));
-
-      const results = await tokenService.getTokenRoles(identifier);
+      const results = await tokenService.getTokenRoles('UNKNOWN');
       expect(results).toBeUndefined();
     });
   });

--- a/src/test/integration/tokens.e2e-spec.ts
+++ b/src/test/integration/tokens.e2e-spec.ts
@@ -661,13 +661,13 @@ describe('Token Service', () => {
           address: "erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8",
           canMint: true,
           canBurn: true,
-          roles: [],
+          roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'],
         },
         {
           address: 'erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy',
           canMint: true,
-          canBurn: true,
-          roles: [],
+          canBurn: false,
+          roles: ['ESDTRoleLocalBurn'],
         },
         ]));
 
@@ -676,20 +676,14 @@ describe('Token Service', () => {
       expect(results).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            canCreate: true,
+            canMint: true,
             canBurn: true,
-            canAddQuantity: false,
-            canUpdateAttributes: false,
-            canAddUri: false,
-            canTransferRole: false,
+            roles: ['ESDTRoleLocalMint', 'ESDTRoleLocalBurn'],
           }),
           expect.objectContaining({
-            canCreate: true,
-            canBurn: true,
-            canAddQuantity: false,
-            canUpdateAttributes: false,
-            canAddUri: false,
-            canTransferRole: false,
+            canMint: true,
+            canBurn: false,
+            roles: ['ESDTRoleLocalBurn'],
           }),
         ])
       );

--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -3,6 +3,7 @@ import * as crypto from 'crypto-js';
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
+import { TokenRoles } from "src/endpoints/tokens/entities/token.roles";
 
 export class TokenUtils {
   static isEsdt(tokenIdentifier: string) {
@@ -46,7 +47,22 @@ export class TokenUtils {
     return true;
   }
 
+  static setTokenRole(tokenRoles: TokenRoles, role: string) {
+    tokenRoles.roles.push(role);
+
+    switch (role) {
+      case 'ESDTRoleLocalMint':
+        tokenRoles.canMint = true;
+        break;
+      case 'ESDTRoleLocalBurn':
+        tokenRoles.canBurn = true;
+        break;
+    }
+  }
+
   static setCollectionRole(tokenRoles: CollectionRoles, role: string) {
+    tokenRoles.roles.push(role);
+
     switch (role) {
       case 'ESDTRoleNFTCreate':
         tokenRoles.canCreate = true;
@@ -65,8 +81,6 @@ export class TokenUtils {
         break;
       case 'ESDTRoleNFTUpdateAttributes':
         tokenRoles.canAddQuantity = true;
-        break;
-      default:
         break;
     }
   }

--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -2,7 +2,7 @@ import { ApiUtils } from "./api.utils";
 import * as crypto from 'crypto-js';
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
-import { CollectionRoles } from "src/endpoints/tokens/entities/collection.role";
+import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 
 export class TokenUtils {
   static isEsdt(tokenIdentifier: string) {


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Fix token roles to use the correct boolean attributes `canMint` & `canBurn`
- Added string array of roles for collection & token, to maintain backwards compatibility

## How to test (mainnet)
- `/collections/PASS-3df7bf` should contain roles attribute exposing roles both as boolean and also as string array
- `/tokens/WEGLD-bd4d79` should contain roles attribute exposing roles both as boolean and also as string array
- `/tokens/WEGLD-bd4d79/roles` should return roles both as boolean and also as string array