### PR TITLE
NoAuth decorator

### DIFF
--- a/src/decorators/no.auth.ts
+++ b/src/decorators/no.auth.ts
@@ -1,0 +1,5 @@
+import { DecoratorUtils } from "src/utils/decorator.utils";
+
+export class NoAuthOptions { }
+
+export const NoAuth = DecoratorUtils.registerMethodDecorator(NoAuthOptions);

--- a/src/endpoints/health-check/health.check.controller.ts
+++ b/src/endpoints/health-check/health.check.controller.ts
@@ -1,10 +1,12 @@
 import { Controller, Get } from "@nestjs/common";
 import { ApiOperation } from "@nestjs/swagger";
+import { NoAuth } from "src/decorators/no.auth";
 
 @Controller()
 export class HealthCheckController {
   @Get("/hello")
   @ApiOperation({ summary: 'Health check', description: 'Returns \'hello\', used for performing health checks' })
+  @NoAuth()
   getHello(): string {
     return 'hello';
   }

--- a/src/utils/guards/jwt.authenticate.global.guard.ts
+++ b/src/utils/guards/jwt.authenticate.global.guard.ts
@@ -1,7 +1,8 @@
 import { CanActivate, ExecutionContext, Injectable, Logger } from "@nestjs/common";
 import { TokenExpiredError, verify } from 'jsonwebtoken';
 import { ApiConfigService } from "src/common/api-config/api.config.service";
-import { HealthCheckController } from "src/endpoints/health-check/health.check.controller";
+import { NoAuthOptions } from "src/decorators/no.auth";
+import { DecoratorUtils } from "../decorator.utils";
 
 @Injectable()
 export class JwtAuthenticateGlobalGuard implements CanActivate {
@@ -18,7 +19,8 @@ export class JwtAuthenticateGlobalGuard implements CanActivate {
   ): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
-    if (context.getClass().name === HealthCheckController.name) {
+    const noAuthMethodMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getHandler());
+    if (noAuthMethodMetadata) {
       return true;
     }
 

--- a/src/utils/guards/jwt.authenticate.guard.ts
+++ b/src/utils/guards/jwt.authenticate.guard.ts
@@ -19,7 +19,7 @@ export class JwtAuthenticateGuard implements CanActivate {
   ): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
 
-    const noAuthMethodMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getClass());
+    const noAuthMethodMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getHandler());
     if (noAuthMethodMetadata) {
       return true;
     }

--- a/src/utils/guards/jwt.authenticate.guard.ts
+++ b/src/utils/guards/jwt.authenticate.guard.ts
@@ -1,6 +1,8 @@
 import { Injectable, CanActivate, ExecutionContext, Logger } from '@nestjs/common';
 import { TokenExpiredError, verify } from 'jsonwebtoken';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { NoAuthOptions } from 'src/decorators/no.auth';
+import { DecoratorUtils } from '../decorator.utils';
 
 @Injectable()
 export class JwtAuthenticateGuard implements CanActivate {
@@ -16,6 +18,11 @@ export class JwtAuthenticateGuard implements CanActivate {
     context: ExecutionContext,
   ): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+
+    const noAuthMethodMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getClass());
+    if (noAuthMethodMetadata) {
+      return true;
+    }
 
     const authorization: string = request.headers['authorization'];
     if (!authorization) {

--- a/src/utils/guards/native.auth.guard.ts
+++ b/src/utils/guards/native.auth.guard.ts
@@ -1,6 +1,8 @@
 import { NativeAuthServer } from '@elrondnetwork/native-auth';
 import { Injectable, CanActivate, ExecutionContext, Logger, UnauthorizedException } from '@nestjs/common';
 import { CachingService } from 'src/common/caching/caching.service';
+import { NoAuthOptions } from 'src/decorators/no.auth';
+import { DecoratorUtils } from '../decorator.utils';
 
 @Injectable()
 export class NativeAuthGuard implements CanActivate {
@@ -29,6 +31,11 @@ export class NativeAuthGuard implements CanActivate {
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
     const request = context.switchToHttp().getRequest();
+
+    const noAuthMethodMetadata = DecoratorUtils.getMethodDecorator(NoAuthOptions, context.getHandler());
+    if (noAuthMethodMetadata) {
+      return true;
+    }
 
     const host = new URL(request.headers['origin']).hostname;
 


### PR DESCRIPTION
## Proposed Changes
- support for NoAuth decorator

## How to test
- activate auth flag in config (`api.auth: true`), then make sure the `/hello` route works, while all other endpoints (e.g. `/accounts` throw ForbiddenException)