### PR TITLE
Transaction send return actual errors

### DIFF
--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -197,19 +197,11 @@ export class TransactionService {
 
     let txHash: string;
     try {
-      // eslint-disable-next-line require-await
-      const result = await this.gatewayService.create('transaction/send', GatewayComponentRequest.sendTransaction, transaction, async (error) => {
-        const message = error.response?.data?.error;
-        if (message && message.includes('transaction generation failed')) {
-          throw error;
-        }
-
-        return false;
-      });
+      const result = await this.gatewayService.create('transaction/send', GatewayComponentRequest.sendTransaction, transaction);
 
       txHash = result?.txHash;
     } catch (error: any) {
-      return error.response?.error ?? '';
+      return error.response?.error ?? error.response?.data?.error ?? '';
     }
 
     return {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- errors were not displayed when malformed transactions were sent

## Proposed Changes
- return actual errors when sending transactions

## How to test
- call `POST /transactions` with a malformed transaction. It should return an error message