### PR TITLE
Small fixes

### DIFF
--- a/src/endpoints/esdt/entities/esdt.locked.account.ts
+++ b/src/endpoints/esdt/entities/esdt.locked.account.ts
@@ -4,8 +4,8 @@ export class EsdtLockedAccount {
   @ApiProperty()
   address: string = '';
 
-  @ApiProperty()
-  name: string = '';
+  @ApiProperty({ type: String, nullable: true })
+  name: string | undefined = undefined;
 
   @ApiProperty()
   balance: string = '';

--- a/src/endpoints/esdt/entities/esdt.locked.account.ts
+++ b/src/endpoints/esdt/entities/esdt.locked.account.ts
@@ -7,6 +7,6 @@ export class EsdtLockedAccount {
   @ApiProperty({ type: String, nullable: true })
   name: string | undefined = undefined;
 
-  @ApiProperty()
-  balance: string = '';
+  @ApiProperty({ type: String })
+  balance: string | number = '';
 }

--- a/src/endpoints/mex/mex.pairs.service.ts
+++ b/src/endpoints/mex/mex.pairs.service.ts
@@ -122,7 +122,7 @@ export class MexPairsService {
       return [];
     }
 
-    return result.pairs.map((pair: any) => this.getPairInfo(pair));
+    return result.pairs.map((pair: any) => this.getPairInfo(pair)).filter((x: MexPair) => x.state === MexPairState.active);
   }
 
   private getPairInfo(pair: any): MexPair {

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -463,10 +463,12 @@ export class TokenService {
     const totalSupply = NumberUtils.denominateString(result.totalSupply, properties.decimals);
     const circulatingSupply = NumberUtils.denominateString(result.circulatingSupply, properties.decimals);
 
-    const lockedAccounts = result.lockedAccounts;
-    if (lockedAccounts && denominated === true) {
-      for (const lockedAccount of lockedAccounts) {
-        lockedAccount.balance = NumberUtils.denominateString(lockedAccount.balance.toString(), properties.decimals);
+    if (result.lockedAccounts) {
+      const lockedAccounts = JSON.parse(JSON.stringify(result.lockedAccounts));
+      if (denominated === true) {
+        for (const lockedAccount of lockedAccounts) {
+          lockedAccount.balance = NumberUtils.denominateString(lockedAccount.balance.toString(), properties.decimals);
+        }
       }
     }
 

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -463,9 +463,11 @@ export class TokenService {
     const totalSupply = NumberUtils.denominateString(result.totalSupply, properties.decimals);
     const circulatingSupply = NumberUtils.denominateString(result.circulatingSupply, properties.decimals);
 
-    if (result.lockedAccounts) {
-      const lockedAccounts = JSON.parse(JSON.stringify(result.lockedAccounts));
+    let lockedAccounts = result.lockedAccounts;
+    if (lockedAccounts !== undefined) {
+      lockedAccounts = JSON.parse(JSON.stringify(lockedAccounts));
       if (denominated === true) {
+        // @ts-ignore
         for (const lockedAccount of lockedAccounts) {
           lockedAccount.balance = NumberUtils.denominateString(lockedAccount.balance.toString(), properties.decimals);
         }
@@ -478,7 +480,7 @@ export class TokenService {
       minted: denominated === true && result.minted ? NumberUtils.denominateString(result.minted, properties.decimals) : result.minted,
       burnt: denominated === true && result.burned ? NumberUtils.denominateString(result.burned, properties.decimals) : result.burned,
       initialMinted: denominated === true && result.initialMinted ? NumberUtils.denominateString(result.initialMinted, properties.decimals) : result.initialMinted,
-      lockedAccounts: result.lockedAccounts,
+      lockedAccounts,
     };
   }
 

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -463,6 +463,13 @@ export class TokenService {
     const totalSupply = NumberUtils.denominateString(result.totalSupply, properties.decimals);
     const circulatingSupply = NumberUtils.denominateString(result.circulatingSupply, properties.decimals);
 
+    const lockedAccounts = result.lockedAccounts;
+    if (lockedAccounts && denominated === true) {
+      for (const lockedAccount of lockedAccounts) {
+        lockedAccount.balance = NumberUtils.denominateString(lockedAccount.balance.toString(), properties.decimals);
+      }
+    }
+
     return {
       supply: denominated === true ? totalSupply : totalSupply.toFixed(),
       circulatingSupply: denominated === true ? circulatingSupply : circulatingSupply.toFixed(),


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- re-establish token price
- locked accounts without name
- denominate locked account balance
- list only active pairs

## How to test (mainnet)
- `/tokens/RIDE-7d18e9` should have price & marketCap
- `/tokens/RIDE-7d18e9/supply` lockedAccount should not contain name attribute at all
- `/tokens/RIDE-7d18e9/supply?denominated=true` lockedAccounts balances should be denominated numbers
- `/mex/pairs` should all have status `active`
