### PR TITLE
Drop support for legacy elastic

### DIFF
--- a/config/config.e2e-mocked.mainnet.yaml
+++ b/config/config.e2e-mocked.mainnet.yaml
@@ -1,6 +1,5 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
-useLegacyElastic: false
 api:
   public: true
   private: true

--- a/config/config.e2e.mainnet.yaml
+++ b/config/config.e2e.mainnet.yaml
@@ -1,6 +1,5 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
-useLegacyElastic: false
 api:
   public: true
   private: true

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -1,6 +1,5 @@
 network: 'mainnet'
 metaChainShardId: 4294967295
-useLegacyElastic: false
 api:
   public: true
   private: true

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -507,15 +507,6 @@ export class ApiConfigService {
     return metaChainShardId;
   }
 
-  getUseLegacyElastic(): boolean {
-    const useLegacyElastic = this.configService.get<boolean>('useLegacyElastic');
-    if (useLegacyElastic === undefined) {
-      return false;
-    }
-
-    return useLegacyElastic;
-  }
-
   getRateLimiterSecret(): string | undefined {
     return this.configService.get<string>('rateLimiterSecret');
   }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -913,7 +913,7 @@ export class ElasticIndexerService implements IndexerInterface {
       queries.push(shardIdQuery);
     }
 
-    if (filter.epoch !== undefined && !this.apiConfigService.getUseLegacyElastic()) {
+    if (filter.epoch !== undefined) {
       const epochQuery = QueryType.Match('epoch', filter.epoch);
       queries.push(epochQuery);
     }

--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -117,7 +117,7 @@ export class AccountService {
         account = { ...account, ...codeAttributes };
       }
 
-      if (account.code && !this.apiConfigService.getUseLegacyElastic()) {
+      if (account.code) {
         const deployedAt = await this.getAccountDeployedAt(address);
         if (deployedAt) {
           account.deployedAt = deployedAt;
@@ -142,10 +142,6 @@ export class AccountService {
   }
 
   async getAccountScResults(address: string): Promise<number> {
-    if (this.apiConfigService.getUseLegacyElastic()) {
-      return 0;
-    }
-
     if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
       return await this.smartContractResultService.getAccountScResultsCount(address);
     }

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -1,5 +1,4 @@
 import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { SmartContractResult } from "../sc-results/entities/smart.contract.result";
@@ -20,7 +19,6 @@ export class TransactionGetService {
   constructor(
     private readonly indexerService: IndexerService,
     private readonly gatewayService: GatewayService,
-    private readonly apiConfigService: ApiConfigService,
     @Inject(forwardRef(() => TokenTransferService))
     private readonly tokenTransferService: TokenTransferService,
   ) {
@@ -72,40 +70,38 @@ export class TransactionGetService {
       hashes.push(txHash);
       const previousHashes: Record<string, string> = {};
 
-      if (!this.apiConfigService.getUseLegacyElastic()) {
-        if (result.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
-          transactionDetailed.results = await this.getTransactionScResultsFromElastic(transactionDetailed.txHash);
+      if (result.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
+        transactionDetailed.results = await this.getTransactionScResultsFromElastic(transactionDetailed.txHash);
 
-          for (const scResult of transactionDetailed.results) {
-            hashes.push(scResult.hash);
-            previousHashes[scResult.hash] = scResult.prevTxHash;
-          }
+        for (const scResult of transactionDetailed.results) {
+          hashes.push(scResult.hash);
+          previousHashes[scResult.hash] = scResult.prevTxHash;
+        }
+      }
+
+      if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.receipt)) {
+        const receipts = await this.indexerService.getTransactionReceipts(txHash);
+        if (receipts.length > 0) {
+          const receipt = receipts[0];
+          transactionDetailed.receipt = ApiUtils.mergeObjects(new TransactionReceipt(), receipt);
+        }
+      }
+
+      if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.logs)) {
+        const logs = await this.getTransactionLogsFromElastic(hashes);
+
+        if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.operations)) {
+          transactionDetailed.operations = await this.tokenTransferService.getOperationsForTransaction(transactionDetailed, logs);
+          transactionDetailed.operations = TransactionUtils.trimOperations(transactionDetailed.sender, transactionDetailed.operations, previousHashes);
         }
 
-        if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.receipt)) {
-          const receipts = await this.indexerService.getTransactionReceipts(txHash);
-          if (receipts.length > 0) {
-            const receipt = receipts[0];
-            transactionDetailed.receipt = ApiUtils.mergeObjects(new TransactionReceipt(), receipt);
-          }
-        }
-
-        if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.logs)) {
-          const logs = await this.getTransactionLogsFromElastic(hashes);
-
-          if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.operations)) {
-            transactionDetailed.operations = await this.tokenTransferService.getOperationsForTransaction(transactionDetailed, logs);
-            transactionDetailed.operations = TransactionUtils.trimOperations(transactionDetailed.sender, transactionDetailed.operations, previousHashes);
-          }
-
-          for (const log of logs) {
-            if (log.id === txHash) {
-              transactionDetailed.logs = log;
-            } else if (transactionDetailed.results) {
-              const foundScResult = transactionDetailed.results.find(({ hash }) => log.id === hash);
-              if (foundScResult) {
-                foundScResult.logs = log;
-              }
+        for (const log of logs) {
+          if (log.id === txHash) {
+            transactionDetailed.logs = log;
+          } else if (transactionDetailed.results) {
+            const foundScResult = transactionDetailed.results.find(({ hash }) => log.id === hash);
+            if (foundScResult) {
+              foundScResult.logs = log;
             }
           }
         }

--- a/src/test/integration/accounts.e2e-spec.ts
+++ b/src/test/integration/accounts.e2e-spec.ts
@@ -117,24 +117,6 @@ describe('Account Service', () => {
           'username', 'shard', 'developerReward', 'ownerAddress', 'scamInfo',
         ]);
     });
-
-    it("should return account details if getUseLegacyElastic is active", async () => {
-      const mock_isAddressValid = jest.spyOn(AddressUtils, 'isAddressValid');
-      mock_isAddressValid.mockImplementation(() => true);
-
-      jest.spyOn(ApiConfigService.prototype, 'getUseLegacyElastic')
-        // eslint-disable-next-line require-await
-        .mockImplementation(jest.fn(() => true));
-
-      const address: string = "erd1cnyng48s8lrjn95rpdfgykxl5993c5qhn5jqt0ar960f7v3umnrsy9yx0s";
-      const results = await accountService.getAccount(address);
-
-      expect(results).toHaveProperties(
-        ['address', 'balance', 'nonce', 'shard', 'code',
-          'codeHash', 'rootHash', 'txCount', 'scrCount',
-          'username', 'shard', 'developerReward', 'ownerAddress', 'scamInfo',
-        ]);
-    });
   });
 
   describe("getAccountDeployedAt", () => {

--- a/src/test/integration/api.config.e2e-spec.ts
+++ b/src/test/integration/api.config.e2e-spec.ts
@@ -1134,26 +1134,6 @@ describe('API Config', () => {
     });
   });
 
-  describe("getUseLegacyElastic", () => {
-    it("should return database slave connections", () => {
-      jest
-        .spyOn(ConfigService.prototype, "get")
-        .mockImplementation(jest.fn(() => true));
-
-      const results = apiConfigService.getUseLegacyElastic();
-      expect(results).toEqual(true);
-    });
-
-    it("should return false value because test simulates that use legacy elastic is not defined", () => {
-      jest
-        .spyOn(ConfigService.prototype, 'get')
-        .mockImplementation(jest.fn(() => undefined));
-
-      const results = apiConfigService.getUseLegacyElastic();
-      expect(results).toEqual(false);
-    });
-  });
-
   describe("getRateLimiterSecret", () => {
     it("should return undefined if rate limeter secret is not defined", () => {
       jest


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- It's been a long time since we had the `useLegacyElastic` flag and we have to make it deprecated
  
## Proposed Changes
- Removed `useLegacyElastic` flag
