### PR TITLE
fix query pagination

### DIFF
--- a/src/endpoints/nfttags/tag.service.ts
+++ b/src/endpoints/nfttags/tag.service.ts
@@ -19,7 +19,7 @@ export class TagService {
 
   async getNftTags(pagination: QueryPagination): Promise<Tag[]> {
     return await this.cachingService.getOrSetCache(
-      'nftTags',
+      `nftTags: ${pagination.from}:${pagination.size}`,
       async () => await this.getNftTagsRaw(pagination),
       Constants.oneHour(),
     );

--- a/src/endpoints/nfttags/tag.service.ts
+++ b/src/endpoints/nfttags/tag.service.ts
@@ -19,7 +19,7 @@ export class TagService {
 
   async getNftTags(pagination: QueryPagination): Promise<Tag[]> {
     return await this.cachingService.getOrSetCache(
-      `nftTags: ${pagination.from}:${pagination.size}`,
+      `nftTags:${pagination.from}:${pagination.size}`,
       async () => await this.getNftTagsRaw(pagination),
       Constants.oneHour(),
     );


### PR DESCRIPTION
## Type
- [ ] Bug
- [ ] Feature  
- [x] Refactoring
- [ ] Performance improvement

## Problem setting
-  Tags endpoint returned by default only two elements
  
## Proposed Changes
-  Fix query pagination
 
## How to test
-  /tags -> 25 tags
- /tags?from=0&size=100 -> 100 tags