### PR TITLE
Network regex for keybase identities

### DIFF
--- a/src/common/keybase/keybase.module.ts
+++ b/src/common/keybase/keybase.module.ts
@@ -1,6 +1,7 @@
 import { forwardRef, Module } from "@nestjs/common";
 import { NodeModule } from "src/endpoints/nodes/node.module";
 import { ProviderModule } from "src/endpoints/providers/provider.module";
+import { ApiConfigModule } from "../api-config/api.config.module";
 import { GithubModule } from "../github/github.module";
 import { KeybaseService } from "./keybase.service";
 
@@ -9,6 +10,7 @@ import { KeybaseService } from "./keybase.service";
     forwardRef(() => NodeModule),
     forwardRef(() => ProviderModule),
     forwardRef(() => GithubModule),
+    ApiConfigModule,
   ],
   providers: [
     KeybaseService,

--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -144,8 +144,10 @@ export class KeybaseService {
 
   async confirmKeybasesAgainstKeybasePubForIdentity(identity: string): Promise<void> {
     const network = this.apiConfigService.getNetwork();
+    const networkSuffix = network !== "mainnet" ? `/${network}` : '';
+
     // eslint-disable-next-line require-await
-    const result = await this.apiService.get(`https://keybase.pub/${identity}/elrond${network !== "mainnet" ? `/${network}` : ''}`, { timeout: 100000 }, async (error) => error.response?.status === HttpStatus.NOT_FOUND);
+    const result = await this.apiService.get(`https://keybase.pub/${identity}/elrond${networkSuffix}`, { timeout: 100000 }, async (error) => error.response?.status === HttpStatus.NOT_FOUND);
 
     if (!result) {
       this.logger.log(`For identity '${identity}', no keybase.pub entry was found`);
@@ -156,7 +158,7 @@ export class KeybaseService {
 
     const networkRegex = network !== "mainnet" ? `${network}\/` : '';
 
-    const nodesRegex = new RegExp("https:\/\/keybase.pub\/" + identity + "\/elrond\/" + networkRegex + "[0-9a-f]{192}", 'g');
+    const nodesRegex = new RegExp(`https:\/\/keybase.pub\/${identity}\/elrond\/${networkRegex}[0-9a-f]{192}`, 'g');
     const blses: string[] = [];
     for (const keybaseUrl of html.match(nodesRegex) || []) {
       const bls = keybaseUrl.match(/[0-9a-f]{192}/)[0];


### PR DESCRIPTION
## Problem setting
- Identities not shown in explorer for testnet & devnet providers
  
## Proposed Changes
- Extend keybase regex to match devnet & testnet identities

## How to test
- Start a testnet or devnet instance and check if identities appear for providers and nodes
- Start a mainnet instance and check if identities are the same