### PR TITLE
Update NFT metadata on refresh

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/metadata/nft.metadata.service.ts
@@ -48,10 +48,8 @@ export class NftMetadataService {
       metadataRaw = {};
     }
 
-    await this.persistenceService.deleteMetadata(nft.identifier);
     await this.persistenceService.setMetadata(nft.identifier, metadataRaw);
 
-    await this.cachingService.deleteInCache(CacheInfo.NftMetadata(nft.identifier).key);
     await this.cachingService.setCache(
       CacheInfo.NftMetadata(nft.identifier).key,
       metadataRaw,

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -70,7 +70,7 @@ export class NftQueueController {
 
       if (nft.metadata && settings.forceRefreshMetadata) {
         const oldMetadata = nft.metadata;
-        nft.metadata = await this.refreshMetadata(nft);
+        nft.metadata = await this.nftMetadataService.refreshMetadata(nft);
         const newMetadata = nft.metadata;
         if (newMetadata) {
           this.logger.log(`Refreshed NFT metadata. Old: '${JSON.stringify(oldMetadata)}', New: '${JSON.stringify(newMetadata)}'`);
@@ -80,7 +80,7 @@ export class NftQueueController {
 
         this.clientProxy.emit('deleteCacheKeys', [CacheInfo.NftMetadata(nft.identifier).key]);
       } else if (!nft.metadata) {
-        nft.metadata = await this.refreshMetadata(nft);
+        nft.metadata = await this.nftMetadataService.refreshMetadata(nft);
       }
 
       nft.media = await this.nftMediaService.getMedia(nft.identifier) ?? undefined;
@@ -113,10 +113,6 @@ export class NftQueueController {
 
       channel.reject(message, false);
     }
-  }
-
-  private async refreshMetadata(nft: Nft) {
-    return await this.nftMetadataService.refreshMetadata(nft);
   }
 
   private async generateThumbnail(nft: Nft, media: NftMedia, forceRefresh: boolean = false): Promise<void> {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- No need to delete metadata from database since on set the value is updated
  
## Proposed Changes
- Just set metadata on refresh

## How to test
- Create a new NFT, check if metadata is returned
- Trigger a force refresh on metadata
