### PR TITLE
change output to jpeg since png creates too heavy images

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -34,7 +34,7 @@ export class NftThumbnailService {
             fit: fit.cover,
           }
         )
-        .png({ progressive: true })
+        .jpeg({ progressive: true })
         .toBuffer();
     } catch (error: any) {
       this.logger.error(error);


### PR DESCRIPTION
## Problem setting
- Sharp PNG output creates too heavy images for NFT thumbnails
  
## Proposed Changes
- Use JPEG output instead

## How to test
- Create write streams from output buffers and compare file size