### PR TITLE
get transaction from gateway only if not found in elastic

### DIFF
--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -175,12 +175,16 @@ export class TransactionController {
     @Param('txHash', ParseTransactionHashPipe) txHash: string,
     @Query('fields', ParseArrayPipe) fields?: string[],
   ): Promise<TransactionDetailed> {
-    const transaction = await this.transactionService.getTransaction(txHash, fields);
-    if (transaction === null) {
-      throw new HttpException('Transaction not found', HttpStatus.NOT_FOUND);
-    }
+    try {
+      const transaction = await this.transactionService.getTransaction(txHash, fields);
+      if (transaction === null) {
+        throw new HttpException('Transaction not found', HttpStatus.NOT_FOUND);
+      }
 
-    return transaction;
+      return transaction;
+    } catch (error: any) {
+      throw new HttpException(error.message, error.status);
+    }
   }
 
   @Post('/transactions')

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -65,7 +65,7 @@ export class TransactionGetService {
       this.logger.error(`Unexpected error when getting transaction from elastic, hash '${txHash}'`);
       this.logger.error(error);
 
-      if (error.status !== HttpStatus.NOT_FOUND) {
+      if (error.response.status !== HttpStatus.NOT_FOUND) {
         throw new HttpException('Could not get transaction', HttpStatus.BAD_GATEWAY);
       }
 

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
+import { forwardRef, HttpException, HttpStatus, Inject, Injectable, Logger } from "@nestjs/common";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { SmartContractResult } from "../sc-results/entities/smart.contract.result";
@@ -54,23 +54,36 @@ export class TransactionGetService {
   }
 
   async tryGetTransactionFromElastic(txHash: string, fields?: string[]): Promise<TransactionDetailed | null> {
+    let transaction: any;
     try {
-      const result = await this.indexerService.getTransaction(txHash) as any;
-      if (!result) {
+      transaction = await this.indexerService.getTransaction(txHash);
+
+      if (!transaction) {
         return null;
       }
+    } catch (error: any) {
+      this.logger.error(`Unexpected error when getting transaction from elastic, hash '${txHash}'`);
+      this.logger.error(error);
 
-      if (result.scResults) {
-        result.results = result.scResults;
+      if (error.response.statusCode !== HttpStatus.NOT_FOUND) {
+        throw new HttpException('Could not get transaction', HttpStatus.BAD_GATEWAY);
       }
 
-      const transactionDetailed: TransactionDetailed = ApiUtils.mergeObjects(new TransactionDetailed(), result);
+      return null;
+    }
+
+    try {
+      if (transaction.scResults) {
+        transaction.results = transaction.scResults;
+      }
+
+      const transactionDetailed: TransactionDetailed = ApiUtils.mergeObjects(new TransactionDetailed(), transaction);
 
       const hashes: string[] = [];
       hashes.push(txHash);
       const previousHashes: Record<string, string> = {};
 
-      if (result.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
+      if (transaction.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
         transactionDetailed.results = await this.getTransactionScResultsFromElastic(transactionDetailed.txHash);
 
         for (const scResult of transactionDetailed.results) {

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -65,7 +65,7 @@ export class TransactionGetService {
       this.logger.error(`Unexpected error when getting transaction from elastic, hash '${txHash}'`);
       this.logger.error(error);
 
-      if (error.response.statusCode !== HttpStatus.NOT_FOUND) {
+      if (error.status !== HttpStatus.NOT_FOUND) {
         throw new HttpException('Could not get transaction', HttpStatus.BAD_GATEWAY);
       }
 

--- a/src/test/integration/transaction.get.e2e-spec.ts
+++ b/src/test/integration/transaction.get.e2e-spec.ts
@@ -65,10 +65,10 @@ describe('Transaction Get Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (txHash: string) => {
           if (txHash == hash) {
-            throw new HttpException("NOT FOUND", HttpStatus.NOT_FOUND);
+            throw new HttpException({ status: HttpStatus.NOT_FOUND, message: "NOT FOUND" }, HttpStatus.NOT_FOUND);
           }
 
-          throw new HttpException("BAD GATEWAY", HttpStatus.BAD_GATEWAY);
+          throw new HttpException({ status: HttpStatus.BAD_GATEWAY, message: "BAD GATEWAY" }, HttpStatus.BAD_GATEWAY);
         }));
 
       const transaction = await transactionGetService.tryGetTransactionFromElastic(hash);
@@ -82,7 +82,7 @@ describe('Transaction Get Service', () => {
         .spyOn(IndexerService.prototype, "getTransaction")
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (_: string) => {
-          throw new HttpException("BAD GATEWAY", HttpStatus.GATEWAY_TIMEOUT);
+          throw new HttpException({ status: HttpStatus.BAD_GATEWAY, message: "BAD GATEWAY" }, HttpStatus.BAD_GATEWAY);
         }));
 
       await expect(transactionGetService.tryGetTransactionFromElastic(hash)).rejects.toThrow(Error);


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- If Elastic is down the load is redirected to gateway
  
## Proposed Changes
- Fallback to gateway only if transaction is not found in elastic 

## How to test
- Check fallback if elastic is down
- Check if a transaction is returned if exists only on gateway
