### PR TITLE
Add `computeScamInfo` flag for NFT list

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -420,10 +420,11 @@ export class AccountController {
     @Query('includeFlagged', new ParseOptionalBoolPipe) includeFlagged?: boolean,
     @Query('withSupply', new ParseOptionalBoolPipe) withSupply?: boolean,
     @Query('withScamInfo', new ParseOptionalBoolPipe) withScamInfo?: boolean,
+    @Query('computeScamInfo', new ParseOptionalBoolPipe) computeScamInfo?: boolean,
     @Query('source', new ParseOptionalEnumPipe(EsdtDataSource)) source?: EsdtDataSource,
   ): Promise<NftAccount[]> {
 
-    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withSupply, withScamInfo }));
+    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withSupply, withScamInfo, computeScamInfo }));
 
     return await this.nftService.getNftsForAddress(
       address,

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -182,9 +182,10 @@ export class CollectionController {
     @Query('withOwner', new ParseOptionalBoolPipe) withOwner?: boolean,
     @Query('withSupply', new ParseOptionalBoolPipe) withSupply?: boolean,
     @Query('withScamInfo', new ParseOptionalBoolPipe) withScamInfo?: boolean,
+    @Query('computeScamInfo', new ParseOptionalBoolPipe) computeScamInfo?: boolean,
   ): Promise<Nft[]> {
-    if ((withOwner === true || withSupply === true || withScamInfo === true) && size > 100) {
-      throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'withScamInfo'`);
+    if ((withOwner === true || withSupply === true || withScamInfo === true || computeScamInfo === true) && size > 100) {
+      throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner', 'withSupply', 'withScamInfo', or 'computeScamInfo'`);
     }
 
     const isCollection = await this.collectionService.isCollection(collection);
@@ -192,7 +193,7 @@ export class CollectionController {
       throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
     }
 
-    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withOwner, withSupply, withScamInfo }));
+    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withOwner, withSupply, withScamInfo, computeScamInfo }));
 
     return await this.nftService.getNfts(
       new QueryPagination({ from, size }),

--- a/src/endpoints/nfts/entities/nft.query.options.ts
+++ b/src/endpoints/nfts/entities/nft.query.options.ts
@@ -8,11 +8,13 @@ export class NftQueryOptions {
   withOwner?: boolean = false;
   withSupply?: boolean = false;
   withScamInfo?: boolean = false;
+  computeScamInfo?: boolean = false;
 
   //TODO: Remove this function when enforce is no longer needed
   static enforceScamInfoFlag(size: number, options: NftQueryOptions): NftQueryOptions {
     if (size <= SIZE_LIMIT) {
       options.withScamInfo = true;
+      options.computeScamInfo = true;
     }
 
     return options;

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -56,12 +56,13 @@ export class NftController {
     @Query('withOwner', new ParseOptionalBoolPipe) withOwner?: boolean,
     @Query('withSupply', new ParseOptionalBoolPipe) withSupply?: boolean,
     @Query('withScamInfo', new ParseOptionalBoolPipe) withScamInfo?: boolean,
+    @Query('computeScamInfo', new ParseOptionalBoolPipe) computeScamInfo?: boolean,
   ): Promise<Nft[]> {
-    if ((withOwner === true || withSupply === true || withScamInfo === true) && size > 100) {
-      throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'withScamInfo'`);
+    if ((withOwner === true || withSupply === true || withScamInfo === true || computeScamInfo === true) && size > 100) {
+      throw new BadRequestException(`Maximum size of 100 is allowed when activating flags 'withOwner', 'withSupply', 'withScamInfo' or 'computeScamInfo'`);
     }
 
-    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withOwner, withSupply, withScamInfo }));
+    const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withOwner, withSupply, withScamInfo, computeScamInfo }));
 
     return await this.nftService.getNfts(
       new QueryPagination({ from, size }),

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -96,7 +96,7 @@ export class NftService {
       await this.applyUnlockSchedule(nft);
     }
 
-    await this.pluginService.batchProcessNfts(nfts, queryOptions?.withScamInfo);
+    await this.pluginService.batchProcessNfts(nfts, queryOptions?.withScamInfo || queryOptions?.computeScamInfo);
 
     return nfts;
   }
@@ -432,7 +432,7 @@ export class NftService {
       await this.applyUnlockSchedule(nft);
     }
 
-    await this.pluginService.batchProcessNfts(nfts, queryOptions?.withScamInfo);
+    await this.pluginService.batchProcessNfts(nfts, queryOptions?.withScamInfo || queryOptions?.computeScamInfo);
 
     return nfts;
   }
@@ -480,7 +480,7 @@ export class NftService {
       return undefined;
     }
 
-    const nfts = await this.getNftsForAddress(address, new QueryPagination({ from: 0, size: 1 }), filter, new NftQueryOptions({ withScamInfo: true }));
+    const nfts = await this.getNftsForAddress(address, new QueryPagination({ from: 0, size: 1 }), filter, new NftQueryOptions({ withScamInfo: true, computeScamInfo: true }));
     if (nfts.length === 0) {
       return undefined;
     }


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- NFTs scam info processing is CPU intensive
  
## Proposed Changes
- add a flag that triggers NFTs scam info processing

## How to test
- `/nfts` - does not return any scam info
- `/nfts?computeScamInfo=true` - scam info should appear for NFTs that are scam