### PR TITLE
process events in parallel

### DIFF
--- a/src/common/rabbitmq/rabbitmq.nft.consumer.ts
+++ b/src/common/rabbitmq/rabbitmq.nft.consumer.ts
@@ -4,7 +4,6 @@ import { NftCreateEvent } from './entities/nft/nft-create.event';
 import { NftEventEnum } from './entities/nft/nft-events.enum';
 import { RabbitMqNftHandlerService } from './rabbitmq.nft.handler.service';
 import configuration from 'config/configuration';
-import { PerformanceProfiler } from 'src/utils/performance.profiler';
 
 @Injectable()
 export class RabbitMqNftConsumer {
@@ -24,11 +23,7 @@ export class RabbitMqNftConsumer {
     try {
       const events = rawEvents?.events;
 
-      const profiler = new PerformanceProfiler();
-
       await Promise.all(events.map((event: any) => this.handleEvent(event)));
-
-      profiler.stop(`Consuming events for block with hash '${rawEvents.hash}'`, true);
     } catch (error) {
       this.logger.error(`An unhandled error occurred when consuming events: ${JSON.stringify(rawEvents)}`);
       this.logger.error(error);

--- a/src/test/integration/controllers/accounts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/accounts.controller.e2e-spec.ts
@@ -224,7 +224,7 @@ describe("Accounts Controller", () => {
   });
 
   it("/accounts/:address/tokens/:tokens - should return 404 status code with no token found", async () => {
-    const address: string = "erd12xspx5z0nm08tvtt8v3nyu3w8mxfr36rj27u99yesmr7uxj6h7cscsvsw5";
+    const address: string = "erd1qqqqqqqqqqqqqpgqhe8t5jewej70zupmh44jurgn29psua5l2jps3ntjj3";
     const token: string = "RIDE-7d18e9";
     await request(app.getHttpServer())
       .get(route + "/" + address + "/tokens" + "/" + token)


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Because events are processed in a serialized way, many NFT Creates can cause ack timeout (30 min)
  
## Proposed Changes
- process all events in parallel

## How to test
- Pretty difficult to test locally
- Block with hash `1b3cdc19710ded3f7a72b2c90498a6fe798f3472bd2c95ff0f45ef9dc3be3787` was processed with the parallel fix on mainnet in 8s instead of at least 2100s (350 NFTs * 5 seconds wait time)