### PR TITLE
Nft price fix

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -456,12 +456,21 @@ export class NftService {
   }
 
   private async applyPriceUsd(nft: NftAccount) {
-    const prices = await this.mexTokenService.getMexPrices();
+    if (nft.type !== NftType.MetaESDT) {
+      return;
+    }
 
-    const price = prices[nft.collection];
-    if (price) {
-      nft.price = price;
-      nft.valueUsd = price * NumberUtils.denominateString(nft.balance, nft.decimals);
+    try {
+      const prices = await this.mexTokenService.getMexPrices();
+
+      const price = prices[nft.collection];
+      if (price) {
+        nft.price = price;
+        nft.valueUsd = price * NumberUtils.denominateString(nft.balance, nft.decimals);
+      }
+    } catch (error) {
+      this.logger.error(`Unable to apply price on MetaESDT with identifier '${nft.identifier}'`);
+      this.logger.error(error);
     }
   }
 


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement

## Problem setting
- If somehow the query of getting the prices from maiar.exchange fails, the API should continue to operate normally
  
## Proposed Changes
- perform various checks when fetching mex prices

## How to test (testnet)
- `/accounts/erd194m3jf6tzg4kwq2u46h7qd207jyh5r4vd6pw2r4f9qdvguzzytfspw7xst/nfts?withOwner=true&withSupply=true&from=0&size=10&hasUris=true&isWhitelistedStorage=true&source=elastic&withMetadata=true&includeFlagged=true` should return 1 element