### PR TITLE
Sort ESDTs by market cap

### DIFF
--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -223,7 +223,7 @@ export class CacheInfo {
   static EsdtSupply(identifier: string): CacheInfo {
     return {
       key: `esdtSupply:${identifier}`,
-      ttl: Constants.oneDay(),
+      ttl: Constants.oneHour(),
     };
   }
 

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -219,4 +219,18 @@ export class CacheInfo {
       ttl: Constants.oneMinute() * 10,
     };
   }
+
+  static EsdtSupply(identifier: string): CacheInfo {
+    return {
+      key: `esdtSupply:${identifier}`,
+      ttl: Constants.oneDay(),
+    };
+  }
+
+  static EsdtPrice(identifier: string): CacheInfo {
+    return {
+      key: `esdtPrice:${identifier}`,
+      ttl: Constants.oneSecond() * 6,
+    };
+  }
 }

--- a/src/common/external/data.api.service.ts
+++ b/src/common/external/data.api.service.ts
@@ -47,4 +47,20 @@ export class DataApiService {
       return undefined;
     }
   }
+
+  async getEsdtPriceLatest(identifier: string): Promise<number | undefined> {
+    if (!this.dataUrl) {
+      return undefined;
+    }
+
+    try {
+      const { data } = await this.apiService.get(`${this.dataUrl}/latest/quotes/${identifier}/${DataQuoteType.price}`);
+
+      return data;
+    } catch (error) {
+      this.logger.error(`An unhandled error occurred when fetching price for esdt '${identifier}'`);
+      this.logger.error(error);
+      return undefined;
+    }
+  }
 }

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -98,6 +98,9 @@ export class CacheWarmerService {
         if (asset.lockedAccounts) {
           const lockedSupply = await this.esdtService.getLockedSupplyRaw(identifier);
           await this.invalidateKey(CacheInfo.TokenLockedSupply(identifier).key, lockedSupply, CacheInfo.TokenLockedSupply(identifier).ttl);
+
+          const esdtSupply = await this.esdtService.getTokenSupplyRaw(identifier);
+          await this.invalidateKey(CacheInfo.EsdtSupply(identifier).key, esdtSupply, CacheInfo.EsdtSupply(identifier).ttl);
         }
       }
     }, true);

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -281,7 +281,7 @@ export class EsdtService {
     return esdtLockedAccounts.sumBigInt(x => x.balance).toString();
   }
 
-  async getTokenSupply(identifier: string): Promise<EsdtSupply> {
+  private async getTokenSupplyRaw(identifier: string): Promise<EsdtSupply> {
     const { supply, minted, burned, initialMinted } = await this.gatewayService.get(`network/esdt/supply/${identifier}`, GatewayComponentRequest.esdtSupply);
 
     const isCollectionOrToken = identifier.split('-').length === 2;
@@ -309,5 +309,17 @@ export class EsdtService {
       burned,
       initialMinted,
     };
+  }
+
+  async getTokenSupply(identifier: string): Promise<EsdtSupply> {
+    return await this.cachingService.getOrSetCache(
+      CacheInfo.EsdtSupply(identifier).key,
+      async () => await this.getTokenSupplyRaw(identifier),
+      CacheInfo.EsdtSupply(identifier).ttl
+    );
+  }
+
+  private async getTokenPriceRaw(identifier: string): Promise<number> {
+
   }
 }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -283,7 +283,7 @@ export class EsdtService {
     return esdtLockedAccounts.sumBigInt(x => x.balance).toString();
   }
 
-  private async getTokenSupplyRaw(identifier: string): Promise<EsdtSupply> {
+  async getTokenSupplyRaw(identifier: string): Promise<EsdtSupply> {
     const { supply, minted, burned, initialMinted } = await this.gatewayService.get(`network/esdt/supply/${identifier}`, GatewayComponentRequest.esdtSupply);
 
     const isCollectionOrToken = identifier.split('-').length === 2;

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -5,8 +5,8 @@ import { ElasticQuery } from "src/common/elastic/entities/elastic.query";
 import { QueryConditionOptions } from "src/common/elastic/entities/query.condition.options";
 import { QueryOperator } from "src/common/elastic/entities/query.operator";
 import { QueryType } from "src/common/elastic/entities/query.type";
+import { DataApiService } from "src/common/external/data.api.service";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
-import { ApiService } from "src/common/network/api.service";
 import { TokenProperties } from "src/endpoints/tokens/entities/token.properties";
 import { VmQueryService } from "src/endpoints/vm.query/vm.query.service";
 import { AddressUtils } from "src/utils/address.utils";
@@ -35,7 +35,7 @@ export class EsdtService {
     private readonly elasticService: ElasticService,
     @Inject(forwardRef(() => TokenAssetService))
     private readonly tokenAssetService: TokenAssetService,
-    private readonly apiService: ApiService,
+    private readonly dataApiService: DataApiService,
   ) {
     this.logger = new Logger(EsdtService.name);
   }
@@ -322,18 +322,9 @@ export class EsdtService {
   }
 
   private async getTokenPriceRaw(identifier: string): Promise<number> {
-    const priceFeedUrl = this.apiConfigService.getDataUrl();
+    const tokenPrice = await this.dataApiService.getEsdtPriceLatest(identifier);
 
-    try {
-      const tokenPrice = await this.apiService.get(`${priceFeedUrl}/latest/quotes/${identifier}/price`);
-
-      return tokenPrice;
-    } catch (error) {
-      this.logger.log(`Unexpected error when trying to get price for esdt '${identifier}'`);
-      this.logger.error(error);
-
-      return 0; //assuming that token does not have any price set
-    }
+    return tokenPrice ?? 0;
   }
 
   async getTokenPrice(identifier: string): Promise<number> {

--- a/src/endpoints/tokens/entities/token.detailed.ts
+++ b/src/endpoints/tokens/entities/token.detailed.ts
@@ -25,11 +25,5 @@ export class TokenDetailed extends Token {
   canWipe: boolean = false;
 
   @ApiProperty()
-  supply: string | undefined = undefined;
-
-  @ApiProperty()
-  circulatingSupply: string | undefined = undefined;
-
-  @ApiProperty()
   roles: TokenRoles[] | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.ts
+++ b/src/endpoints/tokens/entities/token.ts
@@ -37,4 +37,16 @@ export class Token {
 
   @ApiProperty()
   accounts: number | undefined = undefined;
+
+  @ApiProperty()
+  supply: string | undefined = undefined;
+
+  @ApiProperty()
+  circulatingSupply: string | undefined = undefined;
+
+  @ApiProperty()
+  price: number | undefined = undefined;
+
+  @ApiProperty()
+  marketCap: number | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -58,6 +58,10 @@ export class TokenService {
 
     await this.applySupply(token);
 
+    token.price = await this.esdtService.getTokenPrice(token.identifier);
+
+    token.marketCap = token.price ? Number(token.supply) * token.price : 0;
+
     await this.processToken(token);
 
     token.roles = await this.getTokenRoles(identifier);
@@ -70,18 +74,22 @@ export class TokenService {
 
     let tokens = await this.getFilteredTokens(filter);
 
-    tokens = tokens.slice(from, from + size);
-
     for (const token of tokens) {
       this.applyTickerFromAssets(token);
 
       if (token.assets) {
-        // breanded token
+        // branded token
         await this.applySupply(token);
+
+        token.price = await this.esdtService.getTokenPrice(token.identifier);
 
         token.marketCap = token.price ? Number(token.supply) * token.price : 0;
       }
     }
+
+    tokens = tokens.sortedDescending(token => token.marketCap ?? 0);
+
+    tokens = tokens.slice(from, from + size);
 
     await this.batchProcessTokens(tokens);
 

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -74,6 +74,13 @@ export class TokenService {
 
     for (const token of tokens) {
       this.applyTickerFromAssets(token);
+
+      if (token.assets) {
+        // breanded token
+        await this.applySupply(token);
+
+        token.marketCap = token.price ? Number(token.supply) * token.price : 0;
+      }
     }
 
     await this.batchProcessTokens(tokens);


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- No informations about ESDTs market cap on elrond explorer
  
## Proposed Changes
- Get ESDT price & total supply
- Compute market cap
- If an esdt don't have any price set, assume that market cap is 0

## How to test (mainnet)
- Establish connection to price feed url (data)
- Check esdt supply, price & market cap 