### PR TITLE
Ipfs dweb link url support

### DIFF
--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import "./utils/extensions/array.extensions";
 import "./utils/extensions/date.extensions";
 import "./utils/extensions/number.extensions";
+import "./utils/extensions/string.extensions";
 import { EndpointsServicesModule } from './endpoints/endpoints.services.module';
 import { EndpointsControllersModule } from './endpoints/endpoints.controllers.module';
 import { LoggingModule } from './common/logging/logging.module';

--- a/src/test/unit/utils/string.extensions.spec.ts
+++ b/src/test/unit/utils/string.extensions.spec.ts
@@ -1,0 +1,21 @@
+import '../../../utils/extensions/string.extensions';
+
+describe('String Extensions', () => {
+  it('removePrefix', () => {
+    expect('hello world'.removePrefix('hello')).toEqual(' world');
+    expect('hello world'.removePrefix('helllo')).toEqual('hello world');
+  });
+
+  it('removeSuffix', () => {
+    expect('hello world'.removeSuffix('world')).toEqual('hello ');
+    expect('hello world'.removeSuffix('worlld')).toEqual('hello world');
+  });
+
+  it('removePrefix & removeSuffix', () => {
+    expect(
+      'https://bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq.ipfs.dweb.link'
+        .removeSuffix('.ipfs.dweb.link')
+        .removePrefix('https://')
+    ).toEqual('bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq');
+  });
+});

--- a/src/test/unit/utils/token.utils.spec.ts
+++ b/src/test/unit/utils/token.utils.spec.ts
@@ -2,24 +2,28 @@ import { TokenUtils } from "src/utils/token.utils";
 
 describe('Token Utils', () => {
   describe('computeNftUri', () => {
-    it('ipfs.io url works correctly', () => {
+    it('ipfs.io url processing', () => {
       expect(TokenUtils.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
       expect(TokenUtils.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
-    it('gateway.pinata.cloud url works correctly', () => {
+    it('gateway.pinata.cloud url processing', () => {
       expect(TokenUtils.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
       expect(TokenUtils.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
-    it('dweb.link url works correctly', () => {
+    it('dweb.link url processing', () => {
       expect(TokenUtils.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
       expect(TokenUtils.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
-    it('ipfs protocol url works correctly', () => {
+    it('ipfs protocol url processing', () => {
       expect(TokenUtils.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
       expect(TokenUtils.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
+    });
+
+    it('.ipfs.dweb.link url processing', () => {
+      expect(TokenUtils.computeNftUri('https://bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq.ipfs.dweb.link', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq');
     });
   });
 });

--- a/src/utils/extensions/string.extensions.ts
+++ b/src/utils/extensions/string.extensions.ts
@@ -1,0 +1,20 @@
+String.prototype.removePrefix = function (prefix: string): string {
+  if (this.startsWith(prefix)) {
+    return this.slice(prefix.length);
+  }
+
+  return this.toString();
+};
+
+String.prototype.removeSuffix = function (suffix: string): string {
+  if (this.endsWith(suffix)) {
+    return this.slice(0, -suffix.length);
+  }
+
+  return this.toString();
+};
+
+declare interface String {
+  removePrefix(prefix: string): string;
+  removeSuffix(suffix: string): string;
+}

--- a/src/utils/token.utils.ts
+++ b/src/utils/token.utils.ts
@@ -4,6 +4,7 @@ import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 import { TokenRoles } from "src/endpoints/tokens/entities/token.roles";
+import '../utils/extensions/string.extensions';
 
 export class TokenUtils {
   static isEsdt(tokenIdentifier: string) {
@@ -20,6 +21,11 @@ export class TokenUtils {
     uri = ApiUtils.replaceUri(uri, 'https://gateway.pinata.cloud/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'https://dweb.link/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'ipfs:/', prefix);
+
+    if (uri.endsWith('.ipfs.dweb.link')) {
+      const id = uri.removeSuffix('.ipfs.dweb.link').removePrefix('https://');
+      uri = `${prefix}/${id}`;
+    }
 
     return uri;
   }


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- support for ipfs urls ending with '.ipfs.dweb.link'

## How to test (mainnet)
- `/nfts/BOB-6b96b4-17a4` should have url [https://media.elrond.com/nfts/asset/bafybeialabty37gvrk4l5cmvayg5lji7oskm2bhulphnf374aaq3kixch4](https://media.elrond.com/nfts/asset/bafybeialabty37gvrk4l5cmvayg5lji7oskm2bhulphnf374aaq3kixch4)