### PR TITLE
Account assets for transaction

### DIFF
--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -169,8 +169,6 @@ export class AssetsService {
       }
     }
 
-    console.log({ providers, identities, pairs });
-
     if (providers && identities) {
       for (const provider of providers) {
         const identity = identities.find(x => x.identity === provider.identity);

--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -177,7 +177,7 @@ export class AssetsService {
         }
 
         allAssets[provider.provider] = new AccountAssets({
-          name: identity.name ?? '',
+          name: `Staking: ${identity.name ?? ''}`,
           description: identity.description ?? '',
           iconPng: identity.avatar,
           tags: ['staking', 'provider'],

--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -5,6 +5,11 @@ import { TokenAssets } from "src/common/assets/entities/token.assets";
 import { ApiConfigService } from "../api-config/api.config.service";
 import { AccountAssets } from "./entities/account.assets";
 import { ApiUtils, CachingService, FileUtils } from "@elrondnetwork/erdnest";
+import { Provider } from "src/endpoints/providers/entities/provider";
+import { MexPair } from "src/endpoints/mex/entities/mex.pair";
+import { Identity } from "src/endpoints/identities/entities/identity";
+import { MexFarm } from "src/endpoints/mex/entities/mex.farm";
+import { MexSettings } from "src/endpoints/mex/entities/mex.settings";
 const rimraf = require("rimraf");
 const path = require('path');
 const fs = require('fs');
@@ -135,7 +140,7 @@ export class AssetsService {
     );
   }
 
-  getAllAccountAssetsRaw(): { [key: string]: AccountAssets } {
+  getAllAccountAssetsRaw(providers?: Provider[], identities?: Identity[], pairs?: MexPair[], farms?: MexFarm[], mexSettings?: MexSettings): { [key: string]: AccountAssets } {
     const accountAssetsPath = this.getAccountAssetsPath();
     if (!fs.existsSync(accountAssetsPath)) {
       return {};
@@ -162,6 +167,61 @@ export class AssetsService {
         this.logger.error(`An error occurred while reading assets for account with address '${address}'`);
         this.logger.error(error);
       }
+    }
+
+    console.log({ providers, identities, pairs });
+
+    if (providers && identities) {
+      for (const provider of providers) {
+        const identity = identities.find(x => x.identity === provider.identity);
+        if (!identity) {
+          continue;
+        }
+
+        allAssets[provider.provider] = new AccountAssets({
+          name: identity.name ?? '',
+          description: identity.description ?? '',
+          iconPng: identity.avatar,
+          tags: ['staking', 'provider'],
+        });
+      }
+    }
+
+    if (pairs) {
+      for (const pair of pairs) {
+        allAssets[pair.address] = new AccountAssets({
+          name: `MEX ${pair.baseSymbol}/${pair.quoteSymbol} Liquidity Pool`,
+          tags: ['mex', 'liquiditypool'],
+        });
+      }
+    }
+
+    if (farms) {
+      for (const farm of farms) {
+        allAssets[farm.address] = new AccountAssets({
+          name: `MEX ${farm.name} Farm`,
+          tags: ['mex', 'farm'],
+        });
+      }
+    }
+
+    if (mexSettings) {
+      for (const [index, wrapContract] of mexSettings.wrapContracts.entries()) {
+        allAssets[wrapContract] = new AccountAssets({
+          name: `WrappedEGLD Contract Shard ${index}`,
+          tags: ['mex', 'wegld'],
+        });
+      }
+
+      allAssets[mexSettings.lockedAssetContract] = new AccountAssets({
+        name: `MEX Locked asset Contract`,
+        tags: ['mex', 'lockedasset'],
+      });
+
+      allAssets[mexSettings.distributionContract] = new AccountAssets({
+        name: `MEX Distribution Contract`,
+        tags: ['mex', 'lockedasset'],
+      });
     }
 
     return allAssets;

--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -206,7 +206,7 @@ export class AssetsService {
     if (mexSettings) {
       for (const [index, wrapContract] of mexSettings.wrapContracts.entries()) {
         allAssets[wrapContract] = new AccountAssets({
-          name: `WrappedEGLD Contract Shard ${index}`,
+          name: `ESDT: WrappedEGLD Contract Shard ${index}`,
           tags: ['mex', 'wegld'],
         });
       }

--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -188,7 +188,7 @@ export class AssetsService {
     if (pairs) {
       for (const pair of pairs) {
         allAssets[pair.address] = new AccountAssets({
-          name: `MEX ${pair.baseSymbol}/${pair.quoteSymbol} Liquidity Pool`,
+          name: `Maiar Exchange: ${pair.baseSymbol}/${pair.quoteSymbol} Liquidity Pool`,
           tags: ['mex', 'liquiditypool'],
         });
       }
@@ -197,7 +197,7 @@ export class AssetsService {
     if (farms) {
       for (const farm of farms) {
         allAssets[farm.address] = new AccountAssets({
-          name: `MEX ${farm.name} Farm`,
+          name: `Maiar Exchange: ${farm.name} Farm`,
           tags: ['mex', 'farm'],
         });
       }
@@ -212,12 +212,12 @@ export class AssetsService {
       }
 
       allAssets[mexSettings.lockedAssetContract] = new AccountAssets({
-        name: `MEX Locked asset Contract`,
+        name: `Maiar Exchange: Locked asset Contract`,
         tags: ['mex', 'lockedasset'],
       });
 
       allAssets[mexSettings.distributionContract] = new AccountAssets({
-        name: `MEX Distribution Contract`,
+        name: `Maiar Exchange: Distribution Contract`,
         tags: ['mex', 'lockedasset'],
       });
     }

--- a/src/common/assets/entities/account.assets.ts
+++ b/src/common/assets/entities/account.assets.ts
@@ -1,4 +1,8 @@
 export class AccountAssets {
+  constructor(init?: Partial<AccountAssets>) {
+    Object.assign(this, init);
+  }
+
   name: string = '';
   description: string = '';
   tags: string[] = [];

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -221,14 +221,20 @@ export class CacheWarmerService {
     }, true);
   }
 
-  @Cron(CronExpression.EVERY_10_MINUTES)
+  @Cron(CronExpression.EVERY_MINUTE)
   async handleTokenAssetsInvalidations() {
     await Locker.lock('Token assets invalidations', async () => {
       await this.assetsService.checkout();
       const assets = this.assetsService.getAllTokenAssetsRaw();
       await this.invalidateKey(CacheInfo.TokenAssets.key, assets, CacheInfo.TokenAssets.ttl);
 
-      const accountLabels = await this.assetsService.getAllAccountAssetsRaw();
+      const providers = await this.providerService.getAllProviders();
+      const identities = await this.identitiesService.getAllIdentities();
+      const pairs = await this.mexPairsService.getAllMexPairs();
+      const farms = await this.mexFarmsService.getAllMexFarms();
+      const settings = await this.mexSettingsService.getSettings();
+
+      const accountLabels = await this.assetsService.getAllAccountAssetsRaw(providers, identities, pairs, farms, settings ?? undefined);
       await this.invalidateKey(CacheInfo.AccountAssets.key, accountLabels, CacheInfo.AccountAssets.ttl);
     }, true);
   }

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -131,7 +131,7 @@ export class CacheWarmerService {
 
   @Cron(CronExpression.EVERY_MINUTE)
   async handleEsdtTokenInvalidations() {
-    await Locker.lock('Esdt tokens invalidations', async () => {
+    await Locker.lock('All Tokens invalidations', async () => {
       const tokens = await this.esdtService.getAllEsdtTokensRaw();
       await this.invalidateKey(CacheInfo.AllEsdtTokens.key, tokens, CacheInfo.AllEsdtTokens.ttl);
     }, true);

--- a/src/endpoints/sc-results/entities/smart.contract.result.ts
+++ b/src/endpoints/sc-results/entities/smart.contract.result.ts
@@ -1,5 +1,6 @@
 import { SwaggerUtils } from "@elrondnetwork/erdnest";
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { TransactionAction } from "src/endpoints/transactions/transaction-action/entities/transaction.action";
 import { TransactionLog } from "../../transactions/entities/transaction.log";
 
@@ -29,8 +30,14 @@ export class SmartContractResult {
   @ApiProperty({ type: String })
   sender: string = '';
 
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  senderAssets: AccountAssets | undefined = undefined;
+
   @ApiProperty({ type: String })
   receiver: string = '';
+
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  receiverAssets: AccountAssets | undefined = undefined;
 
   @ApiProperty({ type: String })
   relayedValue: string = '';

--- a/src/endpoints/sc-results/scresult.controller.ts
+++ b/src/endpoints/sc-results/scresult.controller.ts
@@ -8,7 +8,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { SmartContractResultFilter } from "./entities/smart.contract.result.filter";
 
 @Controller()
-@ApiTags('sc-results')
+@ApiTags('results')
 export class SmartContractResultController {
   constructor(private readonly scResultService: SmartContractResultService) { }
 

--- a/src/endpoints/sc-results/scresult.module.ts
+++ b/src/endpoints/sc-results/scresult.module.ts
@@ -1,10 +1,12 @@
 import { forwardRef, Module } from "@nestjs/common";
+import { AssetsModule } from "src/common/assets/assets.module";
 import { TransactionActionModule } from "../transactions/transaction-action/transaction.action.module";
 import { SmartContractResultService } from "./scresult.service";
 
 @Module({
   imports: [
     forwardRef(() => TransactionActionModule),
+    AssetsModule,
   ],
   providers: [
     SmartContractResultService,

--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -228,7 +228,7 @@ export class TokenTransferService {
 
       const type = nonce ? TransactionOperationType.nft : TransactionOperationType.esdt;
 
-      return { id: log.id ?? '', action, type, esdtType, collection, identifier, name, sender: event.address, receiver, value, decimals, svgUrl };
+      return { id: log.id ?? '', action, type, esdtType, collection, identifier, name, sender: event.address, receiver, value, decimals, svgUrl, senderAssets: undefined, receiverAssets: undefined };
     } catch (error) {
       this.logger.error(`Error when parsing NFT transaction log for tx hash '${txHash}' with action '${action}' and topics: ${event.topics}`);
       this.logger.error(error);

--- a/src/endpoints/transactions/entities/transaction.log.event.ts
+++ b/src/endpoints/transactions/entities/transaction.log.event.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 
 export class TransactionLogEvent {
   constructor(init?: Partial<TransactionLogEvent>) {
@@ -7,6 +8,9 @@ export class TransactionLogEvent {
 
   @ApiProperty()
   address: string = '';
+
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  addressAssets: AccountAssets | undefined = undefined;
 
   @ApiProperty()
   identifier: string = '';

--- a/src/endpoints/transactions/entities/transaction.log.ts
+++ b/src/endpoints/transactions/entities/transaction.log.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { TransactionLogEvent } from "./transaction.log.event";
 
 export class TransactionLog {
@@ -10,6 +11,9 @@ export class TransactionLog {
 
   @ApiProperty()
   address: string = '';
+
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  addressAssets: AccountAssets | undefined = undefined;
 
   @ApiProperty()
   events: TransactionLogEvent[] = [];

--- a/src/endpoints/transactions/entities/transaction.operation.ts
+++ b/src/endpoints/transactions/entities/transaction.operation.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { TokenType } from "src/endpoints/tokens/entities/token.type";
 import { TransactionOperationAction } from "./transaction.operation.action";
 import { TransactionOperationType } from "./transaction.operation.type";
@@ -35,8 +36,14 @@ export class TransactionOperation {
   @ApiProperty({ type: String })
   sender: string = '';
 
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  senderAssets: AccountAssets | undefined = undefined;
+
   @ApiProperty({ type: String })
   receiver: string = '';
+
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  receiverAssets: AccountAssets | undefined = undefined;
 
   @ApiProperty({ type: Number, nullable: true })
   decimals?: number;

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from "@nestjs/swagger";
+import { AccountAssets } from "src/common/assets/entities/account.assets";
 import { ScamInfo } from "src/common/entities/scam-info.dto";
 import { TransactionType } from "src/endpoints/transactions/entities/transaction.type";
 import { TransactionAction } from "../transaction-action/entities/transaction.action";
@@ -29,6 +30,9 @@ export class Transaction {
   @ApiProperty({ type: String })
   receiver: string = '';
 
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  receiverAssets: AccountAssets | undefined = undefined;
+
   @ApiProperty({ type: Number })
   receiverShard: number = 0;
 
@@ -37,6 +41,9 @@ export class Transaction {
 
   @ApiProperty({ type: String })
   sender: string = '';
+
+  @ApiProperty({ type: AccountAssets, nullable: true })
+  senderAssets: AccountAssets | undefined = undefined;
 
   @ApiProperty({ type: Number })
   senderShard: number = 0;

--- a/src/endpoints/transactions/transaction.module.ts
+++ b/src/endpoints/transactions/transaction.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from "@nestjs/common";
+import { AssetsModule } from "src/common/assets/assets.module";
 import { DataApiModule } from "src/common/external/data.api.module";
 import { PluginModule } from "src/plugins/plugin.module";
 import { TokenModule } from "../tokens/token.module";
@@ -13,6 +14,7 @@ import { TransactionService } from "./transaction.service";
     DataApiModule,
     forwardRef(() => PluginModule),
     TransactionActionModule,
+    AssetsModule,
   ],
   providers: [
     TransactionGetService, TransactionPriceService, TransactionService,

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -171,9 +171,7 @@ export class TransactionService {
 
     const assets = await this.assetsService.getAllAccountAssets();
     for (const transaction of transactions) {
-      await this.processTransaction(transaction);
-
-      await this.applyAssets(transaction, assets);
+      await this.processTransaction(transaction, assets);
     }
 
     return transactions;
@@ -305,7 +303,7 @@ export class TransactionService {
     }
   }
 
-  async processTransaction(transaction: Transaction): Promise<void> {
+  async processTransaction(transaction: Transaction, assets?: Record<string, AccountAssets>): Promise<void> {
     try {
       await this.pluginsService.processTransaction(transaction);
 
@@ -315,6 +313,8 @@ export class TransactionService {
       if (transaction.pendingResults === true) {
         transaction.status = TransactionStatus.pending;
       }
+
+      await this.applyAssets(transaction, assets);
     } catch (error) {
       this.logger.error(`Unhandled error when processing plugin transaction for transaction with hash '${transaction.txHash}'`);
       this.logger.error(error);

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -245,6 +245,10 @@ export class TransactionService {
 
     if (transaction.logs) {
       transaction.logs.addressAssets = accountAssets[transaction.logs.address];
+
+      for (const event of transaction.logs.events) {
+        event.addressAssets = accountAssets[event.address];
+      }
     }
   }
 

--- a/src/endpoints/transfers/transfer.module.ts
+++ b/src/endpoints/transfers/transfer.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from "@nestjs/common";
+import { AssetsModule } from "src/common/assets/assets.module";
 import { TokenModule } from "../tokens/token.module";
 import { TransactionModule } from "../transactions/transaction.module";
 import { TransferService } from "./transfer.service";
@@ -8,6 +9,7 @@ import { TransferService } from "./transfer.service";
   imports: [
     forwardRef(() => TransactionModule),
     forwardRef(() => TokenModule),
+    AssetsModule,
   ],
   providers: [
     TransferService,

--- a/src/test/unit/utils/transaction.utils.spec.ts
+++ b/src/test/unit/utils/transaction.utils.spec.ts
@@ -177,7 +177,7 @@ describe('Transaction Utils', () => {
 
   it('trimOperations', () => {
     const operations: TransactionOperation[] = [
-      {
+      new TransactionOperation({
         id: "f592405c4d6556a5a680c3225ae7bd254b73c7c47cf032ec66936dbbb494ca4c",
         action: TransactionOperationAction.transfer,
         type: TransactionOperationType.esdt,
@@ -188,8 +188,8 @@ describe('Transaction Utils', () => {
         receiver: "erd1f04mhj7mjedkd4snav6zpyjtlgqpnp8hv5ex4sw38wck9ep09s8qhh5k5v",
         value: "25000000",
         decimals: 6,
-      },
-      {
+      }),
+      new TransactionOperation({
         id: "2199b2f2ebf591e1d05ee3c871546cffdc1eb4970a54eee707614aa9374935c0",
         action: TransactionOperationAction.transfer,
         type: TransactionOperationType.esdt,
@@ -200,7 +200,7 @@ describe('Transaction Utils', () => {
         receiver: "erd1f04mhj7mjedkd4snav6zpyjtlgqpnp8hv5ex4sw38wck9ep09s8qhh5k5v",
         value: "25000000",
         decimals: 6,
-      },
+      }),
     ];
 
     const previousHashes = {


### PR DESCRIPTION
## Proposed Changes
- Provide assets wherever an address is returned in the transaction list & details

## How to test (mainnet)
- `/transactions` should return `senderAssets` & `receiverAssets`
- `/transactions/f09434ed2c399fd2d0ca76b2674ff88f8e55626c8052a3b6beca92235736e8fb` should return assets for receiver, results, operations, logs