### PR TITLE
Filter by function in transaction count

### DIFF
--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -112,6 +112,7 @@ export class TransactionController {
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
   @ApiQuery({ name: 'condition', description: 'Condition for elastic search queries', required: false, deprecated: true })
   @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   getTransactionCount(
@@ -124,6 +125,7 @@ export class TransactionController {
     @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('status', new ParseOptionalEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('search') search?: string,
+    @Query('function') scFunction?: string,
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseOptionalIntPipe) before?: number,
     @Query('after', ParseOptionalIntPipe) after?: number,
@@ -138,6 +140,7 @@ export class TransactionController {
       hashes,
       status,
       search,
+      function: scFunction,
       before,
       after,
       condition,
@@ -156,6 +159,7 @@ export class TransactionController {
     @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('status', new ParseOptionalEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('search') search?: string,
+    @Query('function') scFunction?: string,
     @Query('condition') condition?: QueryConditionOptions,
     @Query('before', ParseOptionalIntPipe) before?: number,
     @Query('after', ParseOptionalIntPipe) after?: number,
@@ -170,6 +174,7 @@ export class TransactionController {
       hashes,
       status,
       search,
+      function: scFunction,
       before,
       after,
       condition,


### PR DESCRIPTION
## Proposed Changes
- support for filtering by function in transaction count

## How to test (mainnet)
- `/transactions/count?function=unDelegate` should return ~400.000