### PR TITLE
include svg url in token operations

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -223,6 +223,7 @@ export class TokenTransferService {
       const decimals = properties ? properties.decimals : undefined;
       const name = properties ? properties.name : undefined;
       const esdtType = properties ? properties.type : undefined;
+      const svgUrl = properties ? properties.svgUrl : undefined;
 
       let collection: string | undefined = undefined;
       if (nonce) {
@@ -232,7 +233,7 @@ export class TokenTransferService {
 
       const type = nonce ? TransactionOperationType.nft : TransactionOperationType.esdt;
 
-      return { id: log.id ?? '', action, type, esdtType, collection, identifier, name, sender: event.address, receiver, value, decimals };
+      return { id: log.id ?? '', action, type, esdtType, collection, identifier, name, sender: event.address, receiver, value, decimals, svgUrl };
     } catch (error) {
       this.logger.error(`Error when parsing NFT transaction log for tx hash '${txHash}' with action '${action}' and topics: ${event.topics}`);
       this.logger.error(error);

--- a/src/endpoints/transactions/entities/transaction.operation.ts
+++ b/src/endpoints/transactions/entities/transaction.operation.ts
@@ -34,12 +34,15 @@ export class TransactionOperation {
   @ApiProperty({ type: String })
   receiver: string = '';
 
-  @ApiProperty({ type: Number })
+  @ApiProperty({ type: Number, nullable: true })
   decimals?: number;
 
-  @ApiProperty({ type: String })
-  data?: string = '';
+  @ApiProperty({ type: String, nullable: true })
+  data?: string;
 
-  @ApiProperty({ type: String })
-  message?: string = '';
+  @ApiProperty({ type: String, nullable: true })
+  message?: string;
+
+  @ApiProperty({ type: String, nullable: true })
+  svgUrl?: string;
 }


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- Include `svgUrl` in token operations, so that they can be rendered on front-ends without needing extra API calls

## How to test (mainnet)
- `/transactions/c3655780ac2a7d3a7ad38baadb9dd1ca4e0f97f37ffb8ca4ecde0a1234e136d6` operations should all contain svgUrl where the operation includes a token/collection