### PR TITLE
/c endpoint for account contracts

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -845,6 +845,12 @@ export class AccountController {
     return this.accountService.getAccountContractsCount(address);
   }
 
+  @Get("/accounts/:address/contracts/c")
+  @ApiExcludeEndpoint()
+  getAccountContractsCountAlternative(@Param('address', ParseAddressPipe) address: string): Promise<number> {
+    return this.accountService.getAccountContractsCount(address);
+  }
+
   @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @Get("/accounts/:address/sc-results")


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Provide Account contracts count alternative endpoint

## How to test (mainnet)
- `/accounts/erd1ss6u80ruas2phpmr82r42xnkd6rxy40g9jl69frppl4qez9w2jpsqj8x97/contracts/c` should return `29`