### PR TITLE
add support for webp image type for NFTs

### DIFF
--- a/src/endpoints/nfts/entities/media.mime.type.ts
+++ b/src/endpoints/nfts/entities/media.mime.type.ts
@@ -1,6 +1,7 @@
 export enum MediaMimeTypeEnum {
   png = 'image/png',
   jpeg = 'image/jpeg',
+  webp = 'image/webp',
   jpg = 'image/jpg',
   gif = 'image/gif',
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- The API can't process NFT thumbnails with webp file type because it isn't supported.
  
## Proposed Changes
- Add image/webp file type in in supported mime types enum

## How to test
- Create an NFT and upload a webp image as NFT asset
- Check if thumbnail is generated for your NFT