### PR TITLE
Support for unlisted mex pairs

### DIFF
--- a/src/endpoints/mex/entities/mex.pair.type.ts
+++ b/src/endpoints/mex/entities/mex.pair.type.ts
@@ -4,4 +4,5 @@ export enum MexPairType {
   ecosystem = 'ecosystem',
   experimental = 'experimental',
   jungle = 'jungle',
+  unlisted = 'unlisted',
 }

--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -117,7 +117,7 @@ export class MexPairService {
     const secondTokenSymbol = pair.secondToken.identifier.split('-')[0];
     const state = this.getPairState(pair.state);
     const type = this.getPairType(pair.type);
-    if (!type || type === MexPairType.jungle) {
+    if (!type || [MexPairType.jungle, MexPairType.unlisted].includes(type)) {
       return undefined;
     }
 
@@ -189,6 +189,8 @@ export class MexPairService {
         return MexPairType.experimental;
       case 'Jungle':
         return MexPairType.jungle;
+      case 'Unlisted':
+        return MexPairType.unlisted;
       default:
         this.logger.error(`Unsupported pair type '${type}'`);
         return undefined;


### PR DESCRIPTION
## Proposed Changes
- Support for unlisted mex pair type

## How to test (mainnet)
- When refreshing mex pairs, do not log error `Unsupported pair type 'Unlisted'`