### PR TITLE
Token multiple assets

### DIFF
--- a/src/common/caching/caching.service.ts
+++ b/src/common/caching/caching.service.ts
@@ -19,6 +19,8 @@ export class CachingService {
   private asyncExpire = promisify(this.client.expire).bind(this.client);
   private asyncFlushDb = promisify(this.client.flushdb).bind(this.client);
   private asyncMGet = promisify(this.client.mget).bind(this.client);
+  private asyncSAdd = promisify(this.client.sadd).bind(this.client);
+  private asyncSCard = promisify(this.client.scard).bind(this.client);
   private asyncMulti = (commands: any[]) => {
     const multi = this.client.multi(commands);
     return promisify(multi.exec).call(multi);
@@ -284,6 +286,28 @@ export class CachingService {
     } finally {
       profiler.stop();
       this.metricsService.setRedisDuration('MDEL', profiler.duration);
+    }
+  }
+
+  async setAdd(key: string, ...values: string[]): Promise<void> {
+    const profiler = new PerformanceProfiler();
+
+    try {
+      await this.asyncSAdd(key, ...values);
+    } finally {
+      profiler.stop();
+      this.metricsService.setRedisDuration('SADD', profiler.duration);
+    }
+  }
+
+  async setCount(key: string): Promise<number> {
+    const profiler = new PerformanceProfiler();
+
+    try {
+      return await this.asyncSCard(key);
+    } finally {
+      profiler.stop();
+      this.metricsService.setRedisDuration('SCARD', profiler.duration);
     }
   }
 

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -187,7 +187,7 @@ export class CacheInfo {
 
   static TokenTransactions(identifier: string): CacheInfo {
     return {
-      key: `tokenTransactions:${identifier}`,
+      key: `tokenTransactions:v2:${identifier}`,
       ttl: Constants.oneMinute() * 10,
     };
   }

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -194,7 +194,7 @@ export class CacheInfo {
 
   static TokenAccounts(identifier: string): CacheInfo {
     return {
-      key: `tokenAccounts:${identifier}`,
+      key: `tokenAccounts:v2:${identifier}`,
       ttl: Constants.oneMinute() * 10,
     };
   }

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -187,14 +187,14 @@ export class CacheInfo {
 
   static TokenTransactions(identifier: string): CacheInfo {
     return {
-      key: `tokenTransactions:v2:${identifier}`,
+      key: `tokenTransactions:${identifier}`,
       ttl: Constants.oneMinute() * 10,
     };
   }
 
   static TokenAccounts(identifier: string): CacheInfo {
     return {
-      key: `tokenAccounts:v2:${identifier}`,
+      key: `tokenAccounts:${identifier}`,
       ttl: Constants.oneMinute() * 10,
     };
   }

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -178,9 +178,9 @@ export class CacheInfo {
     };
   }
 
-  static TokenLockedSupply(identifier: string): CacheInfo {
+  static TokenLockedAccounts(identifier: string): CacheInfo {
     return {
-      key: `tokenLockedSupply:${identifier}`,
+      key: `tokenLockedAccounts:${identifier}`,
       ttl: Constants.oneHour(),
     };
   }
@@ -195,6 +195,13 @@ export class CacheInfo {
   static TokenAccounts(identifier: string): CacheInfo {
     return {
       key: `tokenAccounts:${identifier}`,
+      ttl: Constants.oneHour(),
+    };
+  }
+
+  static TokenAccountsExtra(identifier: string): CacheInfo {
+    return {
+      key: `tokenAccountsExtra:${identifier}`,
       ttl: Constants.oneHour(),
     };
   }

--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -188,14 +188,14 @@ export class CacheInfo {
   static TokenTransactions(identifier: string): CacheInfo {
     return {
       key: `tokenTransactions:${identifier}`,
-      ttl: Constants.oneHour(),
+      ttl: Constants.oneMinute() * 10,
     };
   }
 
   static TokenAccounts(identifier: string): CacheInfo {
     return {
       key: `tokenAccounts:${identifier}`,
-      ttl: Constants.oneHour(),
+      ttl: Constants.oneMinute() * 10,
     };
   }
 

--- a/src/endpoints/esdt/entities/esdt.locked.account.ts
+++ b/src/endpoints/esdt/entities/esdt.locked.account.ts
@@ -1,0 +1,12 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class EsdtLockedAccount {
+  @ApiProperty()
+  address: string = '';
+
+  @ApiProperty()
+  name: string = '';
+
+  @ApiProperty()
+  balance: string = '';
+}

--- a/src/endpoints/esdt/entities/esdt.supply.ts
+++ b/src/endpoints/esdt/entities/esdt.supply.ts
@@ -1,7 +1,10 @@
+import { EsdtLockedAccount } from "./esdt.locked.account";
+
 export class EsdtSupply {
   totalSupply: string = '0';
   circulatingSupply: string = '0';
   minted: string = '0';
   burned: string = '0';
   initialMinted: string = '0';
+  lockedAccounts: EsdtLockedAccount[] | undefined = undefined;
 }

--- a/src/endpoints/esdt/esdt.module.ts
+++ b/src/endpoints/esdt/esdt.module.ts
@@ -5,6 +5,7 @@ import { TokenModule } from "../tokens/token.module";
 import { EsdtAddressService } from "./esdt.address.service";
 import { NftModule } from "../nfts/nft.module";
 import { CollectionModule } from "../collections/collection.module";
+import { TransactionModule } from "../transactions/transaction.module";
 
 
 @Module({
@@ -13,6 +14,7 @@ import { CollectionModule } from "../collections/collection.module";
     forwardRef(() => CollectionModule),
     forwardRef(() => TokenModule),
     VmQueryModule,
+    forwardRef(() => TransactionModule),
   ],
   providers: [
     EsdtService, EsdtAddressService,

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -370,8 +370,9 @@ export class EsdtService {
 
       await this.elasticService.getScrollableList('accountsesdt', 'id', query, async items => {
         const distinctAccounts: string[] = items.map(x => x.address).distinct();
-
-        await this.cachingService.setAdd(key, ...distinctAccounts);
+        if (distinctAccounts.length > 0) {
+          await this.cachingService.setAdd(key, ...distinctAccounts);
+        }
       });
     }
 

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -331,14 +331,14 @@ export class EsdtService {
 
     const isCollectionOrToken = identifier.split('-').length === 2;
     if (isCollectionOrToken) {
+      let circulatingSupply = BigInt(supply);
+
       const lockedAccounts = await this.getLockedAccounts(identifier);
-      if (!lockedAccounts || lockedAccounts.length === 0) {
-        return supply;
+      if (lockedAccounts && lockedAccounts.length > 0) {
+        const totalLockedSupply = lockedAccounts.sumBigInt(x => BigInt(x.balance));
+
+        circulatingSupply = BigInt(supply) - totalLockedSupply;
       }
-
-      const totalLockedSupply = lockedAccounts.sumBigInt(x => BigInt(x.balance));
-
-      const circulatingSupply = BigInt(supply) - totalLockedSupply;
 
       return {
         totalSupply: supply,

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -20,6 +20,8 @@ import { TokenAssets } from "../tokens/entities/token.assets";
 import { TokenDetailed } from "../tokens/entities/token.detailed";
 import { TokenRoles } from "../tokens/entities/token.roles";
 import { TokenAssetService } from "../tokens/token.asset.service";
+import { TransactionService } from "../transactions/transaction.service";
+import { EsdtLockedAccount } from "./entities/esdt.locked.account";
 import { EsdtSupply } from "./entities/esdt.supply";
 
 @Injectable()
@@ -34,6 +36,8 @@ export class EsdtService {
     private readonly elasticService: ElasticService,
     @Inject(forwardRef(() => TokenAssetService))
     private readonly tokenAssetService: TokenAssetService,
+    @Inject(forwardRef(() => TransactionService))
+    private readonly transactionService: TransactionService,
   ) {
     this.logger = new Logger(EsdtService.name);
   }
@@ -81,10 +85,21 @@ export class EsdtService {
         continue;
       }
 
-      token.accounts = await this.cachingService.getOrSetCache(
-        CacheInfo.TokenAccounts(token.identifier).key,
-        async () => await this.getEsdtAccountsCount(token.identifier),
-        CacheInfo.TokenAccounts(token.identifier).ttl
+      let accounts = await this.cachingService.getCacheRemote<number>(CacheInfo.TokenAccountsExtra(token.identifier).key);
+      if (!accounts) {
+        accounts = await this.cachingService.getOrSetCache(
+          CacheInfo.TokenAccounts(token.identifier).key,
+          async () => await this.getEsdtAccountsCount(token.identifier),
+          CacheInfo.TokenAccounts(token.identifier).ttl
+        );
+      }
+
+      token.accounts = accounts;
+
+      token.transactions = await this.cachingService.getOrSetCache(
+        CacheInfo.TokenTransactions(token.identifier).key,
+        async () => await this.transactionService.getTransactionCount({ token: token.identifier }),
+        CacheInfo.TokenTransactions(token.identifier).ttl
       );
     }
 
@@ -255,28 +270,60 @@ export class EsdtService {
     return tokenAddressesAndRoles;
   }
 
-  private async getLockedSupply(identifier: string): Promise<string> {
+  private async getLockedAccounts(identifier: string): Promise<EsdtLockedAccount[]> {
     return await this.cachingService.getOrSetCache(
-      CacheInfo.TokenLockedSupply(identifier).key,
-      async () => await this.getLockedSupplyRaw(identifier),
-      CacheInfo.TokenLockedSupply(identifier).ttl,
+      CacheInfo.TokenLockedAccounts(identifier).key,
+      async () => await this.getLockedAccountsRaw(identifier),
+      CacheInfo.TokenLockedAccounts(identifier).ttl,
     );
   }
 
-  async getLockedSupplyRaw(identifier: string): Promise<string> {
+  async getLockedAccountsRaw(identifier: string): Promise<EsdtLockedAccount[]> {
     const tokenAssets = await this.tokenAssetService.getAssets(identifier);
     if (!tokenAssets) {
-      return '0';
+      return [];
     }
 
     const lockedAccounts = tokenAssets.lockedAccounts;
-    if (!lockedAccounts || lockedAccounts.length === 0) {
-      return '0';
+    if (!lockedAccounts) {
+      return [];
     }
 
-    const esdtLockedAccounts = await this.elasticService.getAccountEsdtByAddressesAndIdentifier(identifier, lockedAccounts);
+    const lockedAccountsWithDescriptions: EsdtLockedAccount[] = [];
+    if (Array.isArray(lockedAccounts)) {
+      for (const [index, lockedAccount] of lockedAccounts.entries()) {
+        lockedAccountsWithDescriptions.push({
+          address: lockedAccount,
+          name: `Locked account #${index + 1}`,
+          balance: '0',
+        });
+      }
+    } else {
+      for (const address of Object.keys(lockedAccounts)) {
+        lockedAccountsWithDescriptions.push({
+          address,
+          name: lockedAccounts[address],
+          balance: '0',
+        });
+      }
+    }
 
-    return esdtLockedAccounts.sumBigInt(x => x.balance).toString();
+    if (Object.keys(lockedAccounts).length === 0) {
+      return [];
+    }
+
+    const addresses = lockedAccountsWithDescriptions.map(x => x.address);
+
+    const esdtLockedAccounts = await this.elasticService.getAccountEsdtByAddressesAndIdentifier(identifier, addresses);
+
+    for (const esdtLockedAccount of esdtLockedAccounts) {
+      const lockedAccountWithDescription = lockedAccountsWithDescriptions.find(x => x.address === esdtLockedAccount.address);
+      if (lockedAccountWithDescription) {
+        lockedAccountWithDescription.balance = esdtLockedAccount.balance;
+      }
+    }
+
+    return lockedAccountsWithDescriptions;
   }
 
   async getTokenSupply(identifier: string): Promise<EsdtSupply> {
@@ -284,12 +331,14 @@ export class EsdtService {
 
     const isCollectionOrToken = identifier.split('-').length === 2;
     if (isCollectionOrToken) {
-      const lockedSupply = await this.getLockedSupply(identifier);
-      if (!lockedSupply) {
+      const lockedAccounts = await this.getLockedAccounts(identifier);
+      if (!lockedAccounts || lockedAccounts.length === 0) {
         return supply;
       }
 
-      const circulatingSupply = BigInt(supply) - BigInt(lockedSupply);
+      const totalLockedSupply = lockedAccounts.sumBigInt(x => BigInt(x.balance));
+
+      const circulatingSupply = BigInt(supply) - totalLockedSupply;
 
       return {
         totalSupply: supply,
@@ -297,6 +346,7 @@ export class EsdtService {
         minted,
         burned,
         initialMinted,
+        lockedAccounts,
       };
     }
 
@@ -306,6 +356,29 @@ export class EsdtService {
       minted,
       burned,
       initialMinted,
+      lockedAccounts: undefined,
     };
+  }
+
+  async countAllAccounts(identifiers: string[]): Promise<number> {
+    const key = `tokens:${identifiers[0]}:distinctAccounts`;
+
+    for (const identifier of identifiers) {
+      const query = ElasticQuery.create()
+        .withPagination({ from: 0, size: 10000 })
+        .withMustMatchCondition('token', identifier, QueryOperator.AND);
+
+      await this.elasticService.getScrollableList('accountsesdt', 'id', query, async items => {
+        const distinctAccounts: string[] = items.map(x => x.address).distinct();
+
+        await this.cachingService.setAdd(key, ...distinctAccounts);
+      });
+    }
+
+    const count = await this.cachingService.setCount(key);
+
+    await this.cachingService.deleteInCache(key);
+
+    return count;
   }
 }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -103,7 +103,7 @@ export class EsdtService {
       );
     }
 
-    tokens = tokens.sortedDescending(token => token.accounts ?? 0);
+    tokens = tokens.sortedDescending(token => token.transactions ?? 0);
 
     return tokens;
   }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -98,7 +98,7 @@ export class EsdtService {
 
       token.transactions = await this.cachingService.getOrSetCache(
         CacheInfo.TokenTransactions(token.identifier).key,
-        async () => await this.transactionService.getTransactionCount({ token: token.identifier }),
+        async () => await this.transactionService.getTransactionCount({ tokens: [token.identifier, ...token.assets?.extraTokens ?? []] }),
         CacheInfo.TokenTransactions(token.identifier).ttl
       );
     }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -177,7 +177,7 @@ export class NftService {
   private async batchApplySupply(nfts: Nft[]) {
     await this.cachingService.batchApply(
       nfts,
-      nft => CacheInfo.TokenLockedSupply(nft.identifier).key,
+      nft => CacheInfo.TokenLockedAccounts(nft.identifier).key,
       async nfts => {
         const result: Record<string, EsdtSupply> = {};
 
@@ -185,10 +185,10 @@ export class NftService {
           result[nft.identifier] = await this.esdtService.getTokenSupply(nft.identifier);
         }
 
-        return RecordUtils.mapKeys(result, identifier => CacheInfo.TokenLockedSupply(identifier).key);
+        return RecordUtils.mapKeys(result, identifier => CacheInfo.TokenLockedAccounts(identifier).key);
       },
       (nft, value) => nft.supply = value.totalSupply,
-      CacheInfo.TokenLockedSupply('').ttl,
+      CacheInfo.TokenLockedAccounts('').ttl,
     );
   }
 

--- a/src/endpoints/tokens/entities/token.assets.ts
+++ b/src/endpoints/tokens/entities/token.assets.ts
@@ -18,5 +18,8 @@ export class TokenAssets {
   svgUrl: string = '';
 
   @ApiProperty()
-  lockedAccounts: string[] | undefined = undefined;
+  lockedAccounts: string[] | Record<string, string> | undefined = undefined;
+
+  @ApiProperty()
+  extraTokens: string[] | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.assets.ts
+++ b/src/endpoints/tokens/entities/token.assets.ts
@@ -20,6 +20,6 @@ export class TokenAssets {
   @ApiProperty({ type: String, isArray: true })
   lockedAccounts: string[] | Record<string, string> | undefined = undefined;
 
-  @ApiProperty()
+  @ApiProperty({ type: String, isArray: true })
   extraTokens: string[] | undefined = undefined;
 }

--- a/src/endpoints/tokens/entities/token.filter.ts
+++ b/src/endpoints/tokens/entities/token.filter.ts
@@ -1,3 +1,6 @@
+import { SortOrder } from "src/common/entities/sort.order";
+import { TokenSort } from "./token.sort";
+
 export class TokenFilter {
   search?: string;
 
@@ -6,4 +9,8 @@ export class TokenFilter {
   identifier?: string;
 
   identifiers?: string[];
+
+  sort?: TokenSort;
+
+  order?: SortOrder;
 }

--- a/src/endpoints/tokens/entities/token.sort.ts
+++ b/src/endpoints/tokens/entities/token.sort.ts
@@ -1,0 +1,4 @@
+export enum TokenSort {
+  accounts = 'accounts',
+  transactions = 'transactions'
+}

--- a/src/endpoints/tokens/entities/token.supply.result.ts
+++ b/src/endpoints/tokens/entities/token.supply.result.ts
@@ -1,7 +1,10 @@
+import { EsdtLockedAccount } from "src/endpoints/esdt/entities/esdt.locked.account";
+
 export class TokenSupplyResult {
   supply: string | number = '';
   circulatingSupply: string | number = '';
   minted: string | number | undefined;
   burnt: string | number | undefined;
   initialMinted: string | number | undefined;
+  lockedAccounts: EsdtLockedAccount[] | undefined = undefined;
 }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -14,6 +14,7 @@ import { TokenDetailed } from "./entities/token.detailed";
 import { TokenService } from "./token.service";
 import { TokenRoles } from "./entities/token.roles";
 import { TokenSupplyResult } from "./entities/token.supply.result";
+import { TokenSort } from "./entities/token.sort";
 
 @Controller()
 @ApiTags('tokens')
@@ -36,6 +37,8 @@ export class TokenController {
   @ApiQuery({ name: 'name', description: 'Search by token name', required: false })
   @ApiQuery({ name: 'identifier', description: 'Search by token identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by multiple token identifiers, comma-separated', required: false })
+  @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false })
+  @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false })
   async getTokens(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -43,8 +46,10 @@ export class TokenController {
     @Query('name') name: string | undefined,
     @Query('identifier') identifier: string | undefined,
     @Query('identifiers', ParseArrayPipe) identifiers: string[] | undefined,
+    @Query('sort', new ParseOptionalEnumPipe(TokenSort)) sort: TokenSort | undefined,
+    @Query('order', new ParseOptionalEnumPipe(SortOrder)) order: SortOrder | undefined,
   ): Promise<TokenDetailed[]> {
-    return await this.tokenService.getTokens({ from, size }, { search, name, identifier, identifiers });
+    return await this.tokenService.getTokens({ from, size }, { search, name, identifier, identifiers, sort, order });
   }
 
   @Get("/tokens/count")

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -114,30 +114,34 @@ export class TokenService {
     }
 
     if (filter.sort) {
-      const order = filter.order ?? SortOrder.desc;
+      tokens = this.sortTokens(tokens, filter.sort, filter.order ?? SortOrder.desc);
+    }
 
-      let criteria: (token: Token) => number;
+    return tokens;
+  }
 
-      switch (filter.sort) {
-        case TokenSort.accounts:
-          criteria = token => token.accounts ?? 0;
-          break;
-        case TokenSort.transactions:
-          criteria = token => token.transactions ?? 0;
-          break;
-        default:
-          criteria = _ => 0;
-          break;
-      }
+  private sortTokens(tokens: TokenDetailed[], sort: TokenSort, order: SortOrder): TokenDetailed[] {
+    let criteria: (token: Token) => number;
 
-      switch (order) {
-        case SortOrder.asc:
-          tokens = tokens.sorted(criteria);
-          break;
-        case SortOrder.desc:
-          tokens = tokens.sortedDescending(criteria);
-          break;
-      }
+    switch (sort) {
+      case TokenSort.accounts:
+        criteria = token => token.accounts ?? 0;
+        break;
+      case TokenSort.transactions:
+        criteria = token => token.transactions ?? 0;
+        break;
+      default:
+        criteria = _ => 0;
+        break;
+    }
+
+    switch (order) {
+      case SortOrder.asc:
+        tokens = tokens.sorted(criteria);
+        break;
+      case SortOrder.desc:
+        tokens = tokens.sortedDescending(criteria);
+        break;
     }
 
     return tokens;

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -25,6 +25,8 @@ import { TokenProperties } from "./entities/token.properties";
 import { TokenRoles } from "./entities/token.roles";
 import { TokenSupplyResult } from "./entities/token.supply.result";
 import { TokenDetailedWithBalance } from "./entities/token.detailed.with.balance";
+import { SortOrder } from "src/common/entities/sort.order";
+import { TokenSort } from "./entities/token.sort";
 
 @Injectable()
 export class TokenService {
@@ -109,6 +111,33 @@ export class TokenService {
       const identifierArray = filter.identifiers.map(identifier => identifier.toLowerCase());
 
       tokens = tokens.filter(token => identifierArray.includes(token.identifier.toLowerCase()));
+    }
+
+    if (filter.sort) {
+      const order = filter.order ?? SortOrder.desc;
+
+      let criteria: (token: Token) => number;
+
+      switch (filter.sort) {
+        case TokenSort.accounts:
+          criteria = token => token.accounts ?? 0;
+          break;
+        case TokenSort.transactions:
+          criteria = token => token.transactions ?? 0;
+          break;
+        default:
+          criteria = _ => 0;
+          break;
+      }
+
+      switch (order) {
+        case SortOrder.asc:
+          tokens = tokens.sorted(criteria);
+          break;
+        case SortOrder.desc:
+          tokens = tokens.sortedDescending(criteria);
+          break;
+      }
     }
 
     return tokens;

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { CachingService } from "src/common/caching/caching.service";
 import { CacheInfo } from "src/common/caching/entities/cache.info";
 import { BinaryUtils } from "src/utils/binary.utils";
@@ -21,6 +21,7 @@ export class TokenTransferService {
 
   constructor(
     private readonly cachingService: CachingService,
+    @Inject(forwardRef(() => EsdtService))
     private readonly esdtService: EsdtService,
     private readonly tokenAssetService: TokenAssetService
   ) {

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -4,19 +4,20 @@ import { TransactionStatus } from "./transaction.status";
 import { TransactionType } from "./transaction.type";
 
 export class TransactionFilter {
-    sender?: string;
-    receiver?: string;
-    token?: string;
-    function?: string;
-    senderShard?: number;
-    receiverShard?: number;
-    miniBlockHash?: string;
-    hashes?: string[];
-    status?: TransactionStatus;
-    search?: string;
-    before?: number;
-    after?: number;
-    condition?: QueryConditionOptions;
-    order?: SortOrder;
-    type?: TransactionType;
+  sender?: string;
+  receiver?: string;
+  token?: string;
+  function?: string;
+  senderShard?: number;
+  receiverShard?: number;
+  miniBlockHash?: string;
+  hashes?: string[];
+  status?: TransactionStatus;
+  search?: string;
+  before?: number;
+  after?: number;
+  condition?: QueryConditionOptions;
+  order?: SortOrder;
+  type?: TransactionType;
+  tokens?: string[];
 }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -124,6 +124,9 @@ export class TransactionService {
       .withCondition(QueryConditionOptions.should, shouldQueries)
       .withCondition(QueryConditionOptions.must, mustQueries);
 
+    if (filter.tokens) {
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.tokens, token => QueryType.Match('tokens', token, QueryOperator.AND));
+    }
 
     if (filter.before || filter.after) {
       elasticQuery = elasticQuery


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Support for declaring `extraTokens` in token assets, with the effect of calculating total number of token accounts / transactions taking into consideration other similar tokens (LP tokens, Farm tokens, Metastaking, etc.)

## How to test (mainnet)
- `/tokens/RIDE-7d18e9` should contain > 70k accounts, > 1mil transactions
- `/tokens/RIDE-7d18e9/supply` should also contain locked accounts information