### PR TITLE
Fix token roles caching issue

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -436,10 +436,14 @@ export class TokenService {
     }
 
     const tokenAddressesRoles = await this.esdtService.getEsdtAddressesRoles(identifier);
-    const addressRoles = tokenAddressesRoles?.find((role: TokenRoles) => role.address === address);
+    let addressRoles = tokenAddressesRoles?.find((role: TokenRoles) => role.address === address);
+    if (addressRoles) {
+      // clone
+      addressRoles = new TokenRoles(JSON.parse(JSON.stringify(addressRoles)));
 
-    //@ts-ignore
-    delete addressRoles?.address;
+      //@ts-ignore
+      delete addressRoles?.address;
+    }
 
     return addressRoles;
   }


### PR DESCRIPTION
## Reasoning
- Token roles and address roles cause caching issue since address specific roles delete the address from the payload
  
## Proposed Changes
- Perform a clone before returning address-specific roles

## How to test (mainnet)
- make sure `indexer-v3` flag is set to false
- `/tokens/MEX-455c57/roles` should return all roles with address
- `/tokens/MEX-455c57/roles/erd1qqqqqqqqqqqqqpgqjpt0qqgsrdhp2xqygpjtfrpwf76f9nvg2jpsg4q7th` should return address-specific roles without address in payload
- `/tokens/MEX-455c57/roles` should return again all roles with address. The bug was manifesting itself that the address was missing in the case of the roles for the address `erd1qqqqqqqqqqqqqpgqjpt0qqgsrdhp2xqygpjtfrpwf76f9nvg2jpsg4q7th`
