### PR TITLE
Small adjustments & refactorings for transaction handling

### DIFF
--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -58,7 +58,7 @@ export interface IndexerInterface {
 
   getCollection(identifier: string): Promise<Collection>
 
-  getTransaction(txHash: string): Promise<Transaction>
+  getTransaction(txHash: string): Promise<Transaction | null>
 
   getScDeploy(address: string): Promise<ScDeploy>
 

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -128,7 +128,7 @@ export class IndexerService implements IndexerInterface {
     return await this.execute('getCollection', this.indexerInterface.getCollection(identifier));
   }
 
-  async getTransaction(txHash: string): Promise<Transaction> {
+  async getTransaction(txHash: string): Promise<Transaction | null> {
     return await this.execute('getTransaction', this.indexerInterface.getTransaction(txHash));
   }
 

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -96,7 +96,7 @@ export class AccountController {
   async getAccountDetails(@Param('address', ParseAddressPipe) address: string): Promise<AccountDetailed> {
     const account = await this.accountService.getAccount(address);
     if (!account) {
-      throw new HttpException('Account not found', HttpStatus.NOT_FOUND);
+      throw new NotFoundException('Account not found');
     }
 
     return account;

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -1,6 +1,6 @@
 import { ParseArrayPipe, QueryConditionOptions } from '@elrondnetwork/erdnest';
 import { ParseAddressPipe, ParseBlockHashPipe, ParseOptionalBoolPipe, ParseOptionalEnumPipe, ParseOptionalIntPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
-import { BadRequestException, Body, Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
+import { BadRequestException, Body, Controller, DefaultValuePipe, Get, NotFoundException, Param, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { ApiCreatedResponse, ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { QueryPagination } from 'src/common/entities/query.pagination';
 import { SortOrder } from 'src/common/entities/sort.order';
@@ -175,16 +175,12 @@ export class TransactionController {
     @Param('txHash', ParseTransactionHashPipe) txHash: string,
     @Query('fields', ParseArrayPipe) fields?: string[],
   ): Promise<TransactionDetailed> {
-    try {
-      const transaction = await this.transactionService.getTransaction(txHash, fields);
-      if (transaction === null) {
-        throw new HttpException('Transaction not found', HttpStatus.NOT_FOUND);
-      }
-
-      return transaction;
-    } catch (error: any) {
-      throw new HttpException(error.message, error.status);
+    const transaction = await this.transactionService.getTransaction(txHash, fields);
+    if (transaction === null) {
+      throw new NotFoundException('Transaction not found');
     }
+
+    return transaction;
   }
 
   @Post('/transactions')
@@ -206,7 +202,7 @@ export class TransactionController {
     const result = await this.transactionService.createTransaction(transaction);
 
     if (typeof result === 'string' || result instanceof String) {
-      throw new HttpException(result, HttpStatus.BAD_REQUEST);
+      throw new BadRequestException(result);
     }
 
     return result;

--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -1,4 +1,4 @@
-import { forwardRef, HttpException, HttpStatus, Inject, Injectable, Logger } from "@nestjs/common";
+import { forwardRef, Inject, Injectable, Logger } from "@nestjs/common";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { SmartContractResult } from "../sc-results/entities/smart.contract.result";
@@ -57,7 +57,6 @@ export class TransactionGetService {
     let transaction: any;
     try {
       transaction = await this.indexerService.getTransaction(txHash);
-
       if (!transaction) {
         return null;
       }
@@ -65,11 +64,7 @@ export class TransactionGetService {
       this.logger.error(`Unexpected error when getting transaction from elastic, hash '${txHash}'`);
       this.logger.error(error);
 
-      if (error.response.status !== HttpStatus.NOT_FOUND) {
-        throw new HttpException('Could not get transaction', HttpStatus.BAD_GATEWAY);
-      }
-
-      return null;
+      throw error;
     }
 
     try {

--- a/src/test/integration/transaction.get.e2e-spec.ts
+++ b/src/test/integration/transaction.get.e2e-spec.ts
@@ -65,7 +65,7 @@ describe('Transaction Get Service', () => {
         // eslint-disable-next-line require-await
         .mockImplementation(jest.fn(async (txHash: string) => {
           if (txHash == hash) {
-            throw new HttpException({ status: HttpStatus.NOT_FOUND, message: "NOT FOUND" }, HttpStatus.NOT_FOUND);
+            return null;
           }
 
           throw new HttpException({ status: HttpStatus.BAD_GATEWAY, message: "BAD GATEWAY" }, HttpStatus.BAD_GATEWAY);


### PR DESCRIPTION
## Proposed Changes
- Small refactorings in the transaction area

## How to test
- ES error should return 500 internal server error, else the functionality should stay the same:
  - valid transaction retrieve should return transaction details
  - retrieving a tx hash that doesn't exist should return 404
