### PR TITLE
Surround mex tokens prices fetching

### DIFF
--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -86,6 +86,14 @@ export class EsdtService {
 
     await this.batchProcessTokens(tokens);
 
+    await this.applyMexPrices(tokens);
+
+    tokens = tokens.sortedDescending(token => token.transactions ?? 0);
+
+    return tokens;
+  }
+
+  private async applyMexPrices(tokens: TokenDetailed[]): Promise<void> {
     try {
       const indexedTokens = await this.mexTokenService.getMexPricesRaw();
       for (const token of tokens) {
@@ -98,13 +106,9 @@ export class EsdtService {
         }
       }
     } catch (error) {
-      this.logger.error(`Could not fetch mex tokens prices`);
+      this.logger.error('Could not apply mex tokens prices');
       this.logger.error(error);
     }
-
-    tokens = tokens.sortedDescending(token => token.transactions ?? 0);
-
-    return tokens;
   }
 
   async batchProcessTokens(tokens: TokenDetailed[]) {

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -86,15 +86,20 @@ export class EsdtService {
 
     await this.batchProcessTokens(tokens);
 
-    const indexedTokens = await this.mexTokenService.getMexPricesRaw();
-    for (const token of tokens) {
-      const price = indexedTokens[token.identifier];
-      if (price) {
-        const supply = await this.getTokenSupply(token.identifier);
+    try {
+      const indexedTokens = await this.mexTokenService.getMexPricesRaw();
+      for (const token of tokens) {
+        const price = indexedTokens[token.identifier];
+        if (price) {
+          const supply = await this.getTokenSupply(token.identifier);
 
-        token.price = price;
-        token.marketCap = price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
+          token.price = price;
+          token.marketCap = price * NumberUtils.denominateString(supply.circulatingSupply, token.decimals);
+        }
       }
+    } catch (error) {
+      this.logger.error(`Could not fetch mex tokens prices`);
+      this.logger.error(error);
     }
 
     tokens = tokens.sortedDescending(token => token.transactions ?? 0);


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- If dex service is down, tokens page on explorer will not show tokens
  
## Proposed Changes
- Show tokens without dex service infos, like price and market cap

## How to test(testnet)
- Check if /tokens retrieves same tokens (without price and marketCap) if dex service is unavailable