### PR TITLE
Sort nfts by timestamp, then by nonce

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -110,7 +110,10 @@ export class EsdtAddressService {
       .withPagination(pagination);
 
     if (this.apiConfigService.getIsIndexerV3FlagActive()) {
-      elasticQuery = elasticQuery.withSort([{ name: "timestamp", order: ElasticSortOrder.descending }]);
+      elasticQuery = elasticQuery.withSort([
+        { name: 'timestamp', order: ElasticSortOrder.descending },
+        { name: 'tokenNonce', order: ElasticSortOrder.descending },
+      ]);
     }
 
     const esdts = await this.elasticService.getList('accountsesdt', 'identifier', elasticQuery);

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -311,7 +311,10 @@ export class NftService {
     const elasticQuery = this.buildElasticNftFilter(filter, identifier);
     elasticQuery
       .withPagination({ from, size })
-      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+      .withSort([
+        { name: 'timestamp', order: ElasticSortOrder.descending },
+        { name: 'nonce', order: ElasticSortOrder.descending },
+      ]);
 
     const elasticNfts = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
 


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- NFTs minted in the same block appear random instead of ordered
  
## Proposed Changes
- both in global nfts and account nfts, sort by nonce as a secondary criteria

## How to test (testnet)
- `/nfts?collection=PIGGYMAX-f0432f` should return nonces in descending order
- `/accounts/erd1qqqqqqqqqqqqqpgq2j35zktgvhazpvzrr9m8649gnqz53uydu00sflu9rz/nfts?collection=PIGGYMAX-f0432f` should return nonces in descending order