### PR TITLE
Support for experimental jungle pairs

### DIFF
--- a/src/endpoints/mex/mex.pair.service.ts
+++ b/src/endpoints/mex/mex.pair.service.ts
@@ -188,6 +188,7 @@ export class MexPairService {
       case 'Experimental':
         return MexPairType.experimental;
       case 'Jungle':
+      case 'Jungle-Experimental':
         return MexPairType.jungle;
       case 'Unlisted':
         return MexPairType.unlisted;


### PR DESCRIPTION
## Proposed Changes
- Add support for experimental jungle pairs

## How to test (mainnet)
- `/mex/pairs` should return `PROTEO-WEGLD` and `PROTEO-USDC` pairs
- `/mex/tokens` should return `PROTEO`
