### PR TITLE
delegation legacy endpoint caching

### DIFF
--- a/src/common/caching/entities/cache.info.ts
+++ b/src/common/caching/entities/cache.info.ts
@@ -280,4 +280,9 @@ export class CacheInfo {
       ttl: Constants.oneMinute() * 10,
     };
   }
+
+  static DelegationLegacy: CacheInfo = {
+    key: "delegationLegacy",
+    ttl: Constants.oneMinute() * 10,
+  };
 }


### PR DESCRIPTION
## Proposed Changes
- Use caching for `/delegation-legacy` endpoint

## How to test
- `/delegation-legacy` must always return from cache
- `delegationLegacy` cache key must be refreshed every minute