### PR TITLE
support for light gateway urls

### DIFF
--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -28,6 +28,15 @@ export class ApiConfigService {
     return gatewayUrls[Math.floor(Math.random() * gatewayUrls.length)];
   }
 
+  getLightGatewayUrl(): string | undefined {
+    const gatewayUrls = this.configService.get<string[]>('urls.lightGateway');
+    if (!gatewayUrls) {
+      return undefined;
+    }
+
+    return gatewayUrls[Math.floor(Math.random() * gatewayUrls.length)];
+  }
+
   getElasticUrl(): string {
     const elasticUrls = this.configService.get<string[]>('urls.elastic');
     if (!elasticUrls) {

--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -38,12 +38,27 @@ export class GatewayService {
     const profiler = new PerformanceProfiler();
 
     try {
-      return await this.apiService.get(`${this.apiConfigService.getGatewayUrl()}/${url}`, new ApiSettings(), errorHandler);
+      return await this.apiService.get(`${this.getUrl(component)}/${url}`, new ApiSettings(), errorHandler);
     } finally {
       profiler.stop();
 
       this.metricsService.setGatewayDuration(component, profiler.duration);
     }
+  }
+
+  private getUrl(component: GatewayComponentRequest): string {
+    const lightGatewayComponents = [
+      GatewayComponentRequest.addressBalance,
+      GatewayComponentRequest.addressDetails,
+      GatewayComponentRequest.addressEsdt,
+      GatewayComponentRequest.vmQuery,
+    ];
+
+    if (lightGatewayComponents.includes(component)) {
+      return this.apiConfigService.getLightGatewayUrl() ?? this.apiConfigService.getGatewayUrl();
+    }
+
+    return this.apiConfigService.getGatewayUrl();
   }
 
   async create(url: string, component: GatewayComponentRequest, data: any, errorHandler?: (error: any) => Promise<boolean>): Promise<any> {


### PR DESCRIPTION
## Reasoning
- Support for alternative gateway that contains only state, not historical information
  
## Proposed Changes
- Possibility to define light gateway url, backwards compatible
- Target lighter gateway for some gateway-related requests

## How to test
- vm queries & address details should target light gatway
