### PR TITLE
Apply casing fix when fetching thumbnail

### DIFF
--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -122,7 +122,7 @@ export class NftController {
       throw new NotFoundException('NFT not found');
     }
 
-    const media = await this.nftMediaService.getMedia(identifier);
+    const media = await this.nftMediaService.getMedia(nfts[0].identifier);
     if (!media || media.length === 0) {
       // @ts-ignore
       response.redirect(this.nftService.DEFAULT_MEDIA[0].thumbnailUrl);


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Integration test


## Proposed Changes
- Use identifier stored in ES when fetching thumbnail from persistence service 

## How to test (mainnet)
- `/nfts/ogv-eca1e9-0160/thumbnail` should return its thumbnail and not default