### PR TITLE
implement content size limit for NFT media

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -152,7 +152,7 @@ export class NftMediaService {
       return false;
     }
 
-    const FILE_SIZE_LIMIT = 64000000; // ~64MB
+    const FILE_SIZE_LIMIT = 64 * 1024 * 1024; // ~64MB
     if (fileProperties.contentLength > FILE_SIZE_LIMIT) {
       this.logger.log(`Media for NFT '${identifier}' excedded file size limit`);
 

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -85,6 +85,12 @@ export class NftMediaService {
       }
 
       if (!fileProperties) {
+        this.logger.log(`Empty file properties for NFT with identifier '${nft.identifier}'`);
+        continue;
+      }
+
+      if (!this.isContentAccepted(nft.identifier, fileProperties)) {
+        this.logger.log(`Content not accepted for NFT with identifier '${nft.identifier}'`);
         continue;
       }
 
@@ -136,14 +142,23 @@ export class NftMediaService {
     const contentType = headers['content-type'];
     const contentLength = Number(headers['content-length']);
 
-    if (!this.isContentAccepted(contentType)) {
-      return null;
-    }
-
     return { contentType, contentLength };
   }
 
-  private isContentAccepted(contentType: MediaMimeTypeEnum) {
-    return Object.values(MediaMimeTypeEnum).includes(contentType);
+  private isContentAccepted(identifier: string, fileProperties: { contentType: string, contentLength: number }): boolean {
+    if (!Object.values(MediaMimeTypeEnum).includes(fileProperties.contentType as MediaMimeTypeEnum)) {
+      this.logger.log(`Media mime type '${fileProperties.contentType}' is not supported'`);
+
+      return false;
+    }
+
+    const FILE_SIZE_LIMIT = 64000000; // ~64MB
+    if (fileProperties.contentLength > FILE_SIZE_LIMIT) {
+      this.logger.log(`Media for NFT '${identifier}' excedded file size limit`);
+
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -364,7 +364,7 @@ describe("NFT Controller", () => {
         .get(path + "?" + params)
         .expect(400)
         .then(res => {
-          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'computeScamInfo'");
+          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply', 'withScamInfo' or 'computeScamInfo'");
         });
     });
   });

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -364,7 +364,7 @@ describe("NFT Controller", () => {
         .get(path + "?" + params)
         .expect(400)
         .then(res => {
-          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply', 'withScamInfo' or 'computeScamInfo'");
+          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner', 'withSupply', 'withScamInfo' or 'computeScamInfo'");
         });
     });
   });

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -364,7 +364,7 @@ describe("NFT Controller", () => {
         .get(path + "?" + params)
         .expect(400)
         .then(res => {
-          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'withScamInfo'");
+          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'computeScamInfo'");
         });
     });
   });

--- a/src/test/integration/services/nft.media.e2e-spec.ts
+++ b/src/test/integration/services/nft.media.e2e-spec.ts
@@ -1,8 +1,10 @@
 import '@elrondnetwork/erdnest/lib/src/utils/extensions/array.extensions';
 import { Test } from '@nestjs/testing';
+import { MediaMimeTypeEnum } from 'src/endpoints/nfts/entities/media.mime.type';
 import { Nft } from 'src/endpoints/nfts/entities/nft';
 import { NftFilter } from 'src/endpoints/nfts/entities/nft.filter';
 import { NftMedia } from 'src/endpoints/nfts/entities/nft.media';
+import { NftType } from 'src/endpoints/nfts/entities/nft.type';
 import { NftService } from 'src/endpoints/nfts/nft.service';
 import { PublicAppModule } from "src/public.app.module";
 import { NftMediaModule } from 'src/queue.worker/nft.worker/queue/job-services/media/nft.media.module';
@@ -28,6 +30,10 @@ describe('Nft Media Service', () => {
     nftIdentifier = nft.identifier;
   });
 
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   describe("Refresh Media", () => {
     it('should return nft media', async () => {
       const nftFilter = new Nft();
@@ -42,6 +48,67 @@ describe('Nft Media Service', () => {
         expect(media.url).toBeDefined();
         expect(media).toHaveStructure(Object.keys(new NftMedia()));
       }
+    });
+
+    it('should not accept content (media file is too large)', async () => {
+      jest
+        .spyOn(NftMediaService.prototype as any, "getFileProperties")
+        // eslint-disable-next-line require-await
+        .mockImplementation(jest.fn(async () => ({ contentType: MediaMimeTypeEnum.mp4, contentLength: 64000001 })));
+
+      const nft = new Nft({ type: NftType.NonFungibleESDT, uris: ['some_uris'], identifier: 'LSC-a2b6b5-04' });
+
+      const mediaRaw = await nftMediaService.refreshMedia(nft);
+
+      expect(mediaRaw?.length).toStrictEqual(0);
+    });
+
+    it('should not accept content (media mime type is not accepted)', async () => {
+      jest
+        .spyOn(NftMediaService.prototype as any, "getFileProperties")
+        // eslint-disable-next-line require-await
+        .mockImplementation(jest.fn(async () => ({ contentType: "NOT_ACCEPTED", contentLength: 1234 })));
+
+      const nft = new Nft({ type: NftType.NonFungibleESDT, uris: ['some_uris'], identifier: 'LSC-a2b6b5-02' });
+
+      const mediaRaw = await nftMediaService.refreshMedia(nft);
+
+      expect(mediaRaw?.length).toStrictEqual(0);
+    });
+
+    it('should not accept content (file properties not returned)', async () => {
+      jest
+        .spyOn(NftMediaService.prototype as any, "getFileProperties")
+        // eslint-disable-next-line require-await
+        .mockImplementation(jest.fn(async () => null));
+
+      const nft = new Nft({ type: NftType.NonFungibleESDT, uris: ['some_uris'], identifier: 'LSC-a2b6b5-03' });
+
+      const mediaRaw = await nftMediaService.refreshMedia(nft);
+
+      expect(mediaRaw?.length).toStrictEqual(0);
+    });
+
+    it('should accept content and return valid media', async () => {
+      jest
+        .spyOn(NftMediaService.prototype as any, "getFileProperties")
+        // eslint-disable-next-line require-await
+        .mockImplementation(jest.fn(async () => ({ contentType: "image/png", contentLength: 4761020 })));
+
+      const nft = new Nft({ type: NftType.NonFungibleESDT, uris: ['aHR0cHM6Ly9pcGZzLmlvL2lwZnMvYmFmeWJlaWVrcHV0a3A3eGR2aXpwaWZ2Yzdkcmp5Mml5M2l4NHU3c3psazdobnR6bTdhZ3UyYjZ2NXEvMzg5Ni5wbmc='], identifier: 'K402-22c4bb-c0', collection: 'K402-22c4bb' });
+
+      const mediaRaw = await nftMediaService.refreshMedia(nft);
+
+      expect(mediaRaw?.length).toStrictEqual(1);
+
+      if (!mediaRaw) {
+        throw new Error("Media should be returned");
+      }
+
+      expect(mediaRaw[0].fileSize).toStrictEqual(4761020);
+      expect(mediaRaw[0].fileType).toStrictEqual(MediaMimeTypeEnum.png);
+      expect(mediaRaw[0].url).toStrictEqual('https://media.elrond.com/nfts/asset/bafybeiekputkp7xdvizpifvc7drjy2iy3ix4u7szlk7hntzm7agu2b6v5q/3896.png');
+      expect(mediaRaw[0].thumbnailUrl).toStrictEqual('https://media.elrond.com/nfts/thumbnail/K402-22c4bb-d5990d89');
     });
   });
 });


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- No content size limit for NFT media
- Risk to restart processor instance when processing large media files
  
## Proposed Changes
- Add a limit of 64MB for accepted media files

## How to test
- Mint one NFT and add a large media file (> 64MB), media should not be processed
- Mint another NFT with a smaller media file, check if is processed
