### PR TITLE
in single nft endpoint, apply attributes from gateway

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -265,11 +265,26 @@ export class NftService {
 
     await this.applyNftOwner(nft);
 
+    await this.applyNftAttributes(nft);
+
     await this.applyAssetsAndTicker(nft);
 
     await this.processNft(nft);
 
     return nft;
+  }
+
+  private async applyNftAttributes(nft: Nft): Promise<void> {
+    if (!nft.owner) {
+      return;
+    }
+
+    const nftsForAddress = await this.esdtAddressService.getNftsForAddress(nft.owner, { identifiers: [nft.identifier] }, { from: 0, size: 1 });
+    if (nftsForAddress.length === 0) {
+      return;
+    }
+
+    nft.attributes = nftsForAddress[0].attributes;
   }
 
   private async applyMedia(nft: Nft) {

--- a/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/esdt/transaction.action.esdt.nft.recognizer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { TokenTransferProperties } from "src/endpoints/tokens/entities/token.transfer.properties";
 import { TokenType } from "src/endpoints/tokens/entities/token.type";
@@ -17,6 +17,7 @@ import { TransactionActionRecognizerInterface } from "../../transaction.action.r
 export class TransactionActionEsdtNftRecognizerService implements TransactionActionRecognizerInterface {
   constructor(
     private readonly apiConfigService: ApiConfigService,
+    @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
   ) { }
 

--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.pair.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.pair.action.recognizer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { BinaryUtils } from "src/utils/binary.utils";
 import { NumberUtils } from "src/utils/number.utils";
 import { TransactionAction } from "../../entities/transaction.action";
@@ -14,6 +14,7 @@ import { TransactionActionEsdtNftRecognizerService } from "../esdt/transaction.a
 export class MexPairActionRecognizerService {
   constructor(
     private readonly mexSettingsService: MexSettingsService,
+    @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
     private readonly transactionActionEsdtNftRecognizerService: TransactionActionEsdtNftRecognizerService,
   ) { }

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { Transaction } from "src/endpoints/transactions/entities/transaction";
 import { AddressUtils } from "src/utils/address.utils";
 import { BinaryUtils } from "src/utils/binary.utils";
@@ -23,6 +23,7 @@ export class TransactionActionService {
     private readonly esdtNftRecognizer: TransactionActionEsdtNftRecognizerService,
     private readonly stakeRecognizer: StakeActionRecognizerService,
     private readonly scCallRecognizer: SCCallActionRecognizerService,
+    @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
   ) {
     this.logger = new Logger(TransactionActionService.name);

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { ElasticService } from "src/common/elastic/elastic.service";
 import { ElasticQuery } from "src/common/elastic/entities/elastic.query";
@@ -27,6 +27,7 @@ export class TransactionGetService {
     private readonly elasticService: ElasticService,
     private readonly gatewayService: GatewayService,
     private readonly apiConfigService: ApiConfigService,
+    @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
   ) {
     this.logger = new Logger(TransactionGetService.name);

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -43,7 +43,9 @@ export class TransactionService {
     private readonly elasticService: ElasticService,
     private readonly gatewayService: GatewayService,
     private readonly transactionPriceService: TransactionPriceService,
+    @Inject(forwardRef(() => TransactionGetService))
     private readonly transactionGetService: TransactionGetService,
+    @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
     private readonly pluginsService: PluginService,
     private readonly cachingService: CachingService,


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Update NFT attributes from gateway to mitigate the issue where the indexer does not reflect attribute changes

## How to test (mainnet)
- `/nfts/EREX-80e5a4-44` base64 decoded attributes should contain `metadata:Qmd5SS16SD7DDPZ3RzSsxdt6Dg3Lkaw9AVbhJMQNojYJdE/468.json`