### PR TITLE
Proactively refresh nft media & metadata after processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^8.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.29",
+        "@elrondnetwork/erdnest": "^0.1.30",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2450,9 +2450,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.29.tgz",
-      "integrity": "sha512-s4PYoOTrOg8Vl1jdhlcy+Eq742te+rSWtLtn2GSiYE2Fxxty/XQGHbmm7GnN68+llYFdP/XY8342qsS9jdB7Vg==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.30.tgz",
+      "integrity": "sha512-8vBaU/YZqiZZxU6Zi/h/8YdA2dH/mvTLlQgdyxKonQ3Hji+MsemJLDUD5hcNR9hphcS7iF8QPMoQcIWZrw0BWQ==",
       "dependencies": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",
@@ -18415,9 +18415,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.29.tgz",
-      "integrity": "sha512-s4PYoOTrOg8Vl1jdhlcy+Eq742te+rSWtLtn2GSiYE2Fxxty/XQGHbmm7GnN68+llYFdP/XY8342qsS9jdB7Vg==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.30.tgz",
+      "integrity": "sha512-8vBaU/YZqiZZxU6Zi/h/8YdA2dH/mvTLlQgdyxKonQ3Hji+MsemJLDUD5hcNR9hphcS7iF8QPMoQcIWZrw0BWQ==",
       "requires": {
         "@elrondnetwork/native-auth-server": "^0.1.1",
         "@golevelup/nestjs-rabbitmq": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^8.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.29",
+    "@elrondnetwork/erdnest": "^0.1.30",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/queue.worker/nft.worker/nft.worker.module.ts
+++ b/src/queue.worker/nft.worker/nft.worker.module.ts
@@ -14,7 +14,8 @@ import { NftThumbnailModule } from './queue/job-services/thumbnails/nft.thumbnai
     NftThumbnailModule,
     NftAssetModule,
   ],
-  providers: [NftWorkerService,
+  providers: [
+    NftWorkerService,
     {
       provide: 'QUEUE_SERVICE',
       useFactory: (configService: ApiConfigService) => {

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.module.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { PersistenceModule } from 'src/common/persistence/persistence.module';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { NftMediaService } from './nft.media.service';
 
 @Module({
@@ -9,6 +10,7 @@ import { NftMediaService } from './nft.media.service';
   controllers: [],
   providers: [
     NftMediaService,
+    DynamicModuleUtils.getPubSubService(),
   ],
   exports: [
     NftMediaService,

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -1,6 +1,6 @@
 import { ApiService, CachingService } from "@elrondnetwork/erdnest";
 import { BinaryUtils, Constants } from "@elrondnetwork/erdnest";
-import { HttpStatus, Injectable, Logger } from "@nestjs/common";
+import { HttpStatus, Inject, Injectable, Logger } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { CacheInfo } from "src/utils/cache.info";
 import { PersistenceService } from "src/common/persistence/persistence.service";
@@ -9,6 +9,7 @@ import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { TokenHelpers } from "src/utils/token.helpers";
+import { ClientProxy } from "@nestjs/microservices";
 
 @Injectable()
 export class NftMediaService {
@@ -21,6 +22,7 @@ export class NftMediaService {
     private readonly apiService: ApiService,
     private readonly apiConfigService: ApiConfigService,
     private readonly persistenceService: PersistenceService,
+    @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
   ) {
     this.logger = new Logger(NftMediaService.name);
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
@@ -47,6 +49,11 @@ export class NftMediaService {
       mediaRaw,
       CacheInfo.NftMedia(nft.identifier).ttl
     );
+
+    await this.clientProxy.emit('refreshCacheKey', {
+      key: CacheInfo.NftMedia(nft.identifier).key,
+      ttl: CacheInfo.NftMedia(nft.identifier).ttl,
+    });
 
     return mediaRaw;
   }

--- a/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.module.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.module.ts
@@ -1,5 +1,6 @@
 import { forwardRef, Module } from '@nestjs/common';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { NftMetadataService } from './nft.metadata.service';
 
 @Module({
@@ -9,6 +10,7 @@ import { NftMetadataService } from './nft.metadata.service';
   controllers: [],
   providers: [
     NftMetadataService,
+    DynamicModuleUtils.getPubSubService(),
   ],
   exports: [
     NftMetadataService,

--- a/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
@@ -1,10 +1,11 @@
 import { CachingService } from "@elrondnetwork/erdnest";
-import { Injectable, Logger } from "@nestjs/common";
+import { Inject, Injectable, Logger } from "@nestjs/common";
 import { CacheInfo } from "src/utils/cache.info";
 import { PersistenceService } from "src/common/persistence/persistence.service";
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { NftExtendedAttributesService } from "src/endpoints/nfts/nft.extendedattributes.service";
+import { ClientProxy } from "@nestjs/microservices";
 
 
 @Injectable()
@@ -15,6 +16,7 @@ export class NftMetadataService {
     private readonly nftExtendedAttributesService: NftExtendedAttributesService,
     private readonly persistenceService: PersistenceService,
     private readonly cachingService: CachingService,
+    @Inject('PUBSUB_SERVICE') private clientProxy: ClientProxy,
   ) {
     this.logger = new Logger(NftMetadataService.name);
   }
@@ -55,6 +57,11 @@ export class NftMetadataService {
       metadataRaw,
       CacheInfo.NftMetadata(nft.identifier).ttl
     );
+
+    await this.clientProxy.emit('refreshCacheKey', {
+      key: CacheInfo.NftMetadata(nft.identifier).key,
+      ttl: CacheInfo.NftMetadata(nft.identifier).ttl,
+    });
 
     return metadataRaw;
   }


### PR DESCRIPTION
## Reasoning
- It took up to 10 minutes for media & metadata to appear, although they were processed in a few seconds
  
## Proposed Changes
- After saving media / metadata, also trigger a cache invalidation to refresh the value in the local cache of the instances

## How to test
- While minting a new NFT, for a few seconds default media should be returned, then the actual media should appear
