### PR TITLE
/tokens endpoint should also include what is returned in /collections…

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -6,6 +6,7 @@ import { KeybaseModule } from 'src/common/keybase/keybase.module';
 import { MexModule } from 'src/endpoints/mex/mex.module';
 import { AssetsModule } from 'src/common/assets/assets.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { CollectionModule } from '../../endpoints/collections/collection.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
     KeybaseModule,
     MexModule,
     AssetsModule,
+    CollectionModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -137,6 +137,14 @@ export class CacheWarmerService {
     }, true);
   }
 
+  @Cron(CronExpression.EVERY_MINUTE)
+  async handleMetaESDTTokensInvalidations() {
+    await Locker.lock('MetaEsdt tokens invalidations', async () => {
+      const tokens = await this.esdtService.getAllMetaESDTTokensRaw();
+      await this.invalidateKey(CacheInfo.AllMetaESDTTokens.key, tokens, CacheInfo.AllMetaESDTTokens.ttl);
+    }, true);
+  }
+
   async handleIdentityInvalidations() {
     await Locker.lock('Identities invalidations', async () => {
       const identities = await this.identitiesService.getAllIdentitiesRaw();

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -387,12 +387,12 @@ export class AccountController {
   }
 
   @Get("/accounts/:address/nfts")
-  @ApiOperation({ summary: 'Account NFTs', description: 'Returns a list of all available NFTs/SFTs/MetaESDTs owned by the provided address' })
+  @ApiOperation({ summary: 'Account NFTs', description: 'Returns a list of all available NFTs/SFTs owned by the provided address' })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Filter by identifiers, comma-separated', required: false })
-  @ApiQuery({ name: 'type', description: 'Filter by type (NonFungibleESDT/SemiFungibleESDT/MetaESDT)', required: false })
+  @ApiQuery({ name: 'type', description: 'Filter by type (NonFungibleESDT/SemiFungibleESDT)', required: false })
   @ApiQuery({ name: 'collection', description: 'Get all tokens by token collection. Deprecated, replaced by collections parameter', required: false, deprecated: true })
   @ApiQuery({ name: 'collections', description: 'Get all tokens by token collections, comma-separated', required: false })
   @ApiQuery({ name: 'name', description: 'Get all nfts by name', required: false })

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -15,7 +15,18 @@ import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { CollectionRoles } from "../tokens/entities/collection.roles";
 import { TokenUtils } from "src/utils/token.utils";
 import { NftCollectionAccount } from "./entities/nft.collection.account";
-import { ApiUtils, BinaryUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryType, QueryOperator, QueryConditionOptions, ElasticSortOrder } from "@elrondnetwork/erdnest";
+import {
+  ApiUtils,
+  BinaryUtils,
+  RecordUtils,
+  CachingService,
+  ElasticService,
+  ElasticQuery,
+  QueryType,
+  QueryOperator,
+  QueryConditionOptions,
+  ElasticSortOrder,
+} from '@elrondnetwork/erdnest';
 
 @Injectable()
 export class CollectionService {
@@ -33,7 +44,7 @@ export class CollectionService {
   buildCollectionRolesFilter(filter: CollectionFilter, address?: string) {
     let elasticQuery = ElasticQuery.create();
     elasticQuery = elasticQuery.withMustNotExistCondition('identifier')
-      .withMustMultiShouldCondition([NftType.MetaESDT, NftType.NonFungibleESDT, NftType.SemiFungibleESDT], type => QueryType.Match('type', type));
+      .withMustMultiShouldCondition([NftType.NonFungibleESDT, NftType.SemiFungibleESDT], type => QueryType.Match('type', type));
 
     if (address) {
       if (this.apiConfigService.getIsIndexerV3FlagActive()) {
@@ -87,7 +98,7 @@ export class CollectionService {
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
       .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
-      .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
+      .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT], type => QueryType.Match('type', type));
   }
 
   private getRoleCondition(query: ElasticQuery, name: string, address: string | undefined, value: string | boolean) {
@@ -223,7 +234,7 @@ export class CollectionService {
       return undefined;
     }
 
-    if (![NftType.MetaESDT, NftType.NonFungibleESDT, NftType.SemiFungibleESDT].includes(elasticCollection.type)) {
+    if (![NftType.NonFungibleESDT, NftType.SemiFungibleESDT].includes(elasticCollection.type)) {
       return undefined;
     }
 

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -1,24 +1,32 @@
-import { BadRequestException, forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
-import { QueryPagination } from "src/common/entities/query.pagination";
-import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
-import { GatewayService } from "src/common/gateway/gateway.service";
-import { ProtocolService } from "src/common/protocol/protocol.service";
-import { TokenUtils } from "src/utils/token.utils";
-import { EsdtDataSource } from "./entities/esdt.data.source";
-import { EsdtService } from "./esdt.service";
-import { GatewayNft } from "../nfts/entities/gateway.nft";
-import { NftAccount } from "../nfts/entities/nft.account";
-import { NftFilter } from "../nfts/entities/nft.filter";
-import { NftType } from "../nfts/entities/nft.type";
-import { NftExtendedAttributesService } from "../nfts/nft.extendedattributes.service";
-import { NftService } from "../nfts/nft.service";
-import { NftCollectionRole } from "../collections/entities/nft.collection.role";
-import { CollectionService } from "../collections/collection.service";
-import { NftCollection } from "../collections/entities/nft.collection";
-import { CollectionFilter } from "../collections/entities/collection.filter";
-import { CollectionRoles } from "../tokens/entities/collection.roles";
-import { AddressUtils, ApiUtils, BinaryUtils, CachingService, ElasticService, ElasticSortOrder, MetricsService } from "@elrondnetwork/erdnest";
+import { BadRequestException, forwardRef, Inject, Injectable, Logger } from '@nestjs/common';
+import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { QueryPagination } from 'src/common/entities/query.pagination';
+import { GatewayComponentRequest } from 'src/common/gateway/entities/gateway.component.request';
+import { GatewayService } from 'src/common/gateway/gateway.service';
+import { ProtocolService } from 'src/common/protocol/protocol.service';
+import { TokenUtils } from 'src/utils/token.utils';
+import { EsdtDataSource } from './entities/esdt.data.source';
+import { EsdtService } from './esdt.service';
+import { GatewayNft } from '../nfts/entities/gateway.nft';
+import { NftAccount } from '../nfts/entities/nft.account';
+import { NftFilter } from '../nfts/entities/nft.filter';
+import { NftType } from '../nfts/entities/nft.type';
+import { NftExtendedAttributesService } from '../nfts/nft.extendedattributes.service';
+import { NftService } from '../nfts/nft.service';
+import { NftCollectionRole } from '../collections/entities/nft.collection.role';
+import { CollectionService } from '../collections/collection.service';
+import { NftCollection } from '../collections/entities/nft.collection';
+import { CollectionFilter } from '../collections/entities/collection.filter';
+import { CollectionRoles } from '../tokens/entities/collection.roles';
+import {
+  AddressUtils,
+  ApiUtils,
+  BinaryUtils,
+  CachingService,
+  ElasticService,
+  ElasticSortOrder,
+  MetricsService,
+} from '@elrondnetwork/erdnest';
 
 @Injectable()
 export class EsdtAddressService {
@@ -238,8 +246,8 @@ export class EsdtAddressService {
     const collator = new Intl.Collator('en', { sensitivity: 'base' });
     nfts.sort((a: GatewayNft, b: GatewayNft) => collator.compare(a.tokenIdentifier, b.tokenIdentifier));
 
-    const nftAccounts: NftAccount[] = await this.mapToNftAccount(nfts);
-
+    let nftAccounts: NftAccount[] = await this.mapToNftAccount(nfts);
+    nftAccounts = nftAccounts.filter(x => [NftType.NonFungibleESDT, NftType.SemiFungibleESDT].includes(x.type));
     return this.filterEsdtsForAddressFromGateway(filter, pagination, nftAccounts);
   }
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -60,7 +60,8 @@ export class NftService {
 
   buildElasticNftFilter(filter: NftFilter, identifier?: string, address?: string) {
     let elasticQuery = ElasticQuery.create()
-      .withCondition(QueryConditionOptions.must, QueryType.Exists('identifier'));
+      .withCondition(QueryConditionOptions.must, QueryType.Exists('identifier'))
+      .withMustNotCondition(QueryType.Match('type', NftType.MetaESDT));
 
     if (address) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Match('address', address));

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -1,26 +1,41 @@
-import { Injectable, Logger } from "@nestjs/common";
-import { Token } from "./entities/token";
-import { TokenWithBalance } from "./entities/token.with.balance";
-import { TokenDetailed } from "./entities/token.detailed";
-import { QueryPagination } from "src/common/entities/query.pagination";
-import { TokenFilter } from "./entities/token.filter";
-import { TokenUtils } from "src/utils/token.utils";
-import { EsdtService } from "../esdt/esdt.service";
-import { TokenAccount } from "./entities/token.account";
-import { TokenType } from "./entities/token.type";
-import { EsdtAddressService } from "../esdt/esdt.address.service";
-import { GatewayService } from "src/common/gateway/gateway.service";
-import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
-import { TokenProperties } from "./entities/token.properties";
-import { TokenRoles } from "./entities/token.roles";
-import { TokenSupplyResult } from "./entities/token.supply.result";
-import { TokenDetailedWithBalance } from "./entities/token.detailed.with.balance";
-import { SortOrder } from "src/common/entities/sort.order";
-import { TokenSort } from "./entities/token.sort";
-import { TokenWithRoles } from "./entities/token.with.roles";
-import { TokenWithRolesFilter } from "./entities/token.with.roles.filter";
-import { AddressUtils, ApiUtils, ElasticQuery, ElasticService, ElasticSortOrder, NumberUtils, QueryConditionOptions, QueryOperator, QueryType } from "@elrondnetwork/erdnest";
+import { Injectable, Logger } from '@nestjs/common';
+import { Token } from './entities/token';
+import { TokenWithBalance } from './entities/token.with.balance';
+import { TokenDetailed } from './entities/token.detailed';
+import { QueryPagination } from 'src/common/entities/query.pagination';
+import { TokenFilter } from './entities/token.filter';
+import { TokenUtils } from 'src/utils/token.utils';
+import { EsdtService } from '../esdt/esdt.service';
+import { TokenAccount } from './entities/token.account';
+import { TokenType } from './entities/token.type';
+import { EsdtAddressService } from '../esdt/esdt.address.service';
+import { GatewayService } from 'src/common/gateway/gateway.service';
+import { GatewayComponentRequest } from 'src/common/gateway/entities/gateway.component.request';
+import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { TokenProperties } from './entities/token.properties';
+import { TokenRoles } from './entities/token.roles';
+import { TokenSupplyResult } from './entities/token.supply.result';
+import { TokenDetailedWithBalance } from './entities/token.detailed.with.balance';
+import { SortOrder } from 'src/common/entities/sort.order';
+import { TokenSort } from './entities/token.sort';
+import { TokenWithRoles } from './entities/token.with.roles';
+import { TokenWithRolesFilter } from './entities/token.with.roles.filter';
+import {
+  AddressUtils,
+  ApiUtils,
+  ElasticQuery,
+  ElasticService,
+  ElasticSortOrder,
+  NumberUtils,
+  QueryConditionOptions,
+  QueryOperator,
+  QueryType,
+} from '@elrondnetwork/erdnest';
+//import { CollectionService } from '../collections/collection.service';
+import { NftService } from '../nfts/nft.service';
+import { NftFilter } from '../nfts/entities/nft.filter';
+import { NftType } from '../nfts/entities/nft.type';
+import { NftAccount } from '../nfts/entities/nft.account';
 
 @Injectable()
 export class TokenService {
@@ -30,18 +45,19 @@ export class TokenService {
     private readonly elasticService: ElasticService,
     private readonly esdtAddressService: EsdtAddressService,
     private readonly gatewayService: GatewayService,
-    private readonly apiConfigService: ApiConfigService
+    private readonly apiConfigService: ApiConfigService,
+    private readonly nftService: NftService,
   ) {
     this.logger = new Logger(TokenService.name);
   }
 
   async isToken(identifier: string): Promise<boolean> {
-    const tokens = await this.esdtService.getAllEsdtTokens();
+    const tokens = await this.esdtService.getAllEsdtAndMetaEsdtTokens();
     return tokens.find(x => x.identifier === identifier) !== undefined;
   }
 
   async getToken(identifier: string): Promise<TokenDetailed | undefined> {
-    const tokens = await this.esdtService.getAllEsdtTokens();
+    const tokens = await this.esdtService.getAllEsdtAndMetaEsdtTokens();
     let token = tokens.find(x => x.identifier === identifier);
     if (!token) {
       return undefined;
@@ -81,8 +97,7 @@ export class TokenService {
   }
 
   async getFilteredTokens(filter: TokenFilter): Promise<TokenDetailed[]> {
-    let tokens = await this.esdtService.getAllEsdtTokens();
-
+    let tokens = await this.esdtService.getAllEsdtAndMetaEsdtTokens();
     if (filter.search) {
       const searchLower = filter.search.toLowerCase();
 
@@ -183,7 +198,7 @@ export class TokenService {
 
   async getTokensForAddressFromElastic(address: string, queryPagination: QueryPagination, filter: TokenFilter): Promise<TokenWithBalance[]> {
     let query = ElasticQuery.create()
-      .withMustNotCondition(QueryType.Exists('identifier'))
+      .withCondition(QueryConditionOptions.must, QueryType.Exists('identifier'))
       .withMustCondition(QueryType.Match('address', address))
       .withPagination({ from: queryPagination.from, size: queryPagination.size });
 
@@ -205,26 +220,29 @@ export class TokenService {
 
     const elasticTokens = await this.elasticService.getList('accountsesdt', 'token', query);
 
-    const elasticTokensWithBalance = elasticTokens.toRecord(token => token.token, token => token.balance);
-
-    const allTokens = await this.esdtService.getAllEsdtTokens();
+    const allTokens = await this.esdtService.getAllEsdtAndMetaEsdtTokens();
 
     const result: TokenWithBalance[] = [];
     for (const token of allTokens) {
-      if (elasticTokensWithBalance[token.identifier]) {
-        const tokenWithBalance: TokenWithBalance = {
-          ...token,
-          balance: elasticTokensWithBalance[token.identifier],
-          valueUsd: undefined,
-        };
-
-        this.applyValueUsd(tokenWithBalance);
-
-        result.push(tokenWithBalance);
-      }
+      this.addTokensWithBalance(elasticTokens, token, result);
     }
 
     return result;
+  }
+
+  private addTokensWithBalance(elasticTokens: any[], token: TokenDetailed, result: TokenWithBalance[]) {
+    for (const elasticToken of elasticTokens) {
+      if (elasticToken.token === token.identifier) {
+        const tokenWithBalance: TokenWithBalance = {
+          ...token,
+          balance: elasticToken.balance,
+          valueUsd: undefined,
+        };
+        tokenWithBalance.identifier = elasticToken.identifier;
+        this.applyValueUsd(tokenWithBalance);
+        result.push(tokenWithBalance);
+      }
+    }
   }
 
   applyValueUsd(tokenWithBalance: TokenWithBalance) {
@@ -298,23 +316,44 @@ export class TokenService {
     }
 
     const esdts = await this.esdtAddressService.getAllEsdtsForAddressFromGateway(address);
+    const metaESDTNfts = await this.nftService.getNftsForAddress(
+      address,
+      new QueryPagination(
+        { from: 0, size: 10000 }
+      ),
+      new NftFilter({
+        identifiers: filter.identifiers ?? (filter.identifier ? [filter.identifier] : []),
+        search: filter.search,
+        name: filter.name,
+        type: NftType.MetaESDT,
+      })
+    );
+    const metaESDTNftsIndexed: { [index: string]: NftAccount } = {};
+    for (const metaESDTNft of metaESDTNfts) {
+      metaESDTNftsIndexed[metaESDTNft.identifier] = metaESDTNft;
+    }
 
     const tokensWithBalance: TokenWithBalance[] = [];
 
     for (const tokenIdentifier of Object.keys(esdts)) {
-      if (!TokenUtils.isEsdt(tokenIdentifier)) {
+      if (
+        !TokenUtils.isEsdt(tokenIdentifier) &&
+        !Object.keys(metaESDTNftsIndexed).includes(tokenIdentifier)
+      ) {
         continue;
       }
 
       const esdt = esdts[tokenIdentifier];
       const token = tokensIndexed[tokenIdentifier];
-      if (!token) {
+      const metaESDTNft = metaESDTNftsIndexed[tokenIdentifier];
+      if (!token && !metaESDTNft) {
         continue;
       }
 
       const tokenWithBalance = {
         ...token,
         ...esdt,
+        ...this.tokenFromNftAccount(metaESDTNft),
       };
 
       tokensWithBalance.push(tokenWithBalance);
@@ -328,6 +367,22 @@ export class TokenService {
     }
 
     return tokensWithBalance;
+  }
+
+  private tokenFromNftAccount(nftAccount: NftAccount): Token | undefined {
+    if (!nftAccount) {
+      return undefined;
+    }
+    return new Token({
+      identifier: nftAccount.identifier,
+      name: nftAccount.name,
+      ticker: nftAccount.ticker,
+      owner: nftAccount.owner,
+      decimals: nftAccount.decimals,
+      assets: nftAccount.assets,
+      price: nftAccount.price,
+      supply: nftAccount.supply,
+    });
   }
 
   async getTokenAccounts(pagination: QueryPagination, identifier: string): Promise<TokenAccount[] | undefined> {
@@ -522,7 +577,7 @@ export class TokenService {
 
     const tokenList = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
 
-    const allTokens = await this.esdtService.getAllEsdtTokens();
+    const allTokens = await this.esdtService.getAllEsdtAndMetaEsdtTokens();
 
     const result: TokenWithRoles[] = [];
 

--- a/src/test/integration/esdt.e2e-spec.ts
+++ b/src/test/integration/esdt.e2e-spec.ts
@@ -94,7 +94,7 @@ describe('ESDT Service', () => {
 
   describe("Get ESDT Tokens Properties", () => {
     it("should return all ESDT tokens", async () => {
-      const results = await esdtService.getAllEsdtTokens();
+      const results = await esdtService.getAllEsdtAndMetaEsdtTokens();
 
       for (const result of results) {
         expect(result.hasOwnProperty("identifier")).toBeTruthy();

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -319,4 +319,9 @@ export class CacheInfo {
     key: "currentEpoch",
     ttl: Constants.oneMinute(),
   };
+
+  static AllMetaESDTTokens: CacheInfo = {
+    key: 'allMetaESDTTokens',
+    ttl: Constants.oneHour(),
+  };
 }


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)

tokens must contain metaEsdt as well
nfts must only contain NonFungibleESDT, SemiFungibleESDT

## Proposed Changes

/tokens endpoint should also include what is returned in /collections…?type=MetaESDT

/collections should return only collections of type NonFungibleESDT, SemiFungibleESDT

/accounts/:account/tokens should also include what is returned in /accounts/:account/nfts?type=MetaESDT

/accounts/:account/nfts should return only NFTs of type NonFungibleESDT, SemiFungibleESDT

## How to test
- 
- 
- 
