### PR TITLE
Nft by identifier branding

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -240,6 +240,10 @@ export class CollectionService {
 
     const [collection] = await this.applyPropertiesToCollections([identifier]);
 
+    if (!collection) {
+      return undefined;
+    }
+
     collection.timestamp = elasticCollection.timestamp;
     collection.roles = await this.getNftCollectionRoles(elasticCollection);
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -239,7 +239,8 @@ export class NftService {
   }
 
   async applyAssetsAndTicker(token: Nft) {
-    token.assets = await this.tokenAssetService.getAssets(token.collection);
+    token.assets = await this.tokenAssetService.getAssets(token.identifier) ??
+      await this.tokenAssetService.getAssets(token.collection);
 
     if (token.assets) {
       token.ticker = token.collection.split('-')[0];


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Allow branding for individual NFTs. This will be used for branding price discovery tokens, which have predictable nonces

## How to test (devnet)
- `/nfts/LKMEX-3b7d9a-01` should return in description field `Locked MEX. Equal in value to MEX. Not tradeable. Testing asset of a specific NFT`