### PR TITLE
Upload nft asset to S3

### DIFF
--- a/src/crons/nft/nft.cron.module.ts
+++ b/src/crons/nft/nft.cron.module.ts
@@ -4,6 +4,7 @@ import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
 import { CollectionModule } from 'src/endpoints/collections/collection.module';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { NftCronService } from './nft.cron.service';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { NftCronService } from './nft.cron.service';
     NftWorkerModule,
     NftModule,
     CollectionModule,
+    DynamicModuleUtils.getCachingModule(),
   ],
   providers: [
     NftCronService,

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -48,10 +48,10 @@ export class NftCronService {
     }
 
     let lastProcessedTimestamp = await this.cachingService.getCache<number>(CacheInfo.LastProcessedTimestamp.key) ?? Math.floor(Date.now() / 1000);
-    this.logger.log(`Last processed timestamp until now: ${lastProcessedTimestamp} (${new Date(lastProcessedTimestamp)})`);
+    this.logger.log(`Last processed timestamp until now: ${lastProcessedTimestamp} (${new Date(lastProcessedTimestamp * 1000)})`);
 
     await Locker.lock('Process NFTs whitelisted', async () => {
-      const nfts = await this.nftService.getNfts(new QueryPagination({ from: 0, size: 10000 }), new NftFilter({ isWhitelistedStorage: true, hasUris: true, before: lastProcessedTimestamp }));
+      const nfts = await this.nftService.getNfts(new QueryPagination({ from: 0, size: 2500 }), new NftFilter({ isWhitelistedStorage: true, hasUris: true, before: lastProcessedTimestamp }));
 
       await Promise.all(nfts.map((nft: Nft) => this.nftWorkerService.addProcessNftQueueJob(nft, new ProcessNftSettings({ forceUploadAsset: true }))));
 

--- a/src/endpoints/process-nfts/entities/process.nft.request.ts
+++ b/src/endpoints/process-nfts/entities/process.nft.request.ts
@@ -22,4 +22,7 @@ export class ProcessNftRequest {
 
   @ApiProperty({ type: Boolean, nullable: true })
   skipRefreshThumbnail?: boolean;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  forceUploadAsset?: boolean;
 }

--- a/src/endpoints/process-nfts/entities/process.nft.settings.ts
+++ b/src/endpoints/process-nfts/entities/process.nft.settings.ts
@@ -5,6 +5,7 @@ export class ProcessNftSettings {
   forceRefreshMetadata: boolean = false;
   forceRefreshThumbnail: boolean = false;
   skipRefreshThumbnail: boolean = false;
+  forceUploadAsset: boolean = false;
 
   constructor(init?: Partial<ProcessNftSettings>) {
     Object.assign(this, init);
@@ -16,6 +17,7 @@ export class ProcessNftSettings {
       forceRefreshMetadata: processNftRequest.forceRefreshMetadata ?? false,
       forceRefreshThumbnail: processNftRequest.forceRefreshThumbnail ?? false,
       skipRefreshThumbnail: processNftRequest.skipRefreshThumbnail ?? false,
+      forceUploadAsset: processNftRequest.forceUploadAsset ?? false,
     });
   }
 }

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -45,7 +45,7 @@ export class NftWorkerService {
       return false;
     }
 
-    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail) {
+    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail || settings.forceUploadAsset) {
       return true;
     }
 

--- a/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.module.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.module.ts
@@ -1,0 +1,11 @@
+import { ApiModule } from "@elrondnetwork/erdnest";
+import { Module } from "@nestjs/common";
+import { AWSService } from "../thumbnails/aws.service";
+import { NftAssetService } from "./nft.asset.service";
+
+@Module({
+  imports: [ApiModule],
+  providers: [NftAssetService, AWSService],
+  exports: [NftAssetService],
+})
+export class NftAssetModule { }

--- a/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
@@ -21,7 +21,8 @@ export class NftAssetService {
     const fileResult: any = await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS });
     const file = fileResult.data;
 
-    const fileName = fileUrl.split('/').slice(-2, -1);
+    //TO DO: use a better euristic to extract file name
+    const fileName = fileUrl.split('/').slice(-2).join('/');
     this.logger.log(`Extracted filename '${fileName}' for NFT '${identifier}'`);
 
     const filePath = `${this.STANDARD_PATH}/${fileName}`;

--- a/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
@@ -1,0 +1,33 @@
+import { ApiService, Constants } from "@elrondnetwork/erdnest";
+import { Injectable, Logger } from "@nestjs/common";
+import { AWSService } from "../thumbnails/aws.service";
+
+@Injectable()
+export class NftAssetService {
+  private readonly logger: Logger;
+  private readonly API_TIMEOUT_MILLISECONDS = Constants.oneSecond() * 30 * 1000;
+  private readonly STANDARD_PATH: string = 'nfts/asset';
+
+  constructor(
+    private readonly apiService: ApiService,
+    private readonly awsService: AWSService
+  ) {
+    this.logger = new Logger(NftAssetService.name);
+  }
+
+  async uploadAsset(identifier: string, fileUrl: string, fileType: string) {
+    this.logger.log(`Started uploading assets to S3 for NFT '${identifier}'`);
+
+    const fileResult: any = await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS });
+    const file = fileResult.data;
+
+    const fileName = fileUrl.split('/').slice(-2, -1);
+    this.logger.log(`Extracted filename '${fileName}' for NFT '${identifier}'`);
+
+    const filePath = `${this.STANDARD_PATH}/${fileName}`;
+
+    await this.awsService.uploadToS3(filePath, file, fileType);
+
+    this.logger.log(`Asset uploaded to S3 for NFT '${identifier}'`);
+  }
+}

--- a/src/queue.worker/nft.worker/queue/job-services/nft.job.processor.module.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/nft.job.processor.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { NftAssetModule } from './assets/nft.asset.module';
 import { NftMediaModule } from './media/nft.media.module';
 import { NftMetadataModule } from './metadata/nft.metadata.module';
 import { NftThumbnailModule } from './thumbnails/nft.thumbnail.module';
@@ -8,11 +9,13 @@ import { NftThumbnailModule } from './thumbnails/nft.thumbnail.module';
     NftMediaModule,
     NftMetadataModule,
     NftThumbnailModule,
+    NftAssetModule,
   ],
   exports: [
     NftMediaModule,
     NftMetadataModule,
     NftThumbnailModule,
+    NftAssetModule,
   ],
 })
 export class NftJobProcessorModule { }

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -10,6 +10,7 @@ import { NftMediaService } from "./job-services/media/nft.media.service";
 import { NftMetadataService } from "./job-services/metadata/nft.metadata.service";
 import { GenerateThumbnailResult } from "./job-services/thumbnails/entities/generate.thumbnail.result";
 import { NftThumbnailService } from "./job-services/thumbnails/nft.thumbnail.service";
+import { NftAssetService } from "./job-services/assets/nft.asset.service";
 
 @Controller()
 export class NftQueueController {
@@ -21,6 +22,7 @@ export class NftQueueController {
     private readonly nftMediaService: NftMediaService,
     private readonly nftThumbnailService: NftThumbnailService,
     private readonly nftService: NftService,
+    private readonly nftAssetService: NftAssetService,
     @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
     apiConfigService: ApiConfigService,
   ) {
@@ -89,6 +91,10 @@ export class NftQueueController {
 
       if (nft.media && !settings.skipRefreshThumbnail) {
         await Promise.all(nft.media.map((media: any) => this.generateThumbnail(nft, media, settings.forceRefreshThumbnail)));
+      }
+
+      if (nft.media) {
+        await Promise.all(nft.media.map((media: NftMedia) => this.nftAssetService.uploadAsset(nft.identifier, media.originalUrl, media.fileType)));
       }
 
       this.logger.log({ type: 'consumer end', identifier: data.identifier });

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -9,6 +9,11 @@ export class CacheInfo {
     ttl: Constants.oneMinute() * 10,
   };
 
+  static LastProcessedTimestamp: CacheInfo = {
+    key: 'lastProcessedTimestamp',
+    ttl: Constants.oneWeek() * 2,
+  };
+
   static Nodes: CacheInfo = {
     key: 'nodes',
     ttl: Constants.oneHour(),


### PR DESCRIPTION
## Problem setting
- NFT original assets retrieved from IPFS or other slow storages
  
## Proposed Changes
- Process NFT original asset (download from IPFS & upload to S3)
- Add a cronjob to process old NFT collections
- Add possibility to request forceUploadAsset from /nfts/process endpoint [public & private(owner only)]

## How to test
- Find one nft for which original asset isn't uploaded to S3 (https://media.elrond.com)
- Use /nfts/process with forceUploadAsset=true 
- Check if original asset from S3 is the same with the one from original storage 