### PR TITLE
Transaction token query bugfix

### DIFF
--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -57,7 +57,7 @@ export class TransactionService {
 
   private buildTransactionFilterQuery(filter: TransactionFilter, address?: string): ElasticQuery {
     let elasticQuery = ElasticQuery.create()
-      .withMustMatchCondition('tokens', filter.token)
+      .withMustMatchCondition('tokens', filter.token, QueryOperator.AND)
       .withMustMatchCondition('function', this.apiConfigService.getIsIndexerV3FlagActive() ? filter.function : undefined)
       .withMustMatchCondition('senderShard', filter.senderShard)
       .withMustMatchCondition('receiverShard', filter.receiverShard)


### PR DESCRIPTION
## Type
- [x] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Integration test

## Problem setting
- Transactions query by NFT returns data for other nfts from the same collection
  
## Proposed Changes
- use AND QueryOperator to fetch transaction token information

## How to test
- `/transactions?token=SHARK-8c1c46-26` should only return transactions involving SHARK-8c1c46-26