### PR TITLE
add nft collection/tokens validation identifier

### DIFF
--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -9,7 +9,7 @@ import { NftType } from "./entities/nft.type";
 import { NftService } from "./nft.service";
 import { QueryPagination } from 'src/common/entities/query.pagination';
 import { NftQueryOptions } from './entities/nft.query.options';
-import { ParseAddressPipe, ParseOptionalBoolPipe, ParseArrayPipe, ParseOptionalIntPipe, ParseNftPipe } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseOptionalBoolPipe, ParseArrayPipe, ParseOptionalIntPipe, ParseNftPipe, ParseCollectionPipe } from '@elrondnetwork/erdnest';
 
 @Controller()
 @ApiTags('nfts')
@@ -44,7 +44,7 @@ export class NftController {
     @Query('search') search?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('type') type?: NftType,
-    @Query('collection') collection?: string,
+    @Query('collection', ParseCollectionPipe) collection?: string,
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
@@ -86,7 +86,7 @@ export class NftController {
     @Query('search') search?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('type') type?: NftType,
-    @Query('collection') collection?: string,
+    @Query('collection', ParseCollectionPipe) collection?: string,
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
@@ -105,7 +105,7 @@ export class NftController {
     @Query('search') search?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('type') type?: NftType,
-    @Query('collection') collection?: string,
+    @Query('collection', ParseCollectionPipe) collection?: string,
     @Query('name') name?: string,
     @Query('tags', ParseArrayPipe) tags?: string[],
     @Query('creator', ParseAddressPipe) creator?: string,
@@ -192,11 +192,7 @@ export class NftController {
 
   @Get('/nfts/:identifier/owners/count')
   @ApiOperation({ deprecated: true })
-  @ApiResponse({
-    status: 200,
-    description: 'Non-fungible / semi-fungible token owners count',
-    type: Number,
-  })
+  @ApiResponse({ status: 200, description: 'Non-fungible / semi-fungible token owners count', type: Number })
   async getNftOwnersCount(
     @Param('identifier', ParseNftPipe) identifier: string
   ): Promise<number> {

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -67,7 +67,7 @@ export class TokenController {
   async getTokenCount(
     @Query('search') search?: string,
     @Query('name') name?: string,
-    @Query('identifier') identifier?: string,
+    @Query('identifier', ParseTokenPipe) identifier?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
   ): Promise<number> {
     return await this.tokenService.getTokenCount(new TokenFilter({ search, name, identifier, identifiers }));


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- NFT collection filter validation missing
- Token identifier filter validation missing
  
## Proposed Changes
-  Add validation pipes

## How to test
- tokens/MEX-455c57/accounts/count -> should return all token accounts count
- tokens/MEX455c57/accounts/count -> should return bad request `Invalid token identifier`