### PR TITLE
Removed "Shard" from DNS contract label

### DIFF
--- a/src/common/assets/assets.service.ts
+++ b/src/common/assets/assets.service.ts
@@ -225,7 +225,7 @@ export class AssetsService {
 
     for (const [index, address] of DnsContracts.addresses.entries()) {
       allAssets[address] = new AccountAssets({
-        name: `Elrond DNS: Contract Shard ${index}`,
+        name: `Elrond DNS: Contract ${index}`,
         tags: ['dns'],
         icon: 'elrond',
       });


### PR DESCRIPTION
## Proposed Changes
- Removed "Shard" from DNS contract label

## How to test
- `/accounts/erd1qqqqqqqqqqqqqpgqez3jrxx3krhncmzhmzf8ksnjvmt0x6vrqreqvees8p` should return label `Elrond DNS: Contract Shard 242`
