### PR TITLE
Support for full history nodes

### DIFF
--- a/src/endpoints/nodes/entities/node.filter.ts
+++ b/src/endpoints/nodes/entities/node.filter.ts
@@ -18,6 +18,7 @@ export class NodeFilter {
   provider: string | undefined;
   owner: string | undefined;
   auctioned: boolean | undefined;
+  fullHistory: boolean | undefined;
   sort: NodeSort | undefined;
   order: SortOrder | undefined;
 } 

--- a/src/endpoints/nodes/entities/node.ts
+++ b/src/endpoints/nodes/entities/node.ts
@@ -94,4 +94,7 @@ export class Node {
 
   @ApiProperty({ type: Boolean, nullable: true })
   auctionSelected: boolean | undefined = undefined;
+
+  @ApiProperty({ type: Boolean, nullable: true })
+  fullHistory: boolean | undefined = undefined;
 }

--- a/src/endpoints/nodes/node.controller.ts
+++ b/src/endpoints/nodes/node.controller.ts
@@ -31,6 +31,7 @@ export class NodeController {
   @ApiQuery({ name: 'provider', description: 'Node provider', required: false })
   @ApiQuery({ name: 'owner', description: 'Node owner', required: false })
   @ApiQuery({ name: 'auctioned', description: 'Whether node is auctioned or not', required: false, type: 'boolean' })
+  @ApiQuery({ name: 'fullHistory', description: 'Whether node is of type \'Full History\' or not', required: false, type: 'boolean' })
   @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false, enum: SortNodes })
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   async getNodes(
@@ -46,10 +47,11 @@ export class NodeController {
     @Query('provider', ParseAddressPipe) provider?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('auctioned', ParseOptionalBoolPipe) auctioned?: boolean,
+    @Query('fullHistory', ParseOptionalBoolPipe) fullHistory?: boolean,
     @Query('sort', new ParseOptionalEnumPipe(NodeSort)) sort?: NodeSort,
     @Query('order', new ParseOptionalEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Node[]> {
-    return await this.nodeService.getNodes(new QueryPagination({ from, size }), new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, sort, order }));
+    return await this.nodeService.getNodes(new QueryPagination({ from, size }), new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, fullHistory, sort, order }));
   }
 
   @Get("/nodes/versions")
@@ -72,6 +74,7 @@ export class NodeController {
   @ApiQuery({ name: 'provider', description: 'Node provider', required: false })
   @ApiQuery({ name: 'owner', description: 'Node owner', required: false })
   @ApiQuery({ name: 'auctioned', description: 'Whether node is auctioned or not', required: false, type: 'boolean' })
+  @ApiQuery({ name: 'fullHistory', description: 'Whether node is of type \'Full History\' or not', required: false, type: 'boolean' })
   @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false, enum: SortNodes })
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   getNodeCount(
@@ -85,10 +88,11 @@ export class NodeController {
     @Query('provider', ParseAddressPipe) provider?: string,
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('auctioned', ParseOptionalBoolPipe) auctioned?: boolean,
+    @Query('fullHistory', ParseOptionalBoolPipe) fullHistory?: boolean,
     @Query('sort', new ParseOptionalEnumPipe(NodeSort)) sort?: NodeSort,
     @Query('order', new ParseOptionalEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<number> {
-    return this.nodeService.getNodeCount(new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, sort, order }));
+    return this.nodeService.getNodeCount(new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, fullHistory, sort, order }));
   }
 
   @Get("/nodes/c")
@@ -103,11 +107,12 @@ export class NodeController {
     @Query('identity') identity?: string,
     @Query('provider', ParseAddressPipe) provider?: string,
     @Query('auctioned', ParseOptionalBoolPipe) auctioned?: boolean,
+    @Query('fullHistory', ParseOptionalBoolPipe) fullHistory?: boolean,
     @Query('owner', ParseAddressPipe) owner?: string,
     @Query('sort', new ParseOptionalEnumPipe(NodeSort)) sort?: NodeSort,
     @Query('order', new ParseOptionalEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<number> {
-    return this.nodeService.getNodeCount(new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, sort, order }));
+    return this.nodeService.getNodeCount(new NodeFilter({ search, online, type, status, shard, issues, identity, provider, owner, auctioned, fullHistory, sort, order }));
   }
 
   @Get('/nodes/:bls')

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -161,6 +161,16 @@ export class NodeService {
         return false;
       }
 
+      if (query.fullHistory !== undefined) {
+        if (query.fullHistory === true && !node.fullHistory) {
+          return false;
+        }
+
+        if (query.fullHistory === false && node.fullHistory === true) {
+          return false;
+        }
+      }
+
       if (query.sort && !(query.sort in node)) {
         return false;
       }
@@ -520,7 +530,7 @@ export class NodeService {
         nodeStatus = peerType ? peerType : validatorStatus;
       }
 
-      const node: Node = {
+      const node: Node = new Node({
         bls,
         name,
         version: version ? (version.includes('-rc') ? version.split('-').slice(0, 2).join('-').split('/')[0] : version.split('-')[0].split('/')[0]) : '',
@@ -528,6 +538,7 @@ export class NodeService {
         rating: parseFloat(parseFloat(rating).toFixed(2)),
         tempRating: parseFloat(parseFloat(tempRating).toFixed(2)),
         ratingModifier: ratingModifier ? ratingModifier : 0,
+        fullHistory: item.peerSubType === 1 ? true : undefined,
         shard,
         type: nodeType,
         status: nodeStatus,
@@ -550,7 +561,7 @@ export class NodeService {
         auctionPosition: undefined,
         auctionTopUp: undefined,
         auctionSelected: undefined,
-      };
+      });
 
       if (['queued', 'jailed'].includes(peerType)) {
         node.shard = undefined;


### PR DESCRIPTION
## Proposed Changes
- Add `fullHistory` attribute in node list / details

## How to test (mainnet)
- `/nodes?size=5000` should return for ~70 nodes `fullHistory: true`
- `/nodes/count?fullHistory=true` should return only nodes which contain `fullHistory: true`
- `/nodes/count?fullHistory=false` should return only nodes which do not have `fullHistory` attribute at all
- `/nodes/count?fullHistory=true` should return ~70
- `/nodes/count?fullHistory=false` should return node count minus count of full history