### PR TITLE
Nft media needs processing

### DIFF
--- a/src/queue.worker/nft.worker/nft.worker.module.ts
+++ b/src/queue.worker/nft.worker/nft.worker.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ClientProxyFactory, Transport } from '@nestjs/microservices';
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
+import { PersistenceModule } from 'src/common/persistence/persistence.module';
 import { NftWorkerService } from './nft.worker.service';
 import { NftAssetModule } from './queue/job-services/assets/nft.asset.module';
 import { NftMediaModule } from './queue/job-services/media/nft.media.module';
@@ -13,6 +14,7 @@ import { NftThumbnailModule } from './queue/job-services/thumbnails/nft.thumbnai
     NftMetadataModule,
     NftThumbnailModule,
     NftAssetModule,
+    PersistenceModule,
   ],
   providers: [
     NftWorkerService,

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -8,6 +8,7 @@ import { ClientProxy } from "@nestjs/microservices";
 import { NftMessage } from "./queue/entities/nft.message";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { NftAssetService } from "./queue/job-services/assets/nft.asset.service";
+import { TokenHelpers } from "src/utils/token.helpers";
 
 @Injectable()
 export class NftWorkerService {
@@ -47,11 +48,11 @@ export class NftWorkerService {
       return false;
     }
 
-    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail || settings.uploadAsset) {
+    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail) {
       return true;
     }
 
-    if (!nft.media || nft.media.length === 0) {
+    if (!nft.media || nft.media.length === 0 || TokenHelpers.hasDefaultMedia(nft)) {
       return true;
     }
 

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -54,11 +54,9 @@ export class NftWorkerService {
     }
 
     const media = await this.persistenceService.getMedia(nft.identifier);
-    if (media == null) {
+    if (media === null) {
       return true;
     }
-
-    nft.media = media;
 
     if (!nft.metadata) {
       return true;
@@ -76,8 +74,8 @@ export class NftWorkerService {
     }
 
     if (settings.uploadAsset) {
-      for (const media of nft.media) {
-        const isAssetUploaded = await this.nftAssetService.isAssetUploaded(media);
+      for (const mediaItem of media) {
+        const isAssetUploaded = await this.nftAssetService.isAssetUploaded(mediaItem);
         if (!isAssetUploaded) {
           return true;
         }

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -47,7 +47,7 @@ export class NftWorkerService {
       return false;
     }
 
-    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail) {
+    if (settings.forceRefreshMedia || settings.forceRefreshMetadata || settings.forceRefreshThumbnail || settings.uploadAsset) {
       return true;
     }
 

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -49,6 +49,10 @@ export class TokenHelpers {
     return true;
   }
 
+  static hasDefaultMedia(nft: Nft): boolean {
+    return nft.media?.length == 1 && nft.media[0].url.includes('default');
+  }
+
   static setTokenRole(tokenRoles: TokenRoles, role: string) {
     tokenRoles.roles.push(role);
 

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -49,10 +49,6 @@ export class TokenHelpers {
     return true;
   }
 
-  static hasDefaultMedia(nft: Nft): boolean {
-    return nft.media?.length == 1 && nft.media[0].url.includes('default');
-  }
-
   static setTokenRole(tokenRoles: TokenRoles, role: string) {
     tokenRoles.roles.push(role);
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Nft worker will never considerate that NFT needs processing if it doesn't have media
  
## Proposed Changes
- Check if NFT has default media, if it has then needs processing

## How to test
- Create an NFT and do not trigger process on NFT create
- Tigger NFT process manually or check using cron if processing is triggered
