### PR TITLE
Nft thumbnail resolver

### DIFF
--- a/src/endpoints/endpoints.services.module.ts
+++ b/src/endpoints/endpoints.services.module.ts
@@ -1,4 +1,5 @@
 import { Module } from "@nestjs/common";
+import { NftMediaModule } from "src/queue.worker/nft.worker/queue/job-services/media/nft.media.module";
 import { AccountModule } from "./accounts/account.module";
 import { BlockModule } from "./blocks/block.module";
 import { BlsModule } from "./bls/bls.module";
@@ -42,6 +43,7 @@ import { WebsocketModule } from "./websocket/websocket.module";
     MiniBlockModule,
     NetworkModule,
     NftModule,
+    NftMediaModule,
     TagModule,
     NodeModule,
     ProviderModule,
@@ -64,7 +66,7 @@ import { WebsocketModule } from "./websocket/websocket.module";
   ],
   exports: [
     AccountModule, CollectionModule, BlockModule, DelegationModule, DelegationLegacyModule, IdentitiesModule, KeysModule,
-    MexModule, MiniBlockModule, NetworkModule, NftModule, TagModule, NodeModule, ProviderModule,
+    MexModule, MiniBlockModule, NetworkModule, NftModule, NftMediaModule, TagModule, NodeModule, ProviderModule,
     RoundModule, SmartContractResultModule, ShardModule, StakeModule, TokenModule, RoundModule, TransactionModule, UsernameModule, VmQueryModule,
     WaitingListModule, EsdtModule, BlsModule, DappConfigModule, TransferModule, TransactionActionModule, WebsocketModule,
   ],

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -1,4 +1,4 @@
-import { BadRequestException, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, ParseIntPipe, Query } from "@nestjs/common";
+import { BadRequestException, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, ParseIntPipe, Query, Res, Response } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { ParseAddressPipe } from "src/utils/pipes/parse.address.pipe";
 import { ParseArrayPipe } from "src/utils/pipes/parse.array.pipe";
@@ -119,6 +119,31 @@ export class NftController {
     }
 
     return token;
+  }
+
+  @Get('/nfts/:identifier/thumbnail')
+  @ApiResponse({
+    status: 200,
+    description: 'Non-fungible / semi-fungible token details',
+    type: Nft,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Token not found',
+  })
+  async resolveNftThumbnail(@Param('identifier') identifier: string, @Res() response: Response) {
+    const token = await this.nftService.getSingleNft(identifier);
+    if (token === undefined) {
+      throw new NotFoundException('NFT not found');
+    }
+
+    const media = token.media;
+    if (!media) {
+      throw new NotFoundException('NFT does not have any media attached to it');
+    }
+
+    // @ts-ignore
+    response.redirect(media[0].thumbnailUrl);
   }
 
   @Get('/nfts/:identifier/supply')

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -35,7 +35,7 @@ import { PersistenceService } from "src/common/persistence/persistence.service";
 export class NftService {
   private readonly logger: Logger;
   private readonly NFT_THUMBNAIL_PREFIX: string;
-  private readonly DEFAULT_MEDIA: NftMedia[];
+  readonly DEFAULT_MEDIA: NftMedia[];
 
   constructor(
     private readonly apiConfigService: ApiConfigService,
@@ -273,7 +273,7 @@ export class NftService {
   }
 
   private async applyMedia(nft: Nft) {
-    nft.media = await this.nftMediaService.getMedia(nft) ?? undefined;
+    nft.media = await this.nftMediaService.getMedia(nft.identifier) ?? undefined;
   }
 
   private async applyMetadata(nft: Nft) {

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -23,7 +23,7 @@ export class NftWorkerService {
 
   async addProcessNftQueueJob(nft: Nft, settings: ProcessNftSettings): Promise<boolean> {
     nft.metadata = await this.nftMetadataService.getMetadata(nft) ?? undefined;
-    nft.media = await this.nftMediaService.getMedia(nft) ?? undefined;
+    nft.media = await this.nftMediaService.getMedia(nft.identifier) ?? undefined;
 
     const needsProcessing = await this.needsProcessing(nft, settings);
     if (!needsProcessing) {

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -28,11 +28,11 @@ export class NftMediaService {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
   }
 
-  async getMedia(nft: Nft): Promise<NftMedia[] | null> {
+  async getMedia(identifier: string): Promise<NftMedia[] | null> {
     return await this.cachingService.getOrSetCache(
-      CacheInfo.NftMedia(nft.identifier).key,
-      async () => await this.persistenceService.getMedia(nft.identifier),
-      CacheInfo.NftMedia(nft.identifier).ttl,
+      CacheInfo.NftMedia(identifier).key,
+      async () => await this.persistenceService.getMedia(identifier),
+      CacheInfo.NftMedia(identifier).ttl,
     );
   }
 

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -81,7 +81,7 @@ export class NftQueueController {
         nft.metadata = await this.refreshMetadata(nft);
       }
 
-      nft.media = await this.nftMediaService.getMedia(nft) ?? undefined;
+      nft.media = await this.nftMediaService.getMedia(nft.identifier) ?? undefined;
 
       if (settings.forceRefreshMedia || !nft.media) {
         nft.media = await this.nftMediaService.refreshMedia(nft);

--- a/src/test/integration/nft.media.e2e-spec.ts
+++ b/src/test/integration/nft.media.e2e-spec.ts
@@ -31,9 +31,7 @@ describe('Nft Media Service', () => {
 
   describe('Get Media', () => {
     it('should return null', async () => {
-      const nftFilter = new Nft();
-      nftFilter.identifier = nftIdentifier;
-      const nftGetMedia = await nftMediaService.getMedia(nftFilter);
+      const nftGetMedia = await nftMediaService.getMedia(nftIdentifier);
       expect(nftGetMedia).toBeNull();
     });
   });


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- NFT Thumbnail resolve endpoint

## How to test (mainnet)
- `/nfts/W3C-bcc335-076e/thumbnail` should redirect to `https://media.elrond.com/nfts/thumbnail/W3C-bcc335-325a9501 `