### PR TITLE
Restore transaction logging

### DIFF
--- a/src/interceptors/transaction.logging.interceptor.ts
+++ b/src/interceptors/transaction.logging.interceptor.ts
@@ -1,0 +1,67 @@
+import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { ProxyController } from "src/endpoints/proxy/proxy.controller";
+import { TransactionController } from "src/endpoints/transactions/transaction.controller";
+import winston from "winston";
+import DailyRotateFile from "winston-daily-rotate-file";
+
+@Injectable()
+export class TransactionLoggingInterceptor implements NestInterceptor {
+  private readonly transactionLogger: winston.Logger;
+  private readonly logger: Logger;
+
+  constructor() {
+    this.transactionLogger = winston.createLogger({
+      format: winston.format.json({
+        replacer: (key: string, value: any) => {
+          if (key === '') {
+            return {
+              ...value.message,
+              level: value.level,
+            };
+          }
+
+          return value;
+        },
+      }),
+      transports: [
+        new DailyRotateFile({
+          filename: 'application-%DATE%.log',
+          datePattern: 'YYYY-MM-DD-HH',
+          zippedArchive: true,
+          maxSize: '20m',
+          maxFiles: '14d',
+          createSymlink: true,
+          dirname: 'dist/logs',
+          symlinkName: 'application.log',
+        }),
+      ],
+    });
+
+    this.logger = new Logger(TransactionLoggingInterceptor.name);
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const apiFunction = context.getClass().name + '.' + context.getHandler().name;
+
+    const request = context.getArgByIndex(0);
+
+    const isCreateTransactionCall = context.getClass().name === TransactionController.name && context.getHandler().name === 'createTransaction';
+    const isSendTransactionCall = context.getClass().name === ProxyController.name && context.getHandler().name === 'transactionSend';
+
+    if (isCreateTransactionCall || isSendTransactionCall) {
+      const logBody = {
+        apiFunction,
+        body: request.body,
+        userAgent: request.headers['user-agent'],
+        clientIp: request.clientIp,
+      };
+
+      this.transactionLogger.info(logBody);
+      this.logger.log(logBody);
+    }
+
+    return next
+      .handle();
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ import { ApiConfigModule } from './common/api-config/api.config.module';
 import { JwtAuthenticateGlobalGuard, CachingService, LoggerInitializer, LoggingInterceptor, MetricsService, CachingInterceptor, LogRequestsInterceptor, FieldsInterceptor, ExtractInterceptor, CleanupInterceptor, PaginationInterceptor, QueryCheckInterceptor } from '@elrondnetwork/erdnest';
 import { ErdnestConfigServiceImpl } from './common/api-config/erdnest.config.service.impl';
 import { RabbitMqModule } from './common/rabbitmq/rabbitmq.module';
+import { TransactionLoggingInterceptor } from './interceptors/transaction.logging.interceptor';
 
 async function bootstrap() {
   const apiConfigApp = await NestFactory.create(ApiConfigModule);
@@ -173,6 +174,7 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   globalInterceptors.push(new PaginationInterceptor());
   // @ts-ignore
   globalInterceptors.push(new QueryCheckInterceptor(httpAdapterHostService));
+  globalInterceptors.push(new TransactionLoggingInterceptor());
 
   await pluginService.bootstrapPublicApp(publicApp);
 


### PR DESCRIPTION
## Proposed Changes
- Restore logging of transactions as before

## How to test
- Transactions sent on the `POST /transaction/send` or `POST /transactions` endpoints should log tx details