### PR TITLE
fixed some status computations

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -480,17 +480,18 @@ export class NodeService {
       let nodeType: NodeType | undefined = undefined;
       let nodeStatus: NodeStatus | undefined = undefined;
 
-      const status = peerType ? peerType : validatorStatus;
-      nodeStatus = status;
-
-      if (status === 'observer') {
+      if (validatorStatus === 'new') {
+        nodeType = NodeType.validator;
+        nodeStatus = NodeStatus.new;
+      } else if (validatorStatus && validatorStatus.includes('leaving')) {
+        nodeType = NodeType.validator;
+        nodeStatus = NodeStatus.leaving;
+      } else if (peerType === 'observer') {
         nodeType = NodeType.observer;
         nodeStatus = undefined;
       } else {
         nodeType = NodeType.validator;
-        if (status && status.includes('leaving')) {
-          nodeStatus = NodeStatus.leaving;
-        }
+        nodeStatus = peerType ? peerType : validatorStatus;
       }
 
       const node: Node = {


### PR DESCRIPTION
## Problem setting
- Node status information is not always accurate for new / leaving nodes
  
## Proposed Changes
- Take validator statistics status information with priority in case of new / leaving status and not from node heartbeatstatus

## How to test (mainnet)
- `/nodes?status=new` should return 25 items today until epoch change
- `/nodes?status=leaving` should return 25 items today until epoch change