### PR TITLE
Adjust rarity field names

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -582,8 +582,8 @@ export class NftService {
   }
 
   applyExtendedAttributes(nft: Nft, elasticNft: any) {
-    nft.score = elasticNft.nft_score;
-    nft.rank = elasticNft.nft_rank;
+    nft.score = elasticNft.nft_rarity_score;
+    nft.rank = elasticNft.nft_rarity_rank;
 
     if (elasticNft.nft_nsfw_mark !== undefined) {
       nft.isNsfw = elasticNft.nft_nsfw_mark >= this.apiConfigService.getNftExtendedAttributesNsfwThreshold();


### PR DESCRIPTION
## Proposed Changes
- adjust attribute names for rank & score to the new ones

## How to test (mainnet)
- `/nfts/ULTRAS-3875ff-025d` should contain `score` & `rank`