### PR TITLE
Add 404 status code for collections endpoint

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -166,12 +166,19 @@ export class CollectionController {
       throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply'`);
     }
 
+    const token = await this.collectionService.getNftCollection(collection);
+
+    if (token === undefined) {
+      throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
+    }
+
     return await this.nftService.getNfts({ from, size }, { search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage }, { withOwner, withSupply });
   }
 
   @Get("/collections/:collection/nfts/count")
   @ApiOperation({ summary: 'Collection NFT count', description: 'Returns non-fungible/semi-fungible/meta-esdt token count that belong to a collection' })
   @ApiOkResponse({ type: Number })
+  @ApiNotFoundResponse({ description: 'Token collection not found' })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by token identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'name', description: 'Get all nfts by name', required: false })
@@ -189,6 +196,12 @@ export class CollectionController {
     @Query('isWhitelistedStorage', new ParseOptionalBoolPipe) isWhitelistedStorage?: boolean,
     @Query('hasUris', new ParseOptionalBoolPipe) hasUris?: boolean,
   ): Promise<number> {
+    const token = await this.collectionService.getNftCollection(collection);
+
+    if (token === undefined) {
+      throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
+    }
+
     return await this.nftService.getNftCount({ search, identifiers, collection, name, tags, creator, isWhitelistedStorage, hasUris });
   }
 }

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -166,10 +166,10 @@ export class CollectionController {
       throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply'`);
     }
 
-    const token = await this.collectionService.getNftCollection(collection);
+    const isCollection = await this.collectionService.isCollection(collection);
 
-    if (token === undefined) {
-      throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
+    if (!isCollection) {
+      throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
     }
 
     return await this.nftService.getNfts({ from, size }, { search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage }, { withOwner, withSupply });
@@ -196,10 +196,10 @@ export class CollectionController {
     @Query('isWhitelistedStorage', new ParseOptionalBoolPipe) isWhitelistedStorage?: boolean,
     @Query('hasUris', new ParseOptionalBoolPipe) hasUris?: boolean,
   ): Promise<number> {
-    const token = await this.collectionService.getNftCollection(collection);
+    const isCollection = await this.collectionService.isCollection(collection);
 
-    if (token === undefined) {
-      throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
+    if (!isCollection) {
+      throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
     }
 
     return await this.nftService.getNftCount({ search, identifiers, collection, name, tags, creator, isWhitelistedStorage, hasUris });

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -167,7 +167,6 @@ export class CollectionController {
     }
 
     const isCollection = await this.collectionService.isCollection(collection);
-
     if (!isCollection) {
       throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
     }
@@ -197,7 +196,6 @@ export class CollectionController {
     @Query('hasUris', new ParseOptionalBoolPipe) hasUris?: boolean,
   ): Promise<number> {
     const isCollection = await this.collectionService.isCollection(collection);
-
     if (!isCollection) {
       throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
     }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -101,6 +101,11 @@ export class CollectionService {
     return query.withCondition(condition, QueryType.Nested('roles', { [`roles.${name}`]: targetAddress }));
   }
 
+  async isCollection(identifier: string): Promise<boolean> {
+    const collection = await this.elasticService.getItem('tokens', '_id', identifier);
+    return collection !== undefined;
+  }
+
   async getNftCollections(pagination: QueryPagination, filter: CollectionFilter): Promise<NftCollection[]> {
     const elasticQuery = this.buildCollectionRolesFilter(filter)
       .withPagination(pagination)


### PR DESCRIPTION
## Type
- [ ] Bug
- [ ] Feature  
- [x] Refactoring
- [ ] Performance improvement
- [ ] Integration test

## Problem setting
- There was no collection not found condition for endpoints:
 - /collections/:collection/nfts/count
 - /collections/:collection/nfts  
  
## Proposed Changes
- Add condition to verify if collection exist

## How to test
-  /collections/Test/nfts -> should return 404 instead of []
- /collections/Test/nfts/count -> should return 404 instead of 0