### PR TITLE
Receiver assets in transaction action receiver

### DIFF
--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -149,6 +149,10 @@ export class TransactionService {
 
     transaction.senderAssets = accountAssets[transaction.sender];
     transaction.receiverAssets = accountAssets[transaction.receiver];
+
+    if (transaction.action?.arguments?.receiver) {
+      transaction.action.arguments.receiverAssets = accountAssets[transaction.action.arguments.receiver];
+    }
   }
 
   async applyAssetsDetailed(transaction: TransactionDetailed): Promise<void> {
@@ -240,8 +244,8 @@ export class TransactionService {
       await this.pluginsService.processTransaction(transaction);
 
       transaction.action = await this.transactionActionService.getTransactionAction(transaction);
-      transaction.pendingResults = await this.getPendingResults(transaction);
 
+      transaction.pendingResults = await this.getPendingResults(transaction);
       if (transaction.pendingResults === true) {
         transaction.status = TransactionStatus.pending;
       }


### PR DESCRIPTION
## Proposed Changes
- Provide assets information also in the case of actual NFTTransfer / MultiESDTNFTTransfer receiver

## How to test (mainnet)
- `/transactions/8cf191a259cbd29775aa85055e6c33241c9a7a5cc25872ab60aacf1aa936338f` should provide `action.arguments.receiverAssets`
