### PR TITLE
Integrate Token Validator pipes from erdnest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2272,9 +2272,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.27.tgz",
-      "integrity": "sha512-OZpXZtXg3zzAGdUPxcL56e0Y9M8TDPfdXJW6o4heJPGi8oSMD94IXm3OQgP4Gf4aXLZWeMviykvd6CQl+u4P0Q==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.29.tgz",
+      "integrity": "sha512-s4PYoOTrOg8Vl1jdhlcy+Eq742te+rSWtLtn2GSiYE2Fxxty/XQGHbmm7GnN68+llYFdP/XY8342qsS9jdB7Vg==",
       "dependencies": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
@@ -17431,9 +17431,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.27.tgz",
-      "integrity": "sha512-OZpXZtXg3zzAGdUPxcL56e0Y9M8TDPfdXJW6o4heJPGi8oSMD94IXm3OQgP4Gf4aXLZWeMviykvd6CQl+u4P0Q==",
+      "version": "0.1.29",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.29.tgz",
+      "integrity": "sha512-s4PYoOTrOg8Vl1jdhlcy+Eq742te+rSWtLtn2GSiYE2Fxxty/XQGHbmm7GnN68+llYFdP/XY8342qsS9jdB7Vg==",
       "requires": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^8.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.25",
+        "@elrondnetwork/erdnest": "^0.1.27",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2272,9 +2272,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.25.tgz",
-      "integrity": "sha512-fK2ApG4E/JcV7aGHP43X3NHcxJdZAogyIxsDX/41pwlwM7K1ZkwM61I9muRUnXJhVskFdKQSVkxiu7hxth3CZQ==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.27.tgz",
+      "integrity": "sha512-OZpXZtXg3zzAGdUPxcL56e0Y9M8TDPfdXJW6o4heJPGi8oSMD94IXm3OQgP4Gf4aXLZWeMviykvd6CQl+u4P0Q==",
       "dependencies": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
@@ -17431,9 +17431,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.25.tgz",
-      "integrity": "sha512-fK2ApG4E/JcV7aGHP43X3NHcxJdZAogyIxsDX/41pwlwM7K1ZkwM61I9muRUnXJhVskFdKQSVkxiu7hxth3CZQ==",
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.27.tgz",
+      "integrity": "sha512-OZpXZtXg3zzAGdUPxcL56e0Y9M8TDPfdXJW6o4heJPGi8oSMD94IXm3OQgP4Gf4aXLZWeMviykvd6CQl+u4P0Q==",
       "requires": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^8.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.27",
+    "@elrondnetwork/erdnest": "^0.1.29",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^8.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.25",
+    "@elrondnetwork/erdnest": "^0.1.27",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/common/locked-asset/locked-asset.service.ts
+++ b/src/common/locked-asset/locked-asset.service.ts
@@ -5,7 +5,7 @@ import { VmQueryService } from '../../endpoints/vm.query/vm.query.service';
 import { CacheInfo } from '../../utils/cache.info';
 import { CachingService, Constants } from '@elrondnetwork/erdnest';
 import { UnlockMileStoneModel } from '../entities/unlock-schedule';
-import { TokenUtils } from '../../utils/token.utils';
+import { TokenHelpers } from '../../utils/token.helpers';
 import { GatewayComponentRequest } from '../gateway/entities/gateway.component.request';
 import { GatewayService } from '../gateway/gateway.service';
 import { MexSettingsService } from 'src/endpoints/mex/mex.settings.service';
@@ -27,7 +27,7 @@ export class LockedAssetService {
     }
 
     const extendedAttributesActivationNonce = await this.getExtendedAttributesActivationNonce();
-    const withActivationNonce = TokenUtils.tokenNonce(identifier) >= extendedAttributesActivationNonce;
+    const withActivationNonce = TokenHelpers.tokenNonce(identifier) >= extendedAttributesActivationNonce;
     const lockedAssetAttributes = LockedAssetAttributes.fromAttributes(withActivationNonce, attributes);
 
     if (!lockedAssetAttributes.unlockSchedule) {

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -33,7 +33,7 @@ import { ProviderStake } from '../stake/entities/provider.stake';
 import { TokenDetailedWithBalance } from '../tokens/entities/token.detailed.with.balance';
 import { NftCollectionAccount } from '../collections/entities/nft.collection.account';
 import { TokenWithRoles } from '../tokens/entities/token.with.roles';
-import { ParseAddressPipe, ParseArrayPipe, ParseBlockHashPipe, ParseOptionalBoolPipe, ParseOptionalEnumArrayPipe, ParseOptionalEnumPipe, ParseOptionalIntPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseArrayPipe, ParseBlockHashPipe, ParseCollectionPipe, ParseNftPipe, ParseOptionalBoolPipe, ParseOptionalEnumArrayPipe, ParseOptionalEnumPipe, ParseOptionalIntPipe, ParseTokenOrNftPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
 import { QueryPagination } from 'src/common/entities/query.pagination';
 import { TransactionQueryOptions } from '../transactions/entities/transactions.query.options';
 import { TokenWithRolesFilter } from '../tokens/entities/token.with.roles.filter';
@@ -42,6 +42,7 @@ import { TokenFilter } from '../tokens/entities/token.filter';
 import { NftFilter } from '../nfts/entities/nft.filter';
 import { NftQueryOptions } from '../nfts/entities/nft.query.options';
 import { TransactionFilter } from '../transactions/entities/transaction.filter';
+import { ParseTokenPipe } from '@elrondnetwork/erdnest';
 
 @Controller()
 @ApiTags('accounts')
@@ -174,7 +175,7 @@ export class AccountController {
   @ApiOperation({ summary: 'Account token details', description: 'Returns details about a specific fungible token from a given address' })
   async getAccountToken(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('token') token: string,
+    @Param('token', ParseTokenPipe) token: string,
   ): Promise<TokenDetailedWithBalance> {
     const result = await this.tokenService.getTokenForAddress(address, token);
     if (!result) {
@@ -255,7 +256,7 @@ export class AccountController {
   @ApiOkResponse({ type: NftCollectionRole })
   async getAccountCollection(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('collection') collection: string,
+    @Param('collection', ParseCollectionPipe) collection: string,
   ): Promise<NftCollectionRole> {
     const result = await this.collectionService.getCollectionForAddressWithRole(address, collection);
     if (!result) {
@@ -321,7 +322,7 @@ export class AccountController {
   @ApiOkResponse({ type: TokenWithRoles })
   async getTokenWithRoles(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
   ): Promise<TokenWithRoles> {
     const result = await this.tokenService.getTokenWithRolesForAddress(address, identifier);
     if (!result) {
@@ -376,7 +377,7 @@ export class AccountController {
   @ApiOkResponse({ type: NftCollectionAccount })
   async getAccountNftCollection(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('collection') collection: string,
+    @Param('collection', ParseCollectionPipe) collection: string,
   ): Promise<NftCollectionAccount> {
     const result = await this.collectionService.getCollectionForAddress(address, collection);
     if (!result) {
@@ -481,7 +482,7 @@ export class AccountController {
   @ApiOkResponse({ type: NftAccount })
   async getAccountNft(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('nft') nft: string,
+    @Param('nft', ParseNftPipe) nft: string,
   ): Promise<NftAccount> {
     const result = await this.nftService.getNftForAddress(address, nft);
     if (!result) {
@@ -545,7 +546,7 @@ export class AccountController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
-    @Query('token') token?: string,
+    @Query('token', ParseTokenPipe) token?: string,
     @Query('senderShard', ParseOptionalIntPipe) senderShard?: number,
     @Query('receiverShard', ParseOptionalIntPipe) receiverShard?: number,
     @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
@@ -889,7 +890,7 @@ export class AccountController {
   @ApiOkResponse({ type: [AccountEsdtHistory] })
   async getAccountTokenHistory(
     @Param('address', ParseAddressPipe) address: string,
-    @Param('tokenIdentifier') tokenIdentifier: string,
+    @Param('tokenIdentifier', ParseTokenOrNftPipe) tokenIdentifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<AccountEsdtHistory[]> {

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -7,7 +7,7 @@ import { Nft } from "../nfts/entities/nft";
 import { NftService } from "../nfts/nft.service";
 import { NftFilter } from "../nfts/entities/nft.filter";
 import { NftQueryOptions } from "../nfts/entities/nft.query.options";
-import { ParseAddressPipe, ParseArrayPipe, ParseOptionalBoolPipe, ParseOptionalEnumArrayPipe, ParseOptionalIntPipe } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseArrayPipe, ParseCollectionPipe, ParseOptionalBoolPipe, ParseOptionalEnumArrayPipe, ParseOptionalIntPipe } from '@elrondnetwork/erdnest';
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { CollectionFilter } from "./entities/collection.filter";
 
@@ -141,7 +141,9 @@ export class CollectionController {
   @ApiOperation({ summary: 'Collection details', description: 'Returns non-fungible/semi-fungible/meta-esdt collection details' })
   @ApiOkResponse({ type: NftCollection })
   @ApiNotFoundResponse({ description: 'Token collection not found' })
-  async getNftCollection(@Param('collection') collection: string): Promise<NftCollection> {
+  async getNftCollection(
+    @Param('collection', ParseCollectionPipe) collection: string
+  ): Promise<NftCollection> {
     const token = await this.collectionService.getNftCollection(collection);
     if (token === undefined) {
       throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
@@ -166,7 +168,7 @@ export class CollectionController {
   @ApiQuery({ name: 'withOwner', description: 'Return owner where type = NonFungibleESDT', required: false, type: Boolean })
   @ApiQuery({ name: 'withSupply', description: 'Return supply where type = SemiFungibleESDT', required: false, type: Boolean })
   async getNfts(
-    @Param('collection') collection: string,
+    @Param('collection', ParseCollectionPipe) collection: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
@@ -206,7 +208,7 @@ export class CollectionController {
   @ApiQuery({ name: 'isWhitelistedStorage', description: 'Return all NFTs that are whitelisted in storage', required: false, type: Boolean })
   @ApiQuery({ name: 'hasUris', description: 'Return all NFTs that have one or more uris', required: false, type: Boolean })
   async getNftCount(
-    @Param('collection') collection: string,
+    @Param('collection', ParseCollectionPipe) collection: string,
     @Query('search') search?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('name') name?: string,

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -13,9 +13,9 @@ import { CacheInfo } from "src/utils/cache.info";
 import { TokenAssets } from "../../common/assets/entities/token.assets";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { CollectionRoles } from "../tokens/entities/collection.roles";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { NftCollectionAccount } from "./entities/nft.collection.account";
-import { ApiUtils, BinaryUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryType, QueryOperator, QueryConditionOptions, ElasticSortOrder } from "@elrondnetwork/erdnest";
+import { ApiUtils, BinaryUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryType, QueryOperator, QueryConditionOptions, ElasticSortOrder, TokenUtils } from "@elrondnetwork/erdnest";
 
 @Injectable()
 export class CollectionService {
@@ -264,13 +264,13 @@ export class CollectionService {
       for (const address of addresses) {
         const foundAddressRoles = allRoles.find((addressRole) => addressRole.address === address);
         if (foundAddressRoles) {
-          TokenUtils.setCollectionRole(foundAddressRoles, role);
+          TokenHelpers.setCollectionRole(foundAddressRoles, role);
           continue;
         }
 
         const addressRole = new CollectionRoles();
         addressRole.address = address;
-        TokenUtils.setCollectionRole(addressRole, role);
+        TokenHelpers.setCollectionRole(addressRole, role);
 
         allRoles.push(addressRole);
       }
@@ -301,7 +301,7 @@ export class CollectionService {
       roleForAddress.address = components[0];
       const roles = components[1].split(',');
       for (const role of roles) {
-        TokenUtils.setCollectionRole(roleForAddress, role);
+        TokenHelpers.setCollectionRole(roleForAddress, role);
       }
 
       allRoles.push(roleForAddress);

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -4,7 +4,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { ProtocolService } from "src/common/protocol/protocol.service";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { EsdtDataSource } from "./entities/esdt.data.source";
 import { EsdtService } from "./esdt.service";
 import { GatewayNft } from "../nfts/entities/gateway.nft";
@@ -142,7 +142,7 @@ export class EsdtAddressService {
           for (const role of Object.keys(indexedCollection.roles)) {
             const addresses = indexedCollection.roles[role].distinct();
             if (addresses.includes(address)) {
-              TokenUtils.setCollectionRole(addressRoles, role);
+              TokenHelpers.setCollectionRole(addressRoles, role);
             }
           }
 
@@ -259,7 +259,7 @@ export class EsdtAddressService {
 
       if (nft.uris && nft.uris.length > 0) {
         try {
-          nft.url = TokenUtils.computeNftUri(BinaryUtils.base64Decode(nft.uris[0]), this.NFT_THUMBNAIL_PREFIX);
+          nft.url = TokenHelpers.computeNftUri(BinaryUtils.base64Decode(nft.uris[0]), this.NFT_THUMBNAIL_PREFIX);
         } catch (error) {
           this.logger.error(error);
         }

--- a/src/endpoints/esdt/esdt.service.ts
+++ b/src/endpoints/esdt/esdt.service.ts
@@ -3,7 +3,7 @@ import { CacheInfo } from "src/utils/cache.info";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { TokenProperties } from "src/endpoints/tokens/entities/token.properties";
 import { VmQueryService } from "src/endpoints/vm.query/vm.query.service";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { GatewayService } from "../../common/gateway/gateway.service";
 import { MexTokenService } from "../mex/mex.token.service";
@@ -227,17 +227,17 @@ export class EsdtService {
       type,
       owner: AddressUtils.bech32Encode(owner),
       decimals: parseInt(decimals.split('-').pop() ?? '0'),
-      isPaused: TokenUtils.canBool(isPaused),
-      canUpgrade: TokenUtils.canBool(canUpgrade),
-      canMint: TokenUtils.canBool(canMint),
-      canBurn: TokenUtils.canBool(canBurn),
-      canChangeOwner: TokenUtils.canBool(canChangeOwner),
-      canPause: TokenUtils.canBool(canPause),
-      canFreeze: TokenUtils.canBool(canFreeze),
-      canWipe: TokenUtils.canBool(canWipe),
-      canAddSpecialRoles: TokenUtils.canBool(canAddSpecialRoles),
-      canTransferNFTCreateRole: TokenUtils.canBool(canTransferNFTCreateRole),
-      NFTCreateStopped: TokenUtils.canBool(NFTCreateStopped),
+      isPaused: TokenHelpers.canBool(isPaused),
+      canUpgrade: TokenHelpers.canBool(canUpgrade),
+      canMint: TokenHelpers.canBool(canMint),
+      canBurn: TokenHelpers.canBool(canBurn),
+      canChangeOwner: TokenHelpers.canBool(canChangeOwner),
+      canPause: TokenHelpers.canBool(canPause),
+      canFreeze: TokenHelpers.canBool(canFreeze),
+      canWipe: TokenHelpers.canBool(canWipe),
+      canAddSpecialRoles: TokenHelpers.canBool(canAddSpecialRoles),
+      canTransferNFTCreateRole: TokenHelpers.canBool(canTransferNFTCreateRole),
+      NFTCreateStopped: TokenHelpers.canBool(NFTCreateStopped),
       wiped: wiped.split('-').pop() ?? '',
     };
 
@@ -302,7 +302,7 @@ export class EsdtService {
       }
 
       const role = BinaryUtils.base64Decode(valueEncoded);
-      TokenUtils.setTokenRole(currentAddressRoles, role);
+      TokenHelpers.setTokenRole(currentAddressRoles, role);
     }
 
     if (currentAddressRoles.address) {

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -9,7 +9,7 @@ import { NftType } from "./entities/nft.type";
 import { NftService } from "./nft.service";
 import { QueryPagination } from 'src/common/entities/query.pagination';
 import { NftQueryOptions } from './entities/nft.query.options';
-import { ParseAddressPipe, ParseOptionalBoolPipe, ParseArrayPipe, ParseOptionalIntPipe } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseOptionalBoolPipe, ParseArrayPipe, ParseOptionalIntPipe, ParseNftPipe } from '@elrondnetwork/erdnest';
 
 @Controller()
 @ApiTags('nfts')
@@ -122,7 +122,9 @@ export class NftController {
   @ApiOperation({ summary: 'NFT details', description: 'Returns the details of an Non-Fungible / Semi-Fungible / MetaESDT token for a given identifier' })
   @ApiOkResponse({ type: Nft })
   @ApiNotFoundResponse({ description: 'Token not found' })
-  async getNft(@Param('identifier') identifier: string): Promise<Nft> {
+  async getNft(
+    @Param('identifier', ParseNftPipe) identifier: string
+  ): Promise<Nft> {
     const token = await this.nftService.getSingleNft(identifier);
     if (token === undefined) {
       throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
@@ -135,7 +137,10 @@ export class NftController {
   @ApiOperation({ summary: 'NFT thumbnail', description: 'Returns nft thumbnail' })
   @ApiOkResponse({ type: Nft })
   @ApiNotFoundResponse({ description: 'NFT thumbnail not found' })
-  async resolveNftThumbnail(@Param('identifier') identifier: string, @Res() response: Response) {
+  async resolveNftThumbnail(
+    @Param('identifier', ParseNftPipe) identifier: string,
+    @Res() response: Response
+  ) {
     const nfts = await this.nftService.getNftsInternal(new QueryPagination({ from: 0, size: 1 }), new NftFilter(), identifier);
     if (nfts.length === 0) {
       throw new NotFoundException('NFT not found');
@@ -155,7 +160,9 @@ export class NftController {
   @ApiOperation({ summary: 'NFT supply', description: 'Returns Non-Fungible / Semi-Fungible / MetaESDT token supply details' })
   @ApiOkResponse({ type: NftSupply })
   @ApiNotFoundResponse({ description: 'Token not found' })
-  async getNftSupply(@Param('identifier') identifier: string): Promise<{ supply: string }> {
+  async getNftSupply(
+    @Param('identifier', ParseNftPipe) identifier: string
+  ): Promise<{ supply: string }> {
     const totalSupply = await this.nftService.getNftSupply(identifier);
     if (!totalSupply) {
       throw new NotFoundException();
@@ -171,7 +178,7 @@ export class NftController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   async getNftOwners(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseNftPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<NftOwner[]> {
@@ -190,7 +197,9 @@ export class NftController {
     description: 'Non-fungible / semi-fungible token owners count',
     type: Number,
   })
-  async getNftOwnersCount(@Param('identifier') identifier: string): Promise<number> {
+  async getNftOwnersCount(
+    @Param('identifier', ParseNftPipe) identifier: string
+  ): Promise<number> {
     const ownersCount = await this.nftService.getNftOwnersCount(identifier);
     if (ownersCount === undefined) {
       throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);
@@ -206,7 +215,7 @@ export class NftController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   async getNftAccounts(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseNftPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
   ): Promise<NftOwner[]> {
@@ -221,7 +230,9 @@ export class NftController {
   @Get('/nfts/:identifier/accounts/count')
   @ApiOperation({ summary: 'NFT accounts count', description: 'Returns number of addresses that hold balances for a specific Non-Fungible / Semi-Fungible / MetaESDT token' })
   @ApiOkResponse({ type: Number })
-  async getNftAccountsCount(@Param('identifier') identifier: string): Promise<number> {
+  async getNftAccountsCount(
+    @Param('identifier', ParseNftPipe) identifier: string
+  ): Promise<number> {
     const ownersCount = await this.nftService.getNftOwnersCount(identifier);
     if (ownersCount === undefined) {
       throw new HttpException('NFT not found', HttpStatus.NOT_FOUND);

--- a/src/endpoints/nfts/nft.extendedattributes.service.ts
+++ b/src/endpoints/nfts/nft.extendedattributes.service.ts
@@ -1,7 +1,7 @@
 import { Constants, MatchUtils, CachingService, ApiService } from "@elrondnetwork/erdnest";
 import { Injectable, Logger } from "@nestjs/common";
 import { NftMetadata } from "src/endpoints/nfts/entities/nft.metadata";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 
 @Injectable()
@@ -62,7 +62,7 @@ export class NftExtendedAttributesService {
     }
 
     if (result.fileUri) {
-      result.fileUri = TokenUtils.computeNftUri(result.fileUri, this.apiConfigService.getExternalMediaUrl() + '/nfts/asset');
+      result.fileUri = TokenHelpers.computeNftUri(result.fileUri, this.apiConfigService.getExternalMediaUrl() + '/nfts/asset');
     }
 
     return result;
@@ -70,7 +70,7 @@ export class NftExtendedAttributesService {
 
   private async getExtendedAttributesFromIpfs(metadata: string): Promise<any> {
     const ipfsUri = `https://ipfs.io/ipfs/${metadata}`;
-    const processedIpfsUri = TokenUtils.computeNftUri(ipfsUri, this.apiConfigService.getMediaUrl() + '/nfts/asset');
+    const processedIpfsUri = TokenHelpers.computeNftUri(ipfsUri, this.apiConfigService.getMediaUrl() + '/nfts/asset');
 
     const result = await this.apiService.get(processedIpfsUri, { timeout: 5000 });
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -1,7 +1,7 @@
 import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { Nft } from "./entities/nft";
 import { NftAccount } from "./entities/nft.account";
 import { NftFilter } from "./entities/nft.filter";
@@ -20,7 +20,7 @@ import { EsdtDataSource } from "../esdt/entities/esdt.data.source";
 import { EsdtAddressService } from "../esdt/esdt.address.service";
 import { PersistenceService } from "src/common/persistence/persistence.service";
 import { MexTokenService } from "../mex/mex.token.service";
-import { ApiUtils, BinaryUtils, Constants, NumberUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryConditionOptions, QueryType, QueryOperator, ElasticSortOrder, RangeGreaterThanOrEqual, RangeLowerThan, BatchUtils } from "@elrondnetwork/erdnest";
+import { ApiUtils, BinaryUtils, Constants, NumberUtils, RecordUtils, CachingService, ElasticService, ElasticQuery, QueryConditionOptions, QueryType, QueryOperator, ElasticSortOrder, RangeGreaterThanOrEqual, RangeLowerThan, BatchUtils, TokenUtils } from "@elrondnetwork/erdnest";
 import { LockedAssetService } from "../../common/locked-asset/locked-asset.service";
 
 @Injectable()
@@ -214,7 +214,7 @@ export class NftService {
     );
 
     for (const nft of nfts) {
-      if (TokenUtils.needsDefaultMedia(nft)) {
+      if (TokenHelpers.needsDefaultMedia(nft)) {
         nft.media = this.DEFAULT_MEDIA;
       }
     }
@@ -241,7 +241,7 @@ export class NftService {
       this.pluginService.processNft(nft),
     ]);
 
-    if (TokenUtils.needsDefaultMedia(nft)) {
+    if (TokenHelpers.needsDefaultMedia(nft)) {
       nft.media = this.DEFAULT_MEDIA;
     }
   }
@@ -383,7 +383,7 @@ export class NftService {
 
         if (nft.uris && nft.uris.length > 0) {
           try {
-            nft.url = TokenUtils.computeNftUri(BinaryUtils.base64Decode(nft.uris[0]), this.NFT_THUMBNAIL_PREFIX);
+            nft.url = TokenHelpers.computeNftUri(BinaryUtils.base64Decode(nft.uris[0]), this.NFT_THUMBNAIL_PREFIX);
           } catch (error) {
             this.logger.error(error);
           }
@@ -430,7 +430,7 @@ export class NftService {
 
     let url = '';
     try {
-      url = TokenUtils.computeNftUri(BinaryUtils.base64Decode(uris[0]), this.NFT_THUMBNAIL_PREFIX);
+      url = TokenHelpers.computeNftUri(BinaryUtils.base64Decode(uris[0]), this.NFT_THUMBNAIL_PREFIX);
     } catch (error) {
       this.logger.error(`Error when computing uri from '${uris[0]}'`);
       this.logger.error(error);

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -18,7 +18,7 @@ import { QueryPagination } from "src/common/entities/query.pagination";
 import { TokenFilter } from "./entities/token.filter";
 import { TransactionFilter } from "../transactions/entities/transaction.filter";
 import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
-import { ParseAddressPipe, ParseBlockHashPipe, ParseOptionalBoolPipe, ParseOptionalEnumPipe, ParseOptionalIntPipe, ParseArrayPipe } from "@elrondnetwork/erdnest";
+import { ParseAddressPipe, ParseBlockHashPipe, ParseOptionalBoolPipe, ParseOptionalEnumPipe, ParseOptionalIntPipe, ParseArrayPipe, ParseTokenPipe } from "@elrondnetwork/erdnest";
 
 @Controller()
 @ApiTags('tokens')
@@ -46,7 +46,7 @@ export class TokenController {
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
     @Query('name') name?: string,
-    @Query('identifier') identifier?: string,
+    @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('sort', new ParseOptionalEnumPipe(TokenSort)) sort?: TokenSort,
     @Query('order', new ParseOptionalEnumPipe(SortOrder)) order?: SortOrder,
@@ -78,7 +78,7 @@ export class TokenController {
   async getTokenCountAlternative(
     @Query('search') search?: string,
     @Query('name') name?: string,
-    @Query('identifier') identifier?: string,
+    @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
   ): Promise<number> {
     return await this.tokenService.getTokenCount(new TokenFilter({ search, name, identifier, identifiers }));
@@ -88,7 +88,9 @@ export class TokenController {
   @ApiOperation({ summary: 'Token', description: 'Returns token details based on a specific token identifier' })
   @ApiOkResponse({ type: TokenDetailed })
   @ApiNotFoundResponse({ description: 'Token not found' })
-  async getToken(@Param('identifier') identifier: string): Promise<TokenDetailed> {
+  async getToken(
+    @Param('identifier', ParseTokenPipe) identifier: string
+  ): Promise<TokenDetailed> {
     const token = await this.tokenService.getToken(identifier);
     if (token === undefined) {
       throw new NotFoundException('Token not found');
@@ -103,7 +105,7 @@ export class TokenController {
   @ApiOkResponse({ type: EsdtSupply })
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getTokenSupply(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('denominated', new ParseOptionalBoolPipe) denominated?: boolean,
   ): Promise<TokenSupplyResult> {
     const isToken = await this.tokenService.isToken(identifier);
@@ -126,7 +128,7 @@ export class TokenController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   async getTokenAccounts(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number
   ): Promise<TokenAccount[]> {
@@ -148,7 +150,7 @@ export class TokenController {
   @ApiOkResponse({ type: Number })
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getTokenAccountsCount(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
   ): Promise<number> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -185,7 +187,7 @@ export class TokenController {
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions', required: false, type: Boolean })
   async getTokenTransactions(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -245,7 +247,7 @@ export class TokenController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getTokenTransactionsCount(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
     @Query('senderShard', ParseOptionalIntPipe) senderShard?: number,
@@ -282,7 +284,7 @@ export class TokenController {
   @ApiOkResponse({ type: [TokenRoles] })
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getTokenRoles(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
   ): Promise<TokenRoles[]> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -302,8 +304,8 @@ export class TokenController {
   @ApiOkResponse({ type: TokenRoles })
   @ApiNotFoundResponse({ description: 'Token not found' })
   async getTokenRolesForAddress(
-    @Param('identifier') identifier: string,
-    @Param('address') address: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
+    @Param('address', ParseAddressPipe) address: string,
   ): Promise<TokenRoles> {
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
@@ -335,7 +337,7 @@ export class TokenController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getTokenTransfers(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('sender', ParseAddressPipe) sender?: string,
@@ -390,7 +392,7 @@ export class TokenController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getTokenTransfersCount(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
     @Query('senderShard', ParseOptionalIntPipe) senderShard?: number,
@@ -431,7 +433,7 @@ export class TokenController {
   @Get("/tokens/:identifier/transfers/c")
   @ApiExcludeEndpoint()
   async getAccountTransfersCountAlternative(
-    @Param('identifier') identifier: string,
+    @Param('identifier', ParseTokenPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressPipe) receiver?: string,
     @Query('senderShard', ParseOptionalIntPipe) senderShard?: number,

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -4,7 +4,7 @@ import { TokenWithBalance } from "./entities/token.with.balance";
 import { TokenDetailed } from "./entities/token.detailed";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { TokenFilter } from "./entities/token.filter";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { EsdtService } from "../esdt/esdt.service";
 import { TokenAccount } from "./entities/token.account";
 import { TokenType } from "./entities/token.type";
@@ -20,7 +20,7 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { TokenSort } from "./entities/token.sort";
 import { TokenWithRoles } from "./entities/token.with.roles";
 import { TokenWithRolesFilter } from "./entities/token.with.roles.filter";
-import { AddressUtils, ApiUtils, ElasticQuery, ElasticService, ElasticSortOrder, NumberUtils, QueryConditionOptions, QueryOperator, QueryType } from "@elrondnetwork/erdnest";
+import { AddressUtils, ApiUtils, ElasticQuery, ElasticService, ElasticSortOrder, NumberUtils, QueryConditionOptions, QueryOperator, QueryType, TokenUtils } from "@elrondnetwork/erdnest";
 
 @Injectable()
 export class TokenService {
@@ -44,7 +44,7 @@ export class TokenService {
     const tokens = await this.esdtService.getAllEsdtTokens();
     let token = tokens.find(x => x.identifier === identifier);
 
-    if (!TokenUtils.isEsdt(identifier)) {
+    if (!TokenUtils.isToken(identifier)) {
       return undefined;
     }
 
@@ -256,7 +256,7 @@ export class TokenService {
   async getTokenForAddress(address: string, identifier: string): Promise<TokenDetailedWithBalance | undefined> {
     const tokens = await this.getFilteredTokens({ identifier });
 
-    if (!TokenUtils.isEsdt(identifier)) {
+    if (!TokenUtils.isToken(identifier)) {
       return undefined;
     }
 
@@ -312,7 +312,7 @@ export class TokenService {
     const tokensWithBalance: TokenWithBalance[] = [];
 
     for (const tokenIdentifier of Object.keys(esdts)) {
-      if (!TokenUtils.isEsdt(tokenIdentifier)) {
+      if (!TokenUtils.isToken(tokenIdentifier)) {
         continue;
       }
 
@@ -393,7 +393,7 @@ export class TokenService {
           roles.push(addressRole);
         }
 
-        TokenUtils.setTokenRole(addressRole, role);
+        TokenHelpers.setTokenRole(addressRole, role);
       }
     }
 
@@ -425,7 +425,7 @@ export class TokenService {
       for (const role of Object.keys(token.roles)) {
         const addresses = token.roles[role].distinct();
         if (addresses.includes(address)) {
-          TokenUtils.setTokenRole(addressRoles, role);
+          TokenHelpers.setTokenRole(addressRoles, role);
         }
       }
 

--- a/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
@@ -2,7 +2,7 @@ import { ApiService, Constants } from "@elrondnetwork/erdnest";
 import { HttpStatus, Injectable, Logger } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 import { AWSService } from "../thumbnails/aws.service";
 
 @Injectable()
@@ -23,12 +23,12 @@ export class NftAssetService {
     this.logger.log(`Started uploading assets to S3 for NFT with identifier '${identifier}', file url '${fileUrl}'`);
 
     try {
-      const mediaUrl = TokenUtils.computeNftUri(fileUrl, this.apiConfigService.getMediaUrl() + '/nfts/asset');
+      const mediaUrl = TokenHelpers.computeNftUri(fileUrl, this.apiConfigService.getMediaUrl() + '/nfts/asset');
 
       const fileResult: any = await this.apiService.get(mediaUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS });
       const file = fileResult.data;
 
-      const fileName = TokenUtils.computeNftUri(fileUrl, '');
+      const fileName = TokenHelpers.computeNftUri(fileUrl, '');
 
       const filePath = `${this.STANDARD_PATH}${fileName}`;
 
@@ -45,7 +45,7 @@ export class NftAssetService {
     try {
       const prefix = (this.apiConfigService.getMediaInternalUrl() ?? this.apiConfigService.getMediaUrl()) + '/nfts/asset';
 
-      const url = TokenUtils.computeNftUri(media.originalUrl, prefix);
+      const url = TokenHelpers.computeNftUri(media.originalUrl, prefix);
 
       // eslint-disable-next-line require-await
       const response = await this.apiService.head(url, undefined, async (error) => {

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -8,7 +8,7 @@ import { MediaMimeTypeEnum } from "src/endpoints/nfts/entities/media.mime.type";
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 
 @Injectable()
 export class NftMediaService {
@@ -82,9 +82,9 @@ export class NftMediaService {
       }
 
       const nftMedia = new NftMedia();
-      nftMedia.url = TokenUtils.computeNftUri(BinaryUtils.base64Decode(uri), this.NFT_THUMBNAIL_PREFIX);
+      nftMedia.url = TokenHelpers.computeNftUri(BinaryUtils.base64Decode(uri), this.NFT_THUMBNAIL_PREFIX);
       nftMedia.originalUrl = BinaryUtils.base64Decode(uri);
-      nftMedia.thumbnailUrl = `${this.apiConfigService.getExternalMediaUrl()}/nfts/thumbnail/${nft.collection}-${TokenUtils.getUrlHash(nftMedia.url)}`;
+      nftMedia.thumbnailUrl = `${this.apiConfigService.getExternalMediaUrl()}/nfts/thumbnail/${nft.collection}-${TokenHelpers.getUrlHash(nftMedia.url)}`;
       nftMedia.fileType = fileProperties.contentType;
       nftMedia.fileSize = fileProperties.contentLength;
 
@@ -96,7 +96,7 @@ export class NftMediaService {
 
   private getUrl(nftUri: string, prefix: string): string {
     const url = BinaryUtils.base64Decode(nftUri);
-    return TokenUtils.computeNftUri(url, prefix);
+    return TokenHelpers.computeNftUri(url, prefix);
   }
 
   private async getFileProperties(uri: string): Promise<{ contentType: string, contentLength: number } | null> {

--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -8,7 +8,7 @@ import { GenerateThumbnailResult } from "./entities/generate.thumbnail.result";
 import { ThumbnailType } from "./entities/thumbnail.type";
 import { AWSService } from "./aws.service";
 import { ApiService, Constants, FileUtils } from "@elrondnetwork/erdnest";
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 
 @Injectable()
 export class NftThumbnailService {
@@ -151,7 +151,7 @@ export class NftThumbnailService {
   }
 
   async hasThumbnailGenerated(identifier: string, fileUrl: string): Promise<boolean> {
-    const urlIdentifier = TokenUtils.getThumbnailUrlIdentifier(identifier, fileUrl);
+    const urlIdentifier = TokenHelpers.getThumbnailUrlIdentifier(identifier, fileUrl);
     const url = this.getFullThumbnailUrl(urlIdentifier);
 
     let hasThumbnail = true;
@@ -171,7 +171,7 @@ export class NftThumbnailService {
 
   async generateThumbnail(nft: Nft, fileUrl: string, fileType: string, forceRefresh: boolean = false): Promise<GenerateThumbnailResult> {
     const nftIdentifier = nft.identifier;
-    const urlHash = TokenUtils.getUrlHash(fileUrl);
+    const urlHash = TokenHelpers.getUrlHash(fileUrl);
 
     this.logger.log(`Generating thumbnail for NFT with identifier '${nftIdentifier}', url '${fileUrl}' and url hash '${urlHash}'`);
 
@@ -183,7 +183,7 @@ export class NftThumbnailService {
     const fileResult: any = await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS });
     const file = fileResult.data;
 
-    const urlIdentifier = TokenUtils.getThumbnailUrlIdentifier(nftIdentifier, fileUrl);
+    const urlIdentifier = TokenHelpers.getThumbnailUrlIdentifier(nftIdentifier, fileUrl);
     if (!forceRefresh) {
       const hasThumbnailGenerated = await this.hasThumbnailGenerated(nftIdentifier, fileUrl);
       if (hasThumbnailGenerated) {

--- a/src/test/unit/utils/token.utils.spec.ts
+++ b/src/test/unit/utils/token.utils.spec.ts
@@ -1,29 +1,29 @@
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 
 describe('Token Utils', () => {
   describe('computeNftUri', () => {
     it('ipfs.io url processing', () => {
-      expect(TokenUtils.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
-      expect(TokenUtils.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
+      expect(TokenHelpers.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
+      expect(TokenHelpers.computeNftUri('https://ipfs.io/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
     it('gateway.pinata.cloud url processing', () => {
-      expect(TokenUtils.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
-      expect(TokenUtils.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
+      expect(TokenHelpers.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
+      expect(TokenHelpers.computeNftUri('https://gateway.pinata.cloud/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
     it('dweb.link url processing', () => {
-      expect(TokenUtils.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
-      expect(TokenUtils.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
+      expect(TokenHelpers.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
+      expect(TokenHelpers.computeNftUri('https://dweb.link/ipfs/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
     it('ipfs protocol url processing', () => {
-      expect(TokenUtils.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
-      expect(TokenUtils.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
+      expect(TokenHelpers.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6');
+      expect(TokenHelpers.computeNftUri('ipfs://QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png');
     });
 
     it('.ipfs.dweb.link url processing', () => {
-      expect(TokenUtils.computeNftUri('https://bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq.ipfs.dweb.link', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq');
+      expect(TokenHelpers.computeNftUri('https://bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq.ipfs.dweb.link', 'https://media.elrond.com/nfts/asset')).toStrictEqual('https://media.elrond.com/nfts/asset/bafybeigc7veznuahvghwz4viugnp3ulegsbkiqld7466u5migimuzhp6bq');
     });
   });
 });

--- a/src/test/unit/utils/tokens.utils.spec.ts
+++ b/src/test/unit/utils/tokens.utils.spec.ts
@@ -1,24 +1,45 @@
 import { TokenHelpers } from "src/utils/token.helpers";
+import { TokenUtils } from "@elrondnetwork/erdnest";
 
 describe('Token Utils', () => {
-    describe('canBool', () => {
-        it('Check function canBool', () => {
-            expect(TokenHelpers.canBool('EWLD-e23800')).toBeFalsy();
-            expect(TokenHelpers.canBool('MARS-96823d-01')).toBeFalsy();
-        });
+  describe('canBool', () => {
+    it('Check function canBool', () => {
+      expect(TokenHelpers.canBool('EWLD-e23800')).toBeFalsy();
+      expect(TokenHelpers.canBool('MARS-96823d-01')).toBeFalsy();
     });
-    describe('getUrlHash', () => {
-        it('Check function getUrlHash', () => {
-            expect(TokenHelpers.getUrlHash('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png')).toStrictEqual('947a3912');
-        });
-    });
-    describe('getThumbnailUrlIdentifier', () => {
-        it('Check function getThumbnailUrlIdentifier', () => {
-            expect(TokenHelpers.getThumbnailUrlIdentifier('MOS-b9b4b2-2710', 'https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png'))
-                .toStrictEqual('MOS-b9b4b2-947a3912');
+  });
 
-        });
+  describe('getUrlHash', () => {
+    it('Check function getUrlHash', () => {
+      expect(TokenHelpers.getUrlHash('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png')).toStrictEqual('947a3912');
     });
+  });
 
+  describe('getThumbnailUrlIdentifier', () => {
+    it('Check function getThumbnailUrlIdentifier', () => {
+      expect(TokenHelpers.getThumbnailUrlIdentifier('MOS-b9b4b2-2710', 'https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png'))
+        .toStrictEqual('MOS-b9b4b2-947a3912');
+    });
+  });
+
+  describe('isToken', () => {
+    it('Check isToken function', () => {
+      expect(TokenUtils.isToken('MEX-455c57')).toBeTruthy();
+      expect(TokenUtils.isToken('EWLD-e23800-455c74')).toBeFalsy();
+    });
+  });
+
+  describe('isCollection', () => {
+    it('Check isCollection function', () => {
+      expect(TokenUtils.isCollection('MOS-b9b4b2')).toBeTruthy();
+      expect(TokenUtils.isCollection('MOS-b9b4b2-455c74')).toBeFalsy();
+    });
+  });
+
+  describe('isNft', () => {
+    it('Check isNft function', () => {
+      expect(TokenUtils.isNft('MOS-b9b4b2-947a3912')).toBeTruthy();
+      expect(TokenUtils.isNft('MOS-b9b4b2')).toBeFalsy();
+    });
+  });
 });
-

--- a/src/test/unit/utils/tokens.utils.spec.ts
+++ b/src/test/unit/utils/tokens.utils.spec.ts
@@ -1,12 +1,6 @@
 import { TokenHelpers } from "src/utils/token.helpers";
 
 describe('Token Utils', () => {
-    describe('isEsdt', () => {
-        it('Check if is Esdt', () => {
-            expect(TokenHelpers.isEsdt('EWLD-e23800')).toBeTruthy();
-            expect(TokenHelpers.isEsdt('MARS-96823d-01')).toBeFalsy();
-        });
-    });
     describe('canBool', () => {
         it('Check function canBool', () => {
             expect(TokenHelpers.canBool('EWLD-e23800')).toBeFalsy();

--- a/src/test/unit/utils/tokens.utils.spec.ts
+++ b/src/test/unit/utils/tokens.utils.spec.ts
@@ -1,26 +1,26 @@
-import { TokenUtils } from "src/utils/token.utils";
+import { TokenHelpers } from "src/utils/token.helpers";
 
 describe('Token Utils', () => {
     describe('isEsdt', () => {
         it('Check if is Esdt', () => {
-            expect(TokenUtils.isEsdt('EWLD-e23800')).toBeTruthy();
-            expect(TokenUtils.isEsdt('MARS-96823d-01')).toBeFalsy();
+            expect(TokenHelpers.isEsdt('EWLD-e23800')).toBeTruthy();
+            expect(TokenHelpers.isEsdt('MARS-96823d-01')).toBeFalsy();
         });
     });
     describe('canBool', () => {
         it('Check function canBool', () => {
-            expect(TokenUtils.canBool('EWLD-e23800')).toBeFalsy();
-            expect(TokenUtils.canBool('MARS-96823d-01')).toBeFalsy();
+            expect(TokenHelpers.canBool('EWLD-e23800')).toBeFalsy();
+            expect(TokenHelpers.canBool('MARS-96823d-01')).toBeFalsy();
         });
     });
     describe('getUrlHash', () => {
         it('Check function getUrlHash', () => {
-            expect(TokenUtils.getUrlHash('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png')).toStrictEqual('947a3912');
+            expect(TokenHelpers.getUrlHash('https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png')).toStrictEqual('947a3912');
         });
     });
     describe('getThumbnailUrlIdentifier', () => {
         it('Check function getThumbnailUrlIdentifier', () => {
-            expect(TokenUtils.getThumbnailUrlIdentifier('MOS-b9b4b2-2710', 'https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png'))
+            expect(TokenHelpers.getThumbnailUrlIdentifier('MOS-b9b4b2-2710', 'https://media.elrond.com/nfts/asset/QmUUhAmBQKGkSqN775NZAAYUaqd8ssMadFg2UYSECSERz6/914.png'))
                 .toStrictEqual('MOS-b9b4b2-947a3912');
 
         });

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -6,21 +6,9 @@ import { TokenRoles } from "src/endpoints/tokens/entities/token.roles";
 import { ApiUtils } from '@elrondnetwork/erdnest';
 import '@elrondnetwork/erdnest/lib/utils/extensions/string.extensions';
 
-export class TokenUtils {
-  static isEsdt(tokenIdentifier: string) {
-    return tokenIdentifier.split('-').length === 2;
-  }
-
-  static isCollection(collectionIdentifier: string) {
-    return collectionIdentifier.split('-').length === 2;
-  }
-
+export class TokenHelpers {
   static canBool(string: string) {
     return string.split('-').pop() === 'true';
-  }
-
-  static isNft(nftIdentifier: string) {
-    return nftIdentifier.split('-').length === 3;
   }
 
   static computeNftUri(uri: string, prefix: string) {
@@ -44,7 +32,7 @@ export class TokenUtils {
 
   static getThumbnailUrlIdentifier(nftIdentifier: string, fileUrl: string) {
     const collectionIdentifier = nftIdentifier.split('-').slice(0, 2).join('-');
-    const urlHash = TokenUtils.getUrlHash(fileUrl);
+    const urlHash = TokenHelpers.getUrlHash(fileUrl);
 
     return `${collectionIdentifier}-${urlHash}`;
   }


### PR DESCRIPTION
## Reasoning
- Improved validation for token, nft, collection endpoints
  
## Proposed Changes
- Implemented token, nft, collection pipes
- Renamed TokenUtils to TokenHelpers
- Use TokenUtils from erdnest

## How to test (mainnet)
- all endpoints using token, collection or nft identifier should be validated using pipes
