### PR TITLE
deprecate mex/:address route

### DIFF
--- a/src/endpoints/mex/mex.controller.ts
+++ b/src/endpoints/mex/mex.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, HttpException, HttpStatus, Param } from "@nestjs/common";
-import { ApiResponse, ApiTags } from "@nestjs/swagger";
+import { ApiOperation, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { ParseAddressPipe } from "src/utils/pipes/parse.address.pipe";
 import { MexWeek } from "./entities/mex.week";
 import { MexService } from "./mex.service";
@@ -10,6 +10,7 @@ export class MexController {
   constructor(private readonly mexService: MexService) { }
 
   @Get('/mex/:address')
+  @ApiOperation({ deprecated: true })
   @ApiResponse({
     status: 200,
     description: 'Mex details for address',


### PR DESCRIPTION
## Type
- [ ] Bug
- [ ] Feature  
- [x] Refactoring
- [ ] Performance improvement

## Problem setting
-  mex/:address route is no longer available
  
## Proposed Changes
- Deprecate /mex/:address route
