### PR TITLE
account nft collections endpoint

### DIFF
--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -190,7 +190,7 @@ export class ElasticService {
     return await this.apiService.get(url);
   }
 
-  private async post(url: string, body: any) {
+  public async post(url: string, body: any) {
     return await this.apiService.post(url, body);
   }
 

--- a/src/common/elastic/entities/elastic.query.ts
+++ b/src/common/elastic/entities/elastic.query.ts
@@ -24,6 +24,7 @@ export class ElasticQuery {
   filter: AbstractQuery[] = [];
   condition: QueryCondition = new QueryCondition();
   terms?: TermsQuery;
+  extra?: Record<string, any>;
 
   static create(): ElasticQuery {
     return new ElasticQuery();
@@ -65,6 +66,14 @@ export class ElasticQuery {
     return this.withMustCondition(QueryType.Should(values.map(value => action(value))));
   }
 
+  withMustExistCondition(key: string): ElasticQuery {
+    return this.withMustCondition(QueryType.Exists(key));
+  }
+
+  withMustNotExistCondition(key: string): ElasticQuery {
+    return this.withMustNotCondition(QueryType.Exists(key));
+  }
+
   withMustCondition(queries: AbstractQuery[] | AbstractQuery): ElasticQuery {
     return this.withCondition(QueryConditionOptions.must, queries);
   }
@@ -103,6 +112,12 @@ export class ElasticQuery {
     return this;
   }
 
+  withExtra(extra: Record<string, any>): ElasticQuery {
+    this.extra = extra;
+
+    return this;
+  }
+
   toJson() {
     const elasticSort = buildElasticIndexerSort(this.sort);
 
@@ -119,6 +134,7 @@ export class ElasticQuery {
         },
         terms: this.terms?.getQuery(),
       },
+      ...this.extra ?? {},
     };
 
     ApiUtils.cleanupApiValueRecursively(elasticQuery);

--- a/src/endpoints/collections/entities/nft.collection.account.ts
+++ b/src/endpoints/collections/entities/nft.collection.account.ts
@@ -2,21 +2,6 @@ import { ApiProperty } from "@nestjs/swagger";
 import { NftCollection } from "./nft.collection";
 
 export class NftCollectionAccount extends NftCollection {
-  @ApiProperty({ type: Boolean, nullable: true })
-  canCreate: boolean | undefined = undefined;
-
-  @ApiProperty({ type: Boolean, nullable: true })
-  canBurn: boolean | undefined = undefined;
-
-  @ApiProperty({ type: Boolean, nullable: true })
-  canAddQuantity: boolean | undefined = undefined;
-
-  @ApiProperty({ type: Boolean, nullable: true })
-  canUpdateAttributes: boolean | undefined = undefined;
-
-  @ApiProperty({ type: Boolean, nullable: true })
-  canAddUri: boolean | undefined = undefined;
-
-  @ApiProperty({ type: Boolean, nullable: true })
-  canTransferRole: boolean | undefined = undefined;
+  @ApiProperty()
+  count: number = 0;
 }

--- a/src/endpoints/collections/entities/nft.collection.role.ts
+++ b/src/endpoints/collections/entities/nft.collection.role.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { NftCollection } from "./nft.collection";
+
+export class NftCollectionRole extends NftCollection {
+  @ApiProperty({ type: Boolean, nullable: true })
+  canCreate: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  canBurn: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  canAddQuantity: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  canUpdateAttributes: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  canAddUri: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  canTransferRole: boolean | undefined = undefined;
+}

--- a/src/test/integration/collections.e2e-spec.ts
+++ b/src/test/integration/collections.e2e-spec.ts
@@ -4,7 +4,7 @@ import { Test } from "@nestjs/testing";
 import { CollectionService } from "src/endpoints/collections/collection.service";
 import { PublicAppModule } from "src/public.app.module";
 import { NftCollection } from 'src/endpoints/collections/entities/nft.collection';
-import { NftCollectionAccount } from 'src/endpoints/collections/entities/nft.collection.account';
+import { NftCollectionRole } from 'src/endpoints/collections/entities/nft.collection.role';
 import '../../utils/extensions/jest.extensions';
 
 describe('Collection Service', () => {
@@ -264,7 +264,7 @@ describe('Collection Service', () => {
       const address: string = "erd1gv55fk7gn0f437eq53x7u5zux824a9ff86v5pvnneg7yvsucpp0svncsmz";
       const collectionIdentifier: string = 'DEITIES-0d1f10';
       const collection = await collectionService.getCollectionForAddress(address, collectionIdentifier);
-      const collectionResults = new NftCollectionAccount();
+      const collectionResults = new NftCollectionRole();
 
       // @ts-ignore
       delete collectionResults.timestamp;

--- a/src/test/integration/esdt.address.e2e-spec.ts
+++ b/src/test/integration/esdt.address.e2e-spec.ts
@@ -3,7 +3,7 @@ import { EsdtAddressService } from 'src/endpoints/esdt/esdt.address.service';
 import { Test } from "@nestjs/testing";
 import { EsdtDataSource } from 'src/endpoints/esdt/entities/esdt.data.source';
 import { NftCollection } from 'src/endpoints/collections/entities/nft.collection';
-import { NftCollectionAccount } from 'src/endpoints/collections/entities/nft.collection.account';
+import { NftCollectionRole } from 'src/endpoints/collections/entities/nft.collection.role';
 import { NftType } from 'src/endpoints/nfts/entities/nft.type';
 import { CollectionFilter } from 'src/endpoints/collections/entities/collection.filter';
 import '../../utils/extensions/jest.extensions';
@@ -96,7 +96,7 @@ describe('EsdtAddressService', () => {
       const collectionFilter = new CollectionFilter();
       collectionFilter.collection = 'HMORGOTH-ecd5fb';
 
-      const collections: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.elastic);
+      const collections: NftCollection[] | NftCollectionRole[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.elastic);
 
       expect(collections).toHaveLength(1);
       expect(collections).toBeInstanceOf(Object);
@@ -119,7 +119,7 @@ describe('EsdtAddressService', () => {
       const collectionFilter = new CollectionFilter();
       collectionFilter.collection = 'HMORGOTH-ecd5fb';
 
-      const collectionEsdtGateway: NftCollection[] | NftCollectionAccount[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.gateway);
+      const collectionEsdtGateway: NftCollection[] | NftCollectionRole[] = await esdtAddressService.getCollectionsForAddress(address, collectionFilter, { from: 0, size: 1 }, EsdtDataSource.gateway);
 
       for (const collection of collectionEsdtGateway) {
         expect(collection).toBeInstanceOf(Object);


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Create an endpoint for returning distinct collections of nfts belonging to an account

## How to test (mainnet)
- `/accounts/erd1frj909pfums4m8aza596595l9pl56crwdj077vs2aqcw6ynl28wsfkw9rd/nft-collections` should return some nft collections
- `/accounts/erd1frj909pfums4m8aza596595l9pl56crwdj077vs2aqcw6ynl28wsfkw9rd/nft-collections/count` should return 6
- `/accounts/erd1frj909pfums4m8aza596595l9pl56crwdj077vs2aqcw6ynl28wsfkw9rd/nft-collections/c` should return 6
- `/accounts/erd1frj909pfums4m8aza596595l9pl56crwdj077vs2aqcw6ynl28wsfkw9rd/nft-collections/MEME-6fe129` should return collection details