### PR TITLE
Fix token properties fetching for non-ESDT events

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -56,7 +56,7 @@ export class TokenTransferService {
     const identifiers: string[] = [];
     for (const log of logs) {
       for (const event of log.events) {
-        const action = this.getOperationAction(event.identifier);
+        const action = this.getOperationEsdtActionByEventIdentifier(event.identifier);
         if (action) {
           identifiers.push(BinaryUtils.base64Decode(event.topics[0]));
         }
@@ -130,18 +130,18 @@ export class TokenTransferService {
     const operations: TransactionOperation[] = [];
     for (const log of logs) {
       for (const event of log.events) {
-        const action = this.getOperationAction(event.identifier);
-        if (!action) {
-          continue;
+        let operation;
+        if (event.identifier === TransactionOperationAction.writeLog || event.identifier === TransactionOperationAction.signalError) {
+          operation = this.getTransactionLogOperation(log, event, event.identifier, sender);
+        } else if (event.identifier === TransactionOperationAction.transferValueOnly) {
+          operation = this.getTransactionTransferValueOperation(txHash, log, event, event.identifier);
         }
 
-        let operation;
-        if (action === TransactionOperationAction.writeLog || action === TransactionOperationAction.signalError) {
-          operation = this.getTransactionLogOperation(log, event, action, sender);
-        } else if (action === TransactionOperationAction.transferValueOnly) {
-          operation = this.getTransactionTransferValueOperation(txHash, log, event, action);
-        } else {
-          operation = this.getTransactionNftOperation(txHash, log, event, action, tokensProperties);
+        if (!operation) {
+          const action = this.getOperationEsdtActionByEventIdentifier(event.identifier);
+          if (action) {
+            operation = this.getTransactionNftOperation(txHash, log, event, action, tokensProperties);
+          }
         }
 
         if (operation) {
@@ -179,13 +179,10 @@ export class TokenTransferService {
     return operation;
   }
 
-
-  private getOperationAction(identifier: string): TransactionOperationAction | null {
+  private getOperationEsdtActionByEventIdentifier(identifier: string): TransactionOperationAction | null {
     switch (identifier) {
       case TransactionLogEventIdentifier.ESDTNFTTransfer:
         return TransactionOperationAction.transfer;
-      case TransactionLogEventIdentifier.transferValueOnly:
-        return TransactionOperationAction.transferValueOnly;
       case TransactionLogEventIdentifier.ESDTNFTBurn:
         return TransactionOperationAction.burn;
       case TransactionLogEventIdentifier.ESDTNFTAddQuantity:
@@ -206,10 +203,6 @@ export class TokenTransferService {
         return TransactionOperationAction.wipe;
       case TransactionLogEventIdentifier.ESDTFreeze:
         return TransactionOperationAction.freeze;
-      case TransactionLogEventIdentifier.writeLog:
-        return TransactionOperationAction.writeLog;
-      case TransactionLogEventIdentifier.signalError:
-        return TransactionOperationAction.signalError;
       default:
         return null;
     }


### PR DESCRIPTION
## Problem setting
- Token properties were fetched incorrectly in case of non-esdt events
  
## Proposed Changes
- do not fetch token properties for `transferValueOnly`, `writeLog` or `signalError`

## How to test
- `/transactions?withOperations=true` should not attempt to load token properties for events `transferValueOnly`, `writeLog` or `signalError`
  - when running command `KEYS esdt:*` in redis, keys containing tokens only should be returned, and not something like `esdt:\x00\x00\x00\x00\x00\x00\x00\x00\x05\x00\xc3\x93\xc2\xb2\xc2\x88(\xc3\x96 R\x12O\a\xc3\x9c\xc3\x95\x0e\xc3\x93\x1b\b%\xc3\xb6\x0e\xc3\xae\x15&`