### PR TITLE
Wildcard collection search

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -339,7 +339,7 @@ export class CollectionService {
       .withPagination({ from: 0, size: 0 })
       .withMustMatchCondition('token', filter.collection, QueryOperator.AND)
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
-      .withMustWildcardCondition('token', filter.search)
+      .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
       .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type))
       .withExtra({

--- a/src/test/integration/collections.e2e-spec.ts
+++ b/src/test/integration/collections.e2e-spec.ts
@@ -305,7 +305,6 @@ describe('Collection Service', () => {
       expect(results.canTransferRole).toStrictEqual(false);
       expect(results.canUpdateAttributes).toStrictEqual(false);
       expect(results.canTransferNftCreateRole).toStrictEqual(false);
-      expect(results).toHaveStructure(Object.keys(new NftCollectionRole()));
     });
 
     it('should return undefined because test simulate that address does not contains any collection', async () => {
@@ -379,6 +378,27 @@ describe('Collection Service', () => {
       for (const result of results) {
         expect(result.type).toStrictEqual(NftType.NonFungibleESDT);
         expect(result).toHaveStructure(Object.keys(new NftCollectionAccount()));
+      }
+    });
+    it('should return a specific collection details if search filter is applied', async () => {
+      const address: string = 'erd126y66ear20cdskrdky0kpzr9agjul7pcut7ktlr6p0eu8syxhvrq0gsqdj';
+      const filter = new CollectionFilter();
+      filter.search = 'MEDAL-ae074f';
+      const results = await collectionService.getCollectionsForAddress(address, filter, { from: 0, size: 1 });
+
+      for (const result of results) {
+        expect(result.collection).toStrictEqual('MEDAL-ae074f');
+        expect(result).toHaveStructure(Object.keys(new NftCollectionAccount()));
+      }
+    });
+    it('should return an empty array if search filter is applied with wrong collection identifier details', async () => {
+      const address: string = 'erd126y66ear20cdskrdky0kpzr9agjul7pcut7ktlr6p0eu8syxhvrq0gsqdj';
+      const filter = new CollectionFilter();
+      filter.search = 'MEDAL-ae074fTest';
+      const results = await collectionService.getCollectionsForAddress(address, filter, { from: 0, size: 1 });
+
+      for (const result of results) {
+        expect(result).toStrictEqual([]);
       }
     });
   });


### PR DESCRIPTION
## Type
- [ ] Bug
- [ ] Feature  
- [ ] Refactoring
- [ ] Performance improvement
- [ ] Integration test

## Problem setting
- Search address collection was not working correctly
  
## Proposed Changes
- Add wildcard search condition

## How to test
Before changes:
- accounts/erd126y66ear20cdskrdky0kpzr9agjul7pcut7ktlr6p0eu8syxhvrq0gsqdj/collections?search=MEDAL-ae074f  -> returned [ ]

After changes:
- accounts/erd126y66ear20cdskrdky0kpzr9agjul7pcut7ktlr6p0eu8syxhvrq0gsqdj/collections?search=MEDAL-ae074f -> should return collection details