### PR TITLE
Filter collections by multiple types

### DIFF
--- a/src/common/elastic/entities/elastic.query.ts
+++ b/src/common/elastic/entities/elastic.query.ts
@@ -1,4 +1,3 @@
-import { Logger } from "@nestjs/common";
 import { ApiUtils } from "src/utils/api.utils";
 import { AbstractQuery } from "./abstract.query";
 import { ElasticPagination } from "./elastic.pagination";
@@ -143,8 +142,7 @@ export class ElasticQuery {
   }
 
   debug() {
-    const logger = new Logger(ElasticQuery.name);
-    logger.log({ elasticQuery: JSON.stringify(this.toJson()) });
+    console.log({ elasticQuery: JSON.stringify(this.toJson()) });
   }
 
   toJson() {

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -40,6 +40,7 @@ import { ProviderStake } from '../stake/entities/provider.stake';
 import { TokenDetailedWithBalance } from '../tokens/entities/token.detailed.with.balance';
 import { NftCollectionAccount } from '../collections/entities/nft.collection.account';
 import { TokenWithRoles } from '../tokens/entities/token.with.roles';
+import { ParseOptionalEnumArrayPipe } from 'src/utils/pipes/parse.optional.enum.array.pipe';
 
 @Controller()
 @ApiTags('accounts')
@@ -201,7 +202,7 @@ export class AccountController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
     @Query('owner') owner?: string,
     @Query('canCreate', new ParseOptionalBoolPipe) canCreate?: boolean,
     @Query('canBurn', new ParseOptionalBoolPipe) canBurn?: boolean,
@@ -225,7 +226,7 @@ export class AccountController {
   async getCollectionWithRolesCount(
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('canCreate', new ParseOptionalBoolPipe) canCreate?: boolean,
     @Query('canBurn', new ParseOptionalBoolPipe) canBurn?: boolean,
@@ -239,7 +240,7 @@ export class AccountController {
   async getCollectionCountAlternative(
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('canCreate', new ParseOptionalBoolPipe) canCreate?: boolean,
     @Query('canBurn', new ParseOptionalBoolPipe) canBurn?: boolean,
@@ -341,7 +342,7 @@ export class AccountController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
   ): Promise<NftCollectionAccount[]> {
     return await this.collectionService.getCollectionsForAddress(address, { search, type }, { from, size });
   }
@@ -354,7 +355,7 @@ export class AccountController {
   async getNftCollectionCount(
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddress(address, { search, type });
   }
@@ -364,7 +365,7 @@ export class AccountController {
   async getNftCollectionCountAlternative(
     @Param('address', ParseAddressPipe) address: string,
     @Query('search') search?: string,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type?: NftType,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type?: NftType[],
   ): Promise<number> {
     return await this.collectionService.getCollectionCountForAddress(address, { search, type });
   }

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, ParseIntPipe, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
-import { ParseOptionalEnumPipe } from "src/utils/pipes/parse.optional.enum.pipe";
 import { NftCollection } from "./entities/nft.collection";
 import { NftType } from "../nfts/entities/nft.type";
 import { CollectionService } from "./collection.service";
@@ -9,6 +8,7 @@ import { ParseArrayPipe } from "src/utils/pipes/parse.array.pipe";
 import { Nft } from "../nfts/entities/nft";
 import { ParseOptionalBoolPipe } from "src/utils/pipes/parse.optional.bool.pipe";
 import { NftService } from "../nfts/nft.service";
+import { ParseOptionalEnumArrayPipe } from "src/utils/pipes/parse.optional.enum.array.pipe";
 
 @Controller()
 @ApiTags('collections')
@@ -38,7 +38,7 @@ export class CollectionController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search: string | undefined,
     @Query('identifiers', ParseArrayPipe) identifiers: string[] | undefined,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type: NftType | undefined,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type: NftType[] | undefined,
     @Query('creator', ParseAddressPipe) creator: string | undefined,
     @Query('canCreate', new ParseAddressPipe) canCreate?: string,
     @Query('canBurn', new ParseAddressPipe) canBurn?: string,
@@ -74,7 +74,7 @@ export class CollectionController {
   @ApiOkResponse({ type: Number })
   async getCollectionCount(
     @Query('search') search: string | undefined,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type: NftType | undefined,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type: NftType[] | undefined,
     @Query('creator', ParseAddressPipe) creator: string | undefined,
     @Query('canCreate', new ParseAddressPipe) canCreate?: string,
     @Query('canBurn', new ParseAddressPipe) canBurn?: string,
@@ -99,7 +99,7 @@ export class CollectionController {
   @ApiExcludeEndpoint()
   async getCollectionCountAlternative(
     @Query('search') search: string | undefined,
-    @Query('type', new ParseOptionalEnumPipe(NftType)) type: NftType | undefined,
+    @Query('type', new ParseOptionalEnumArrayPipe(NftType)) type: NftType[] | undefined,
     @Query('creator', ParseAddressPipe) creator: string | undefined,
     @Query('canCreate', new ParseAddressPipe) canCreate?: string,
     @Query('canBurn', new ParseAddressPipe) canBurn?: string,

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -89,8 +89,8 @@ export class CollectionService {
 
     return elasticQuery.withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
-      .withMustMatchCondition('type', filter.type)
       .withSearchWildcardCondition(filter.search, ['token', 'name'])
+      .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
   }
 
@@ -327,7 +327,7 @@ export class CollectionService {
   }
 
   async getCollectionForAddress(address: string, identifier: string): Promise<NftCollectionAccount | undefined> {
-    const collections = await this.getCollectionsForAddress(address, {}, { from: 0, size: 10000 });
+    const collections = await this.getCollectionsForAddress(address, { collection: identifier }, { from: 0, size: 1 });
 
     return collections.find(x => x.collection === identifier);
   }
@@ -340,7 +340,7 @@ export class CollectionService {
       .withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
       .withMustWildcardCondition('token', filter.search)
-      .withMustMatchCondition('type', filter.type)
+      .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type))
       .withExtra({
         aggs: {

--- a/src/endpoints/collections/entities/collection.filter.ts
+++ b/src/endpoints/collections/entities/collection.filter.ts
@@ -4,7 +4,7 @@ export class CollectionFilter {
   collection?: string;
   identifiers?: string[];
   search?: string;
-  type?: NftType;
+  type?: NftType[];
   owner?: string;
   canCreate?: boolean | string;
   canBurn?: boolean | string;

--- a/src/test/integration/collections.e2e-spec.ts
+++ b/src/test/integration/collections.e2e-spec.ts
@@ -22,7 +22,7 @@ describe('Collection Service', () => {
   describe("NFT Collections", () => {
     it("shoult return 10 NonFungibleESDT collections", async () => {
       const filter = new CollectionFilter();
-      filter.type = NftType.NonFungibleESDT;
+      filter.type = [NftType.NonFungibleESDT];
       const results = await collectionService.getNftCollections({ from: 0, size: 10 }, filter);
 
       expect(results).toHaveLength(10);
@@ -34,7 +34,7 @@ describe('Collection Service', () => {
     });
 
     it(`should return a list with SemiFungibleESDT collections`, async () => {
-      const results = await collectionService.getNftCollections({ from: 0, size: 10 }, { type: NftType.SemiFungibleESDT });
+      const results = await collectionService.getNftCollections({ from: 0, size: 10 }, { type: [NftType.SemiFungibleESDT] });
 
       expect(results).toHaveLength(10);
 
@@ -153,7 +153,7 @@ describe('Collection Service', () => {
 
     it("should return collection count for collection of type NonFungibleESDT", async () => {
       const filters = new CollectionFilter();
-      filters.type = NftType.NonFungibleESDT;
+      filters.type = [NftType.NonFungibleESDT];
 
       const results = await collectionService.getNftCollectionCount(filters);
       expect(typeof results).toBe("number");
@@ -161,7 +161,7 @@ describe('Collection Service', () => {
 
     it("should return collection count for collection of type SemiFungibleESDT", async () => {
       const filters = new CollectionFilter();
-      filters.type = NftType.SemiFungibleESDT;
+      filters.type = [NftType.SemiFungibleESDT];
 
       const results = await collectionService.getNftCollectionCount(filters);
       expect(typeof results).toBe("number");
@@ -221,7 +221,7 @@ describe('Collection Service', () => {
     it("should return collection of NonFungibleESDT for address", async () => {
       const address: string = "erd1qqqqqqqqqqqqqpgq09vq93grfqy7x5fhgmh44ncqfp3xaw57ys5s7j9fed";
       const filter = new CollectionFilter();
-      filter.type = NftType.NonFungibleESDT;
+      filter.type = [NftType.NonFungibleESDT];
 
       const results = await collectionService.getCollectionsForAddress(address, filter, { from: 0, size: 10 });
 

--- a/src/utils/pipes/parse.optional.enum.array.pipe.ts
+++ b/src/utils/pipes/parse.optional.enum.array.pipe.ts
@@ -1,0 +1,29 @@
+import { ArgumentMetadata, HttpException, HttpStatus, PipeTransform } from "@nestjs/common";
+
+export class ParseOptionalEnumArrayPipe<T extends { [name: string]: any }> implements PipeTransform<string | undefined, Promise<string[] | undefined>> {
+  constructor(private readonly type: T) { }
+
+  transform(value: string | undefined, _: ArgumentMetadata): Promise<string[] | undefined> {
+    return new Promise(resolve => {
+      if (value === undefined || value === '') {
+        return resolve(undefined);
+      }
+
+      const values = value.split(',');
+
+      const expectedValues = this.getValues(this.type);
+      for (const value of values) {
+        if (!expectedValues.includes(value)) {
+          throw new HttpException(`Validation failed (one of the following values is expected: ${expectedValues.join(', ')})`, HttpStatus.BAD_REQUEST);
+        }
+      }
+
+      return resolve(values);
+    });
+  }
+
+
+  private getValues<T extends { [name: string]: any }>(value: T): string[] {
+    return Object.keys(value).map(key => value[key]).filter(value => typeof value === 'string') as string[];
+  }
+}


### PR DESCRIPTION
## Type
- [ ] Bug
- [x] Feature  
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Integration test


## Proposed Changes
- Possibility to filter by multiple types in global collections & account collections

## How to test (mainnet)
- `/collections?type=SemiFungibleESDT,MetaESDT` should return multiple results
- `/accounts/erd1gkn5eppdkrkpyaq852vkgkqudg62qmsfy4nvdyj9w07eed2nmkdq9rgrk5/collections?type=SemiFungibleESDT,MetaESDT` should return multiple values
- `/accounts/erd1gkn5eppdkrkpyaq852vkgkqudg62qmsfy4nvdyj9w07eed2nmkdq9rgrk5/roles/collections?type=SemiFungibleESDT,MetaESDT` should return multiple values