### PR TITLE
Fetch collection type from ES

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -244,6 +244,7 @@ export class CollectionService {
       return undefined;
     }
 
+    collection.type = elasticCollection.type;
     collection.timestamp = elasticCollection.timestamp;
     collection.roles = await this.getNftCollectionRoles(elasticCollection);
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- Type is incorrectly fetched for collection details
  
## Proposed Changes
- Fetch collection type from ES for collection details

## How to test
- `/collections/PANDAS-2c4369` should have type `MetaESDT`