### PR TITLE
Collection type bugfix

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -132,6 +132,7 @@ export class CollectionService {
         continue;
       }
 
+      nftCollection.type = indexedCollection.type;
       nftCollection.timestamp = indexedCollection.timestamp;
     }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- requesting /collections?size=1000&type=MetaESDT returns some collections as NonFungibleESDT
  
## Proposed Changes
- fetch collection type from elasticsearch

## How to test
- `/collections/PANDAS-2c4369` should return type `MetaESDT`