### PR TITLE
undefined check when fetching token supply minted / burned / initialM…

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -22,7 +22,7 @@ flags:
   indexer-v3: false
 features:
   eventsNotifier:
-    enabled: true
+    enabled: false
     port: 5674
     url: 'amqp://guest:guest@127.0.0.1:5672'
     exchange: 'all_events'

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -23,7 +23,7 @@ flags:
   indexer-v3: false
 features:
   eventsNotifier:
-    enabled: true
+    enabled: false
     port: 5674
     url: 'amqp://guest:guest@127.0.0.1:5672'
     exchange: 'all_events'

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -22,7 +22,7 @@ flags:
   indexer-v3: true
 features:
   eventsNotifier:
-    enabled: true
+    enabled: false
     port: 5674
     url: 'amqp://guest:guest@127.0.0.1:5672'
     exchange: 'all_events'

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -464,9 +464,9 @@ export class TokenService {
     return {
       supply: denominated === true ? totalSupply : totalSupply.toFixed(),
       circulatingSupply: denominated === true ? circulatingSupply : circulatingSupply.toFixed(),
-      minted: denominated === true ? NumberUtils.denominateString(result.minted, properties.decimals) : result.minted,
-      burnt: denominated === true ? NumberUtils.denominateString(result.burned, properties.decimals) : result.burned,
-      initialMinted: denominated === true ? NumberUtils.denominateString(result.initialMinted, properties.decimals) : result.initialMinted,
+      minted: denominated === true && result.minted ? NumberUtils.denominateString(result.minted, properties.decimals) : result.minted,
+      burnt: denominated === true && result.burned ? NumberUtils.denominateString(result.burned, properties.decimals) : result.burned,
+      initialMinted: denominated === true && result.initialMinted ? NumberUtils.denominateString(result.initialMinted, properties.decimals) : result.initialMinted,
     };
   }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- take into account that `minted`, `burned`, `initialMinted` can be undefined in gateway response for supply

## How to test (mainnet)
- `/tokens/WEGLD-bd4d79/supply` should not crash when connected to gateway.elrond.com