### PR TITLE
Fix rabbitmq logs and events handler

### DIFF
--- a/src/common/rabbitmq/rabbitmq.nft.consumer.ts
+++ b/src/common/rabbitmq/rabbitmq.nft.consumer.ts
@@ -21,8 +21,9 @@ export class RabbitMqNftConsumer {
   async consumeEvents(rawEvents: any) {
     try {
       const events = rawEvents?.events;
-
-      await Promise.all(events.map((event: any) => this.handleEvent(event)));
+      if (events) {
+        await Promise.all(events.map((event: any) => this.handleEvent(event)));
+      }
     } catch (error) {
       this.logger.error(`An unhandled error occurred when consuming events: ${JSON.stringify(rawEvents)}`);
       this.logger.error(error);


### PR DESCRIPTION
## Problem setting
- Breaking change occurred on the go-notifier node to also notify blocks with no events
  
## Proposed Changes
- handle null events

## How to test
- No `An unhandled error occurred when consuming events` error message should not appear when the notifier sends blocks with null events attribute