### PR TITLE
fetch nft details from accountsesdt if not found

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -331,7 +331,10 @@ export class NftService {
         { name: 'nonce', order: ElasticSortOrder.descending },
       ]);
 
-    const elasticNfts = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
+    let elasticNfts = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
+    if (elasticNfts.length === 0 && identifier !== undefined) {
+      elasticNfts = await this.elasticService.getList('accountsesdt', 'identifier', ElasticQuery.create().withMustMatchCondition('identifier', identifier, QueryOperator.AND));
+    }
 
     const nfts: Nft[] = [];
 


### PR DESCRIPTION
## Type
- [x] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Since the last index update, MetaESDTs are not stored in the `tokens` index
  
## Proposed Changes
- If fetching NFT details fails, try to fetch it also from the `accountsesdt` index

## How to test (mainnet)
- `/nfts/LKMEX-aab910-39a090` should return data