### PR TITLE
unlock lkmex description fix

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/mex/mex.locked.asset.action.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/mex/mex.locked.asset.action.recognizer.service.ts
@@ -24,7 +24,12 @@ export class MexLockedAssetActionRecognizerService {
       case MexFunction.lockAssets:
         return this.getAssetsAction(metadata, 'Lock');
       case MexFunction.unlockAssets:
-        return this.getAssetsAction(metadata, 'Unlock');
+        const action = this.getAssetsAction(metadata, 'Unlock');
+        if (action) {
+          action.description = 'Unlock assets';
+        }
+
+        return action;
       case MexFunction.mergeLockedAssetTokens:
         return this.getMergeLockedAssetTokens(metadata);
       default:


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Unlock assets description misleading
  
## Proposed Changes
- Simplified unlock assets message

## How to test (mainnet)
- `/transactions/9b3f058a376907b52aeaf20f24c6e0bc0fb380ff4d77b3c50b6d7743f97e1ec4` should have action.description = 'Unlock assets'