### PR TITLE
Account nft sorting fix

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -48,6 +48,7 @@ urls:
   socket: 'devnet-socket-fra.elrond.com'
 database:
   enabled: false
+  url: 'mongodb://127.0.0.1:27017/api?authSource=admin'
   type: 'mysql'
   host: 'localhost'
   port: 3306

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -51,6 +51,7 @@ urls:
   socket: 'socket-fra.elrond.com'
 database:
   enabled: false
+  url: 'mongodb://127.0.0.1:27017/api?authSource=admin'
   type: 'mysql'
   host: 'localhost'
   port: 3306

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -48,6 +48,7 @@ urls:
   socket: 'testnet-socket-fra.elrond.com'
 database:
   enabled: false
+  url: 'mongodb://127.0.0.1:27017/api?authSource=admin'
   type: 'mysql'
   host: 'localhost'
   port: 3306

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -178,9 +178,14 @@ export class EsdtAddressService {
       throw new BadRequestException('canCreate / canBurn / canAddQuantity / canUpdateAttributes / canAddUri / canTransferRole filter not supported when fetching account collections from elastic');
     }
 
-    const elasticQuery = this.collectionService.buildCollectionFilter(filter, address)
-      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }])
+    let elasticQuery = this.collectionService.buildCollectionFilter(filter, address)
       .withPagination(pagination);
+
+    if (this.apiConfigService.getIsIndexerV3FlagActive()) {
+      elasticQuery = elasticQuery.withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
+    } else {
+      elasticQuery = elasticQuery.withSort([{ name: 'identifier', order: ElasticSortOrder.ascending }]);
+    }
 
     const tokenCollections = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
     const collectionsIdentifiers = tokenCollections.map((collection) => collection.token);

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -114,6 +114,8 @@ export class EsdtAddressService {
         { name: 'timestamp', order: ElasticSortOrder.descending },
         { name: 'tokenNonce', order: ElasticSortOrder.descending },
       ]);
+    } else {
+      elasticQuery = elasticQuery.withSort([{ name: '_id', order: ElasticSortOrder.ascending }]);
     }
 
     const esdts = await this.elasticService.getList('accountsesdt', 'identifier', elasticQuery);
@@ -178,14 +180,9 @@ export class EsdtAddressService {
       throw new BadRequestException('canCreate / canBurn / canAddQuantity / canUpdateAttributes / canAddUri / canTransferRole filter not supported when fetching account collections from elastic');
     }
 
-    let elasticQuery = this.collectionService.buildCollectionFilter(filter, address)
+    const elasticQuery = this.collectionService.buildCollectionFilter(filter, address)
+      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }])
       .withPagination(pagination);
-
-    if (this.apiConfigService.getIsIndexerV3FlagActive()) {
-      elasticQuery = elasticQuery.withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
-    } else {
-      elasticQuery = elasticQuery.withSort([{ name: 'identifier', order: ElasticSortOrder.ascending }]);
-    }
 
     const tokenCollections = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
     const collectionsIdentifiers = tokenCollections.map((collection) => collection.token);

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,7 +6,6 @@ import { join } from 'path';
 import { LoggingInterceptor } from './interceptors/logging.interceptor';
 import { ApiConfigService } from './common/api-config/api.config.service';
 import { CachingService } from './common/caching/caching.service';
-import { TokenAssetService } from './endpoints/tokens/token.asset.service';
 import { CachingInterceptor } from './interceptors/caching.interceptor';
 import { FieldsInterceptor } from './interceptors/fields.interceptor';
 import { PrivateAppModule } from './private.app.module';
@@ -53,7 +52,6 @@ async function bootstrap() {
   const cachingService = publicApp.get<CachingService>(CachingService);
   const httpAdapterHostService = publicApp.get<HttpAdapterHost>(HttpAdapterHost);
   const metricsService = publicApp.get<MetricsService>(MetricsService);
-  const tokenAssetService = publicApp.get<TokenAssetService>(TokenAssetService);
   const protocolService = publicApp.get<ProtocolService>(ProtocolService);
   const pluginService = publicApp.get<PluginService>(PluginService);
 
@@ -64,8 +62,6 @@ async function bootstrap() {
   const httpServer = httpAdapterHostService.httpAdapter.getHttpServer();
   httpServer.keepAliveTimeout = apiConfigService.getServerTimeout();
   httpServer.headersTimeout = apiConfigService.getHeadersTimeout(); //`keepAliveTimeout + server's expected response time`
-
-  await tokenAssetService.checkout();
 
   const globalInterceptors: NestInterceptor[] = [];
   globalInterceptors.push(new LoggingInterceptor(metricsService));


### PR DESCRIPTION
## Type
- [x] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- When targeting non-update ES, account nfts are returned in no particular order, thus causing pagination issues
- Is it a bug or or is it a feature? Who knows...
  
## Proposed Changes
- When indexer v3 is not activated, sort by accountesdt `_id`

## How to test (mainnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqd9rvv2n378e27jcts8vfwynpx0gfl5ufz6hqhfy0u0/nfts` should always be returned in the same order