### PR TITLE
Fix tags representation

### DIFF
--- a/src/endpoints/nfttags/entities/tag.ts
+++ b/src/endpoints/nfttags/entities/tag.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from "@nestjs/swagger";
 
 export class Tag {
-  @ApiProperty({ type: String, nullable: true, example: 'RWxyb25k' })
-  tag: string | undefined = undefined;
+  @ApiProperty({ type: String, nullable: true, example: 'sunny' })
+  tag: string = '';
 
   @ApiProperty({ type: Number, nullable: true, example: 46135 })
   count: number | undefined = undefined;

--- a/src/endpoints/nfttags/tag.service.ts
+++ b/src/endpoints/nfttags/tag.service.ts
@@ -7,6 +7,7 @@ import { Tag } from "./entities/tag";
 import { ElasticService } from "src/common/elastic/elastic.service";
 import { ElasticSortOrder } from "src/common/elastic/entities/elastic.sort.order";
 import { ElasticQuery } from "src/common/elastic/entities/elastic.query";
+import { BinaryUtils } from "src/utils/binary.utils";
 
 @Injectable()
 export class TagService {
@@ -34,12 +35,19 @@ export class TagService {
 
     const nftTags: Tag[] = result.map(item => ApiUtils.mergeObjects(new Tag(), item));
 
+    for (const tag of nftTags) {
+      tag.tag = BinaryUtils.base64Decode(tag.tag);
+    }
+
     return nftTags;
   }
 
   async getNftTag(tag: string): Promise<Tag> {
-    const result = await this.elasticService.getItem('tags', 'tag', tag);
+    const result = await this.elasticService.getItem('tags', 'tag', BinaryUtils.base64Encode(tag));
 
-    return ApiUtils.mergeObjects(new Tag(), result);
+    const nftTag = ApiUtils.mergeObjects(new Tag(), result);
+    nftTag.tag = BinaryUtils.base64Decode(nftTag.tag);
+
+    return nftTag;
   }
 }

--- a/src/test/integration/nft.tag.e2e-spec.ts
+++ b/src/test/integration/nft.tag.e2e-spec.ts
@@ -16,27 +16,29 @@ describe('NFT Tag Service', () => {
 
   });
 
-  it(`should return list of tags for 1 nft`, async () => {
-    const tags = await tagService.getNftTags({ from: 0, size: 1 });
+  it(`should return list of tags for 2 nft`, async () => {
+    const tags = await tagService.getNftTags({ from: 0, size: 2 });
 
     for (const tag of tags) {
       expect(tag).toHaveStructure(Object.keys(new Tag()));
     }
+    expect(tags).toHaveLength(2);
   });
 
-  it(`should return a list of tags raw for 1 nft`, async () => {
-    const tagsRaw = await tagService.getNftTagsRaw({ from: 0, size: 1 });
-    expect(tagsRaw.length).toBe(1);
+  it(`should return a list of tags raw for 2 nft`, async () => {
+    const tagsRaw = await tagService.getNftTagsRaw({ from: 0, size: 2 });
 
     for (const tag of tagsRaw) {
       expect(tag).toHaveStructure(Object.keys(new Tag()));
     }
+    expect(tagsRaw).toHaveLength(2);
   });
 
   describe('Get Nft Tag', () => {
-    it('should return tag', async () => {
-      const tag = await tagService.getNftTag('ZWxyb25k');
-      expect(tag).toHaveStructure(Object.keys(new Tag()));
+    it('should return a specific tag', async () => {
+      const tag = await tagService.getNftTag('elrond');
+
+      expect(tag.tag).toStrictEqual('elrond');
     });
   });
 });


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Integration test


## Problem setting
- Tag names appear as base64
  
## Proposed Changes
- encode / decode tag so that it appears human readable in the request / response

## How to test (mainnet)
- `/tags` should return human readable `tag` attributes
- `/tags/elrond` should return tag `elrond`