### PR TITLE
Transaction action on smart contract results

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -866,7 +866,7 @@ export class AccountController {
     return this.accountService.getAccountContractsCount(address);
   }
 
-  @Get("/accounts/:address/sc-results")
+  @Get("/accounts/:address/results")
   @ApiOperation({ summary: 'Account smart contract results', description: 'Returns smart contract results where the account is sender or receiver' })
   @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -887,7 +887,7 @@ export class AccountController {
     return this.scResultService.getAccountScResults(address, { from, size });
   }
 
-  @Get("/accounts/:address/sc-results/count")
+  @Get("/accounts/:address/results/count")
   @ApiOperation({ summary: 'Account smart contracts results count', description: 'Returns number of smart contract results where the account is sender or receiver' })
   @ApiResponse({
     status: 200,
@@ -903,7 +903,7 @@ export class AccountController {
     return this.scResultService.getAccountScResultsCount(address);
   }
 
-  @Get("/accounts/:address/sc-results/:scHash")
+  @Get("/accounts/:address/results/:scHash")
   @ApiOperation({ summary: 'Account smart contract result', description: 'Returns details of a smart contract result where the account is sender or receiver' })
   @ApiResponse({
     status: 200,
@@ -914,11 +914,70 @@ export class AccountController {
     description: 'Account not found',
   })
   async getAccountScResult(
-    @Param('address', ParseAddressPipe) _: string,
+    @Param('address', ParseAddressPipe) address: string,
     @Param('scHash', ParseTransactionHashPipe) scHash: string,
   ): Promise<SmartContractResult> {
     const scResult = await this.scResultService.getScResult(scHash);
-    if (!scResult) {
+    if (!scResult || (scResult.sender !== address && scResult.receiver !== address)) {
+      throw new NotFoundException('Smart contract result not found');
+    }
+
+    return scResult;
+  }
+
+  @Get("/accounts/:address/sc-results")
+  @ApiOperation({ summary: 'Account smart contract results', description: 'Returns smart contract results where the account is sender or receiver', deprecated: true })
+  @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiResponse({
+    status: 200,
+    isArray: true,
+    type: SmartContractResult,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Account not found',
+  })
+  getAccountScResultsDeprecated(
+    @Param('address', ParseAddressPipe) address: string,
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+  ): Promise<SmartContractResult[]> {
+    return this.scResultService.getAccountScResults(address, { from, size });
+  }
+
+  @Get("/accounts/:address/sc-results/count")
+  @ApiOperation({ summary: 'Account smart contracts results count', description: 'Returns number of smart contract results where the account is sender or receiver', deprecated: true })
+  @ApiResponse({
+    status: 200,
+    type: Number,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Account not found',
+  })
+  getAccountScResultsCountDeprecated(
+    @Param('address', ParseAddressPipe) address: string,
+  ): Promise<number> {
+    return this.scResultService.getAccountScResultsCount(address);
+  }
+
+  @Get("/accounts/:address/sc-results/:scHash")
+  @ApiOperation({ summary: 'Account smart contract result', description: 'Returns details of a smart contract result where the account is sender or receiver', deprecated: true })
+  @ApiResponse({
+    status: 200,
+    type: SmartContractResult,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Account not found',
+  })
+  async getAccountScResultDeprecated(
+    @Param('address', ParseAddressPipe) address: string,
+    @Param('scHash', ParseTransactionHashPipe) scHash: string,
+  ): Promise<SmartContractResult> {
+    const scResult = await this.scResultService.getScResult(scHash);
+    if (!scResult || (scResult.sender !== address && scResult.receiver !== address)) {
       throw new NotFoundException('Smart contract result not found');
     }
 

--- a/src/endpoints/accounts/account.module.ts
+++ b/src/endpoints/accounts/account.module.ts
@@ -21,7 +21,7 @@ import { AccountService } from "./account.service";
     WaitingListModule,
     forwardRef(() => StakeModule),
     forwardRef(() => TransactionModule),
-    SmartContractResultModule,
+    forwardRef(() => SmartContractResultModule),
     forwardRef(() => CollectionModule),
     forwardRef(() => PluginModule),
     forwardRef(() => TransferModule),

--- a/src/endpoints/sc-results/entities/smart.contract.result.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.ts
@@ -1,53 +1,57 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { TransactionAction } from "src/endpoints/transactions/transaction-action/entities/transaction.action";
 import { SwaggerUtils } from "src/utils/swagger.utils";
 import { TransactionLog } from "../../transactions/entities/transaction.log";
 
 export class SmartContractResult {
-    @ApiProperty({ type: String })
-    hash: string = '';
+  @ApiProperty({ type: String })
+  hash: string = '';
 
-    @ApiProperty({ type: Number })
-    timestamp: number = 0;
+  @ApiProperty({ type: Number })
+  timestamp: number = 0;
 
-    @ApiProperty({ type: Number })
-    nonce: number = 0;
+  @ApiProperty({ type: Number })
+  nonce: number = 0;
 
-    @ApiProperty({ type: Number })
-    gasLimit: number = 0;
+  @ApiProperty({ type: Number })
+  gasLimit: number = 0;
 
-    @ApiProperty({ type: Number })
-    gasPrice: number = 0;
+  @ApiProperty({ type: Number })
+  gasPrice: number = 0;
 
-    @ApiProperty(SwaggerUtils.amountPropertyOptions())
-    value: string = '';
+  @ApiProperty(SwaggerUtils.amountPropertyOptions())
+  value: string = '';
 
-    @ApiProperty({ type: String })
-    sender: string = '';
+  @ApiProperty({ type: String })
+  sender: string = '';
 
-    @ApiProperty({ type: String })
-    receiver: string = '';
+  @ApiProperty({ type: String })
+  receiver: string = '';
 
-    @ApiProperty({ type: String })
-    relayedValue: string = '';
+  @ApiProperty({ type: String })
+  relayedValue: string = '';
 
-    @ApiProperty({ type: String })
-    data: string = '';
+  @ApiProperty({ type: String })
+  data: string = '';
 
-    @ApiProperty({ type: String })
-    prevTxHash: string = '';
+  @ApiProperty({ type: String })
+  prevTxHash: string = '';
 
-    @ApiProperty({ type: String })
-    originalTxHash: string = '';
+  @ApiProperty({ type: String })
+  originalTxHash: string = '';
 
-    @ApiProperty({ type: String })
-    callType: string = '';
+  @ApiProperty({ type: String })
+  callType: string = '';
 
-    @ApiProperty({ type: String, nullable: true })
-    miniBlockHash: string | undefined = undefined;
+  @ApiProperty({ type: String, nullable: true })
+  miniBlockHash: string | undefined = undefined;
 
-    @ApiProperty({ type: TransactionLog, nullable: true })
-    logs: TransactionLog | undefined = undefined;
+  @ApiProperty({ type: TransactionLog, nullable: true })
+  logs: TransactionLog | undefined = undefined;
 
-    @ApiProperty({ type: String, nullable: true })
-    returnMessage: string | undefined = undefined;
+  @ApiProperty({ type: String, nullable: true })
+  returnMessage: string | undefined = undefined;
+
+  @ApiProperty({ type: TransactionAction, nullable: true })
+  action: TransactionAction | undefined = undefined;
 }

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -11,7 +11,7 @@ import { ParseBlockHashPipe } from "src/utils/pipes/parse.block.hash.pipe";
 export class SmartContractResultController {
   constructor(private readonly scResultService: SmartContractResultService) { }
 
-  @Get("/sc-results")
+  @Get("/results")
   @ApiOperation({ summary: 'Smart contract results', description: 'Returns all smart contract results available on the blockchain' })
   @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
@@ -30,7 +30,7 @@ export class SmartContractResultController {
     return this.scResultService.getScResults({ from, size }, { miniBlockHash, originalTxHashes });
   }
 
-  @Get("/sc-results/count")
+  @Get("/results/count")
   @ApiOperation({ summary: 'Smart contracts count', description: 'Returns total number of smart contracts results' })
   @ApiResponse({
     status: 200,
@@ -40,7 +40,7 @@ export class SmartContractResultController {
     return this.scResultService.getScResultsCount();
   }
 
-  @Get("/sc-results/:scHash")
+  @Get("/results/:scHash")
   @ApiOperation({ summary: 'Smart contract results details', description: 'Returns smart contract details for a given hash' })
   @ApiResponse({
     status: 200,
@@ -51,6 +51,54 @@ export class SmartContractResultController {
     description: 'Smart contract result not found',
   })
   async getScResult(@Param('scHash', ParseTransactionHashPipe) scHash: string): Promise<SmartContractResult> {
+    const scResult = await this.scResultService.getScResult(scHash);
+    if (!scResult) {
+      throw new NotFoundException('Smart contract result not found');
+    }
+
+    return scResult;
+  }
+
+  @Get("/sc-results")
+  @ApiOperation({ summary: 'Smart contract results', description: 'Returns all smart contract results available on the blockchain', deprecated: true })
+  @ApiQuery({ name: 'from', description: 'Numer of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'miniBlockHash', description: 'The hash of the parent miniBlock', required: false })
+  @ApiResponse({
+    status: 200,
+    isArray: true,
+    type: SmartContractResult,
+  })
+  getScResultsDeprecated(
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
+    @Query('originalTxHashes', ParseArrayPipe, ParseTransactionHashPipe) originalTxHashes?: string[],
+  ): Promise<SmartContractResult[]> {
+    return this.scResultService.getScResults({ from, size }, { miniBlockHash, originalTxHashes });
+  }
+
+  @Get("/sc-results/count")
+  @ApiOperation({ summary: 'Smart contracts count', description: 'Returns total number of smart contracts results', deprecated: true })
+  @ApiResponse({
+    status: 200,
+    type: Number,
+  })
+  getScResultsCountDeprecated(): Promise<number> {
+    return this.scResultService.getScResultsCount();
+  }
+
+  @Get("/sc-results/:scHash")
+  @ApiOperation({ summary: 'Smart contract results details', description: 'Returns smart contract details for a given hash', deprecated: true })
+  @ApiResponse({
+    status: 200,
+    type: SmartContractResult,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Smart contract result not found',
+  })
+  async getScResultDeprecated(@Param('scHash', ParseTransactionHashPipe) scHash: string): Promise<SmartContractResult> {
     const scResult = await this.scResultService.getScResult(scHash);
     if (!scResult) {
       throw new NotFoundException('Smart contract result not found');

--- a/src/endpoints/sc-results/scresult.module.ts
+++ b/src/endpoints/sc-results/scresult.module.ts
@@ -1,7 +1,11 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
+import { TransactionActionModule } from "../transactions/transaction-action/transaction.action.module";
 import { SmartContractResultService } from "./scresult.service";
 
 @Module({
+  imports: [
+    forwardRef(() => TransactionActionModule),
+  ],
   providers: [
     SmartContractResultService,
   ],

--- a/src/endpoints/sc-results/scresult.service.ts
+++ b/src/endpoints/sc-results/scresult.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { forwardRef, Inject, Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { ElasticService } from "src/common/elastic/elastic.service";
 import { AbstractQuery } from "src/common/elastic/entities/abstract.query";
@@ -8,6 +8,9 @@ import { QueryConditionOptions } from "src/common/elastic/entities/query.conditi
 import { QueryType } from "src/common/elastic/entities/query.type";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { ApiUtils } from "src/utils/api.utils";
+import { Transaction } from "../transactions/entities/transaction";
+import { TransactionType } from "../transactions/entities/transaction.type";
+import { TransactionActionService } from "../transactions/transaction-action/transaction.action.service";
 import { SmartContractResult } from "./entities/smart.contract.result";
 import { SmartContractResultFilter } from "./entities/smart.contract.result.filter";
 
@@ -16,6 +19,8 @@ export class SmartContractResultService {
   constructor(
     private readonly elasticService: ElasticService,
     private readonly apiConfigService: ApiConfigService,
+    @Inject(forwardRef(() => TransactionActionService))
+    private readonly transactionActionService: TransactionActionService,
   ) { }
 
   private buildSmartContractResultFilterQuery(address?: string): ElasticQuery {
@@ -51,7 +56,16 @@ export class SmartContractResultService {
 
     const elasticResult = await this.elasticService.getList('scresults', 'hash', query);
 
-    return elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
+    const smartContractResults = elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
+
+    for (const smartContractResult of smartContractResults) {
+      const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
+      transaction.type = TransactionType.SmartContractResult;
+
+      smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+    }
+
+    return smartContractResults;
   }
 
   async getScResult(scHash: string): Promise<SmartContractResult | undefined> {
@@ -60,7 +74,13 @@ export class SmartContractResultService {
       return undefined;
     }
 
-    return ApiUtils.mergeObjects(new SmartContractResult(), scResult);
+    const smartContractResult = ApiUtils.mergeObjects(new SmartContractResult(), scResult);
+    const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
+    transaction.type = TransactionType.SmartContractResult;
+
+    smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+
+    return smartContractResult;
   }
 
   async getScResultsCount(): Promise<number> {
@@ -75,7 +95,16 @@ export class SmartContractResultService {
 
     const elasticResult = await this.elasticService.getList('scresults', 'hash', elasticQuery);
 
-    return elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
+    const smartContractResults = elasticResult.map(scResult => ApiUtils.mergeObjects(new SmartContractResult(), scResult));
+
+    for (const smartContractResult of smartContractResults) {
+      const transaction = ApiUtils.mergeObjects(new Transaction(), smartContractResult);
+      transaction.type = TransactionType.SmartContractResult;
+
+      smartContractResult.action = await this.transactionActionService.getTransactionAction(transaction);
+    }
+
+    return smartContractResults;
   }
 
   async getAccountScResultsCount(address: string): Promise<number> {

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -1,6 +1,7 @@
 import { ApiProperty } from "@nestjs/swagger";
 import { ScamInfo } from "src/common/entities/scam-info.dto";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
+import { TransactionAction } from "../transaction-action/entities/transaction.action";
 
 export class Transaction {
   @ApiProperty({ type: String })
@@ -57,8 +58,8 @@ export class Transaction {
   @ApiProperty({ type: String, nullable: true })
   function: string | undefined = undefined;
 
-  @ApiProperty({ type: String, nullable: true })
-  action: any | undefined = undefined;
+  @ApiProperty({ type: TransactionAction, nullable: true })
+  action: TransactionAction | undefined = undefined;
 
   @ApiProperty({ type: ScamInfo, nullable: true })
   scamInfo: ScamInfo | undefined = undefined;

--- a/src/endpoints/transactions/transaction-action/transaction.action.service.ts
+++ b/src/endpoints/transactions/transaction-action/transaction.action.service.ts
@@ -139,9 +139,9 @@ export class TransactionActionService {
         }
 
         if (metadata.functionName === 'ESDTNFTTransfer' &&
-          metadata.functionArgs.length > 3 &&
-          AddressUtils.bech32Encode(metadata.functionArgs[3]) === metadata.receiver
+          metadata.functionArgs.length > 3
         ) {
+          metadata.functionArgs[3] = AddressUtils.bech32Decode(metadata.receiver);
           metadata.receiver = metadata.sender;
         }
       }


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Proposed Changes
- use the same interpreter used for transaction action to also interpret scresult actions
- alternative "results" endpoint
- deprecate "sc-results" endpoints

## How to test (mainnet)
- `/results`
- `/results/b2a82dbd563f6f597de4e45e1a4c09e93c93e6011a0f9a565f32bdbef27fb03e`
- `/accounts/erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy/results`
- `/accounts/erd1qqqqqqqqqqqqqpgqvc7gdl0p4s97guh498wgz75k8sav6sjfjlwqh679jy/results/b2a82dbd563f6f597de4e45e1a4c09e93c93e6011a0f9a565f32bdbef27fb03e`
- ... should also contain `action` attribute