### PR TITLE
Old transaction price error

### DIFF
--- a/src/endpoints/transactions/transaction.price.service.ts
+++ b/src/endpoints/transactions/transaction.price.service.ts
@@ -28,6 +28,10 @@ export class TransactionPriceService {
       return undefined;
     }
 
+    if (transactionDate.isLessThan(new Date(2020, 9, 10))) {
+      return undefined;
+    }
+
     let price = await this.getTransactionPriceForDate(transactionDate);
     if (price) {
       price = Number(price).toRounded(2);

--- a/src/utils/extensions/date.extensions.ts
+++ b/src/utils/extensions/date.extensions.ts
@@ -6,8 +6,17 @@ Date.prototype.toISODateString = function (): string {
   return this.toISOString().slice(0, 10);
 };
 
+Date.prototype.isGreaterThan = function (other: Date): boolean {
+  return this.getTime() > other.getTime();
+};
+
+Date.prototype.isLessThan = function (other: Date): boolean {
+  return this.getTime() < other.getTime();
+};
 
 declare interface Date {
   toISODateString(): string;
   isToday(): boolean;
+  isGreaterThan(other: Date): boolean;
+  isLessThan(other: Date): boolean;
 }


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Transactions older than 9 sept 2020 will not be able to fetch price from [data.elrond.com](http://data.elrond.com/), thus logging an error internally
  
## Proposed Changes
- do not fetch price for transaction older than 10 sept 2020

## How to test
- `/transactions/63efdb5e1ccea744fe3bfe7746b56e641e0dee9e0171fa62bc5d91a205051011` should not log internal error regarding price fetcher