### PR TITLE
search by collection case insensitive

### DIFF
--- a/src/common/elastic/entities/elastic.query.ts
+++ b/src/common/elastic/entities/elastic.query.ts
@@ -77,6 +77,29 @@ export class ElasticQuery {
     return this.withCondition(QueryConditionOptions.should, queries);
   }
 
+  withSearchWildcardCondition(search: string | undefined, keys: string[]): ElasticQuery {
+    return this.withSearchCondition(search, term => keys.map(key => QueryType.Wildcard(key, `*${term.toLowerCase()}*`)));
+  }
+
+  withSearchCondition(search: string | undefined, func: (term: string) => AbstractQuery[]): ElasticQuery {
+    if (!search) {
+      return this;
+    }
+
+    const searchConditions = [];
+
+    const components = search.matchAll(/\w{3,}/g);
+    for (const component of components) {
+      const term = component[0];
+
+      const conditions = func(term);
+
+      searchConditions.push(QueryType.Should(conditions));
+    }
+
+    return this.withMustCondition(searchConditions);
+  }
+
   withCondition(queryCondition: QueryConditionOptions, queries: AbstractQuery[] | AbstractQuery): ElasticQuery {
     if (!Array.isArray(queries)) {
       queries = [queries];

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -95,9 +95,15 @@ export class CollectionService {
       }
     }
 
+    if (filter.search) {
+      elasticQuery = elasticQuery.withShouldCondition([
+        QueryType.Wildcard('token', filter.search.toLowerCase()),
+        QueryType.Wildcard('name', filter.search.toLowerCase()),
+      ]);
+    }
+
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
-      .withMustWildcardCondition('token', filter.search)
       .withMustMatchCondition('type', filter.type)
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
   }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -95,16 +95,10 @@ export class CollectionService {
       }
     }
 
-    if (filter.search) {
-      elasticQuery = elasticQuery.withShouldCondition([
-        QueryType.Wildcard('token', filter.search.toLowerCase()),
-        QueryType.Wildcard('name', filter.search.toLowerCase()),
-      ]);
-    }
-
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
       .withMustMatchCondition('type', filter.type)
+      .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
   }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- searching by `SHARK` in [api.elrond.com](http://api.elrond.com/) will return multiple resuts, whereas in [internal-api.elrond.com](http://internal-api.elrond.com/) will return 0 results
  
## Proposed Changes
- always perform lowercase search
- search also by name field

## How to test (mainnet, internal api)
- `collections?search=SHARK` should return multiple results
- `collections?search=ElrondSharks` should return one result