### PR TITLE
NFT owners sort fix

### DIFF
--- a/src/common/elastic/elastic.service.ts
+++ b/src/common/elastic/elastic.service.ts
@@ -161,7 +161,8 @@ export class ElasticService {
     elasticQuery = elasticQuery
       .withSort([{ name: "balanceNum", order: ElasticSortOrder.descending }])
       .withCondition(QueryConditionOptions.mustNot, [QueryType.Match('address', 'pending')])
-      .withCondition(QueryConditionOptions.should, queries);
+      .withCondition(QueryConditionOptions.should, queries)
+      .withSort([{ name: 'timestamp', order: ElasticSortOrder.descending }]);
 
     const documents = await this.getDocuments('accountsesdt', elasticQuery.toJson());
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- in case of indexer having issues indexing owners, the wrong one is returned in the API
  
## Proposed Changes
- when fetching accountsesdt by identifiers, sort by timestamp descending to fetch correct owners first

## How to test (mainnet)
- `/nfts/SRB-61daf7-1e11` should return owner `erd1qafz8ljqr8mksmjkdvxvcms0qcqe4nqzj6lw2pv5vjxr2xjsnxcqfcg85r`
- `/nfts/PASS-1c7c6a-51` should return owner `erd1adz0ud7q3edwv5de9suu6lcdz4lf4svje50vpplngkslhadvjmxqa0qwcr`