### PR TITLE
Fix account nfts 1024 size limitation

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -20,7 +20,7 @@ import { EsdtDataSource } from "../esdt/entities/esdt.data.source";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { PersistenceService } from "src/common/persistence/persistence.service";
 import { MexTokenService } from "../mex/mex.token.service";
-import { ApiUtils, BinaryUtils, Constants, NumberUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryConditionOptions, QueryType, QueryOperator, ElasticSortOrder, RangeGreaterThanOrEqual, RangeLowerThan } from "@elrondnetwork/erdnest";
+import { ApiUtils, BinaryUtils, Constants, NumberUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryConditionOptions, QueryType, QueryOperator, ElasticSortOrder, RangeGreaterThanOrEqual, RangeLowerThan, BatchUtils } from "@elrondnetwork/erdnest";
 
 @Injectable()
 export class NftService {
@@ -471,7 +471,7 @@ export class NftService {
     await this.batchProcessNfts(nfts);
 
     if (this.apiConfigService.isNftExtendedAttributesEnabled()) {
-      const internalNfts = await this.getNftsInternal(new QueryPagination({ from: 0, size: nfts.length }), new NftFilter({ identifiers: nfts.map(x => x.identifier) }));
+      const internalNfts = await this.getNftsInternalByIdentifiers(nfts.map(x => x.identifier));
 
       const indexedInternalNfts = internalNfts.toRecord<Nft>(x => x.identifier);
       for (const nft of nfts) {
@@ -485,6 +485,18 @@ export class NftService {
     }
 
     return nfts;
+  }
+
+  private async getNftsInternalByIdentifiers(identifiers: string[]): Promise<Nft[]> {
+    const chunks = BatchUtils.splitArrayIntoChunks(identifiers, 1024);
+    const result: Nft[] = [];
+    for (const identifiers of chunks) {
+      const internalNfts = await this.getNftsInternal(new QueryPagination({ from: 0, size: identifiers.length }), new NftFilter({ identifiers }));
+
+      result.push(...internalNfts);
+    }
+
+    return result;
   }
 
   private async applyPriceUsd(nft: NftAccount) {


### PR DESCRIPTION
## Problem setting
- 500 Internal server error occurs when fetching > 1024 account NFTs
  
## Proposed Changes
- fetch by identifiers split into 1024 size chunks

## How to test (mainnet)
- `/accounts/erd1qqqqqqqqqqqqqpgqh438d42h9ltlqgpmjxc3srxafnx383n5kagq6hynlu/nfts?from=0&size=1025&hasUris=true&collection=REALM-579543` should return 200 success

Thanks to @SkullElf (Telegram) for reporting this