### PR TITLE
Removed support for accessAddress in jwt global authenticator

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -89,7 +89,6 @@ inflation:
 security:
   admins:
   jwtSecret:
-  accessAddress:
 nftProcess:
   parallelism: 1
   maxRetries: 3

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -92,7 +92,6 @@ inflation:
 security:
   admins:
   jwtSecret:
-  accessAddress:
 nftProcess:
   parallelism: 1
   maxRetries: 3

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -89,7 +89,6 @@ inflation:
 security:
   admins:
   jwtSecret:
-  accessAddress:
 nftProcess:
   parallelism: 1
   maxRetries: 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^8.0.0",
-        "@elrondnetwork/erdnest": "^0.1.12",
+        "@elrondnetwork/erdnest": "^0.1.15",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.13.tgz",
-      "integrity": "sha512-QXbKpgc/kmPsjR+Gkk3J5OmDCyLfkukILimcC046shHFH7b8q+y5Lndmtz/uqrOSfK9y8CKRhgIhl51H9d5//w==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.15.tgz",
+      "integrity": "sha512-qdimr/0N3j2xrVyLKtekUqxHcbv9fGkzEzxXXcj+GX4QCesC1vzSZPy6QR0NzhtHeq1vKciOeNzzXxEmK2+Dqg==",
       "dependencies": {
         "@elrondnetwork/native-auth": "^0.1.20",
         "@types/redis": "^2.8.32",
@@ -17171,9 +17171,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.13.tgz",
-      "integrity": "sha512-QXbKpgc/kmPsjR+Gkk3J5OmDCyLfkukILimcC046shHFH7b8q+y5Lndmtz/uqrOSfK9y8CKRhgIhl51H9d5//w==",
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.15.tgz",
+      "integrity": "sha512-qdimr/0N3j2xrVyLKtekUqxHcbv9fGkzEzxXXcj+GX4QCesC1vzSZPy6QR0NzhtHeq1vKciOeNzzXxEmK2+Dqg==",
       "requires": {
         "@elrondnetwork/native-auth": "^0.1.20",
         "@types/redis": "^2.8.32",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2216,9 +2216,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.15.tgz",
-      "integrity": "sha512-qdimr/0N3j2xrVyLKtekUqxHcbv9fGkzEzxXXcj+GX4QCesC1vzSZPy6QR0NzhtHeq1vKciOeNzzXxEmK2+Dqg==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.16.tgz",
+      "integrity": "sha512-FO4jSBvw5GRWXtdGMvb3TxnLSyWFCg2evbOOM6aRbKw2qJau2WYM7Z7BDwDBmUurO7xfBcJFKeTzZAQuP7NNtg==",
       "dependencies": {
         "@elrondnetwork/native-auth": "^0.1.20",
         "@types/redis": "^2.8.32",
@@ -17171,9 +17171,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.15.tgz",
-      "integrity": "sha512-qdimr/0N3j2xrVyLKtekUqxHcbv9fGkzEzxXXcj+GX4QCesC1vzSZPy6QR0NzhtHeq1vKciOeNzzXxEmK2+Dqg==",
+      "version": "0.1.16",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.16.tgz",
+      "integrity": "sha512-FO4jSBvw5GRWXtdGMvb3TxnLSyWFCg2evbOOM6aRbKw2qJau2WYM7Z7BDwDBmUurO7xfBcJFKeTzZAQuP7NNtg==",
       "requires": {
         "@elrondnetwork/native-auth": "^0.1.20",
         "@types/redis": "^2.8.32",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^8.0.0",
-    "@elrondnetwork/erdnest": "^0.1.13",
+    "@elrondnetwork/erdnest": "^0.1.15",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^8.0.0",
-    "@elrondnetwork/erdnest": "^0.1.15",
+    "@elrondnetwork/erdnest": "^0.1.16",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -565,10 +565,6 @@ export class ApiConfigService {
     return jwtSecret;
   }
 
-  getAccessAddress(): string {
-    return this.configService.get<string>('security.accessAddress') ?? '';
-  }
-
   getMockKeybases(): boolean | undefined {
     return this.configService.get<boolean>('test.mockKeybases');
   }

--- a/src/common/api-config/erdnest.config.service.impl.ts
+++ b/src/common/api-config/erdnest.config.service.impl.ts
@@ -15,9 +15,4 @@ export class ErdnestConfigServiceImpl implements ErdnestConfigService {
   getJwtSecret(): string {
     return this.apiConfigService.getJwtSecret();
   }
-
-  getAccessAddress(): string {
-    return this.apiConfigService.getAccessAddress();
-  }
-
 }

--- a/src/test/integration/api.config.e2e-spec.ts
+++ b/src/test/integration/api.config.e2e-spec.ts
@@ -1290,26 +1290,6 @@ describe('API Config', () => {
     });
   });
 
-  describe("getAccessAddress", () => {
-    it("should return access address", () => {
-      jest
-        .spyOn(ConfigService.prototype, "get")
-        .mockImplementation(jest.fn(() => ['address1, aaddress2']));
-
-      const results = apiConfigService.getAccessAddress();
-      expect(results).toEqual(['address1, aaddress2']);
-    });
-
-    it("should return default access address", () => {
-      jest
-        .spyOn(ConfigService.prototype, 'get')
-        .mockImplementation(jest.fn(() => undefined));
-
-      const results = apiConfigService.getAccessAddress();
-      expect(results).toEqual('');
-    });
-  });
-
   describe("getMockKeybases", () => {
     it("should return mock keybases flag", () => {
       jest


### PR DESCRIPTION
## Proposed Changes
- Validate any correctly emitted jwt, not only from a specified `accessAddress`, meaning that when the global authentication flag is activated, a jwt emitted from i.e. web wallet can be used without any issues

## How to test
- when setting `api.auth: true`, any emitted jwt using the given secret is allowed