### PR TITLE
NFT metadata fix

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -355,10 +355,6 @@ export class NftService {
         } else {
           nft.isWhitelistedStorage = nft.url.startsWith(this.NFT_THUMBNAIL_PREFIX);
         }
-
-        if (elasticNftData.metadata) {
-          nft.attributes = BinaryUtils.base64Encode(`metadata:${elasticNftData.metadata}`);
-        }
       }
 
       nfts.push(nft);


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- do not reprocess attributes for metadata

## How to test
- `/nfts/OSHIRO-cb3446-4a` attributes should return `dGFnczpKYXBhbixFbHJvbmQsS2l0c3VuZSxZb2thaTttZXRhZGF0YTpRbVRUVVl3VnhmZ0JRaUJLYjlOdHJQamJrNktzamZFU29WN1p5ZmpTNUNNWHJOLzQwMC5qc29u`