### PR TITLE
Refactor & test elastic queries builder functions

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -123,7 +123,7 @@ export class ElasticIndexerService implements IndexerInterface {
 
 
   async getTokensWithRolesForAddressCount(address: string, filter: TokenWithRolesFilter): Promise<number> {
-    const elasticQuery = this.buildTokensWithRolesForAddressQuery(address, filter);
+    const elasticQuery = filter.buildElasticQuery(address);
     return await this.elasticService.getCount('tokens', elasticQuery);
   }
 
@@ -216,7 +216,11 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getTokensWithRolesForAddress(address: string, filter: TokenWithRolesFilter, pagination: QueryPagination): Promise<any[]> {
-    const elasticQuery = this.buildTokensWithRolesForAddressQuery(address, filter, pagination);
+    let elasticQuery = filter.buildElasticQuery(address);
+    if (pagination) {
+      elasticQuery = elasticQuery.withPagination(pagination);
+    }
+
     const tokenList = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
     return tokenList;
   }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -725,45 +725,6 @@ export class ElasticIndexerService implements IndexerInterface {
     return queries;
   }
 
-  buildTokensWithRolesForAddressQuery(address: string, filter: TokenWithRolesFilter, pagination?: QueryPagination): ElasticQuery {
-    let elasticQuery = ElasticQuery.create()
-      .withMustNotExistCondition('identifier')
-      .withMustCondition(QueryType.Should(
-        [
-          QueryType.Match('currentOwner', address),
-          QueryType.Nested('roles', { 'roles.ESDTRoleLocalMint': address }),
-          QueryType.Nested('roles', { 'roles.ESDTRoleLocalBurn': address }),
-        ]
-      ))
-      .withMustMatchCondition('type', TokenType.FungibleESDT)
-      .withMustMatchCondition('token', filter.identifier)
-      .withMustMatchCondition('currentOwner', filter.owner);
-
-    if (filter.search) {
-      elasticQuery = elasticQuery
-        .withShouldCondition([
-          QueryType.Wildcard('token', filter.search),
-          QueryType.Wildcard('name', filter.search),
-        ]);
-    }
-
-    if (filter.canMint !== undefined) {
-      const condition = filter.canMint === true ? QueryConditionOptions.must : QueryConditionOptions.mustNot;
-      elasticQuery = elasticQuery.withCondition(condition, QueryType.Nested('roles', { 'roles.ESDTRoleLocalMint': address }));
-    }
-
-    if (filter.canBurn !== undefined) {
-      const condition = filter.canBurn === true ? QueryConditionOptions.must : QueryConditionOptions.mustNot;
-      elasticQuery = elasticQuery.withCondition(condition, QueryType.Nested('roles', { 'roles.ESDTRoleLocalBurn': address }));
-    }
-
-    if (pagination) {
-      elasticQuery = elasticQuery.withPagination(pagination);
-    }
-
-    return elasticQuery;
-  }
-
   buildSmartContractResultFilterQuery(address?: string): ElasticQuery {
     const shouldQueries: AbstractQuery[] = [];
     const mustQueries: AbstractQuery[] = [];

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -3,6 +3,7 @@ import { Injectable, Logger } from "@nestjs/common";
 import { Cron, CronExpression } from "@nestjs/schedule";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { Nft } from "src/endpoints/nfts/entities/nft";
+import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
 import { NftService } from "src/endpoints/nfts/nft.service";
 import { ProcessNftSettings } from "src/endpoints/process-nfts/entities/process.nft.settings";
 import { NftWorkerService } from "src/queue.worker/nft.worker/nft.worker.service";
@@ -45,7 +46,7 @@ export class NftCronService {
     let totalProcessedNfts = 0;
 
     while (true) {
-      let nfts = await this.nftService.getNfts({ from: 0, size: 10000 }, { before, after });
+      let nfts = await this.nftService.getNfts({ from: 0, size: 10000 }, new NftFilter({ before, after }));
 
       nfts = nfts.sortedDescending(x => x.timestamp ?? 0);
 

--- a/src/endpoints/blocks/entities/block.filter.ts
+++ b/src/endpoints/blocks/entities/block.filter.ts
@@ -1,3 +1,5 @@
+import { AbstractQuery, ElasticQuery, QueryConditionOptions, QueryType } from "@elrondnetwork/erdnest";
+
 export class BlockFilter {
   constructor(init?: Partial<BlockFilter>) {
     Object.assign(this, init);
@@ -8,4 +10,36 @@ export class BlockFilter {
   validator?: string;
   epoch?: number;
   nonce?: number;
+
+  buildElasticQuery(proposerIndex?: number, validatorIndex?: number): ElasticQuery {
+    const queries: AbstractQuery[] = [];
+    if (this.nonce !== undefined) {
+      const nonceQuery = QueryType.Match("nonce", this.nonce);
+      queries.push(nonceQuery);
+    }
+    if (this.shard !== undefined) {
+      const shardIdQuery = QueryType.Match('shardId', this.shard);
+      queries.push(shardIdQuery);
+    }
+
+    if (this.epoch !== undefined) {
+      const epochQuery = QueryType.Match('epoch', this.epoch);
+      queries.push(epochQuery);
+    }
+
+    if (proposerIndex !== undefined) {
+      const proposerQuery = QueryType.Match('proposer', proposerIndex);
+      queries.push(proposerQuery);
+    }
+
+    if (validatorIndex !== undefined) {
+      const validatorsQuery = QueryType.Match('validators', validatorIndex);
+      queries.push(validatorsQuery);
+    }
+
+    const elasticQuery: ElasticQuery = ElasticQuery.create()
+      .withCondition(QueryConditionOptions.must, queries);
+
+    return elasticQuery;
+  }
 }

--- a/src/endpoints/bls/bls.service.ts
+++ b/src/endpoints/bls/bls.service.ts
@@ -27,7 +27,7 @@ export class BlsService {
     return [];
   }
 
-  async getBlsIndex(bls: string, shardId: number, epoch: number): Promise<number | boolean> {
+  async getBlsIndex(bls: string, shardId: number, epoch: number): Promise<number> {
     const publicKeys = await this.getPublicKeys(shardId, epoch);
 
     return publicKeys.indexOf(bls);

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -248,7 +248,7 @@ export class CollectionService {
   }
 
   async getCollectionForAddressWithRole(address: string, collection: string): Promise<NftCollectionRole | undefined> {
-    const filter: CollectionFilter = { collection };
+    const filter: CollectionFilter = new CollectionFilter({ collection });
 
     const collections = await this.esdtAddressService.getCollectionsForAddress(address, filter, new QueryPagination({ from: 0, size: 1 }));
     if (collections.length === 0) {

--- a/src/endpoints/collections/entities/collection.filter.ts
+++ b/src/endpoints/collections/entities/collection.filter.ts
@@ -1,3 +1,4 @@
+import { ElasticQuery, QueryConditionOptions, QueryOperator, QueryType } from "@elrondnetwork/erdnest";
 import { NftType } from "../../nfts/entities/nft.type";
 
 export class CollectionFilter {
@@ -18,4 +19,71 @@ export class CollectionFilter {
   canUpdateAttributes?: boolean | string;
   canAddUri?: boolean | string;
   canTransferRole?: boolean | string;
+
+  buildElasticQuery(address?: string, indexerV3Active: boolean = false): ElasticQuery {
+    let elasticQuery = ElasticQuery.create();
+    elasticQuery = elasticQuery.withMustNotExistCondition('identifier')
+      .withMustMultiShouldCondition([NftType.MetaESDT, NftType.NonFungibleESDT, NftType.SemiFungibleESDT], type => QueryType.Match('type', type));
+
+    if (address) {
+      if (indexerV3Active) {
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Should(
+          [
+            QueryType.Match('currentOwner', address),
+            QueryType.Nested('roles', { 'roles.ESDTRoleNFTCreate': address }),
+            QueryType.Nested('roles', { 'roles.ESDTRoleNFTBurn': address }),
+            QueryType.Nested('roles', { 'roles.ESDTRoleNFTAddQuantity': address }),
+            QueryType.Nested('roles', { 'roles.ESDTRoleNFTUpdateAttributes': address }),
+            QueryType.Nested('roles', { 'roles.ESDTRoleNFTAddURI': address }),
+            QueryType.Nested('roles', { 'roles.ESDTTransferRole': address }),
+          ]
+        ));
+      } else {
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Match('currentOwner', address));
+      }
+    }
+
+    if (this.before || this.after) {
+      elasticQuery = elasticQuery.withDateRangeFilter('timestamp', this.before, this.after);
+    }
+
+    if (indexerV3Active) {
+      if (this.canCreate !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTCreate', address, this.canCreate);
+      }
+
+      if (this.canBurn !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTBurn', address, this.canBurn);
+      }
+
+      if (this.canAddQuantity !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTAddQuantity', address, this.canAddQuantity);
+      }
+
+      if (this.canUpdateAttributes !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTUpdateAttributes', address, this.canUpdateAttributes);
+      }
+
+      if (this.canAddUri !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTAddURI', address, this.canAddUri);
+      }
+
+      if (this.canTransferRole !== undefined) {
+        elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTTransferRole', address, this.canTransferRole);
+      }
+    }
+
+    return elasticQuery.withMustMatchCondition('token', this.collection, QueryOperator.AND)
+      .withMustMultiShouldCondition(this.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
+      .withSearchWildcardCondition(this.search, ['token', 'name'])
+      .withMustMultiShouldCondition(this.type, type => QueryType.Match('type', type))
+      .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
+  }
+
+  private getRoleCondition(query: ElasticQuery, name: string, address: string | undefined, value: string | boolean) {
+    const condition = value === false ? QueryConditionOptions.mustNot : QueryConditionOptions.must;
+    const targetAddress = typeof value === 'string' ? value : address;
+
+    return query.withCondition(condition, QueryType.Nested('roles', { [`roles.${name}`]: targetAddress }));
+  }
 }

--- a/src/endpoints/nfts/entities/nft.filter.ts
+++ b/src/endpoints/nfts/entities/nft.filter.ts
@@ -1,3 +1,4 @@
+import { ElasticQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan } from "@elrondnetwork/erdnest";
 import { NftType } from "./nft.type";
 
 export class NftFilter {
@@ -19,4 +20,71 @@ export class NftFilter {
   after?: number;
   isWhitelistedStorage?: boolean;
   isNsfw?: boolean;
+
+  buildElasticQuery(nsfwThreshold: number, identifier?: string, address?: string, indexerV3Active: boolean = false): ElasticQuery {
+    let elasticQuery = ElasticQuery.create()
+      .withCondition(QueryConditionOptions.must, QueryType.Exists('identifier'));
+
+    if (address) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('address', address));
+    }
+
+    if (this.search !== undefined) {
+      elasticQuery = elasticQuery.withSearchWildcardCondition(this.search, ['token', 'name']);
+    }
+
+    if (this.type !== undefined) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('type', this.type));
+    }
+
+    if (identifier !== undefined) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('identifier', identifier, QueryOperator.AND));
+    }
+
+    if (this.collection !== undefined && this.collection !== '') {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Match('token', this.collection, QueryOperator.AND));
+    }
+
+    if (this.collections !== undefined && this.collections.length !== 0) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(this.collections.map(collection => QueryType.Match('token', collection, QueryOperator.AND))));
+    }
+
+    if (this.name !== undefined && this.name !== '') {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Nested('data', { "data.name": this.name }));
+    }
+
+    if (this.hasUris !== undefined) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Nested('data', { "data.nonEmptyURIs": this.hasUris }));
+    }
+
+    if (this.tags) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(this.tags.map(tag => QueryType.Nested("data", { "data.tags": tag }))));
+    }
+
+    if (this.creator !== undefined) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Nested("data", { "data.creator": this.creator }));
+    }
+
+    if (this.identifiers) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(this.identifiers.map(identifier => QueryType.Match('identifier', identifier, QueryOperator.AND))));
+    }
+
+    if (this.isWhitelistedStorage !== undefined && indexerV3Active) {
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Nested("data", { "data.whiteListedStorage": this.isWhitelistedStorage }));
+    }
+
+    if (this.isNsfw !== undefined) {
+      if (this.isNsfw === true) {
+        elasticQuery = elasticQuery.withRangeFilter('nft_nsfw_mark', new RangeGreaterThanOrEqual(nsfwThreshold));
+      } else {
+        elasticQuery = elasticQuery.withRangeFilter('nft_nsfw_mark', new RangeLowerThan(nsfwThreshold));
+      }
+    }
+
+    if (this.before || this.after) {
+      elasticQuery = elasticQuery.withDateRangeFilter('timestamp', this.before, this.after);
+    }
+
+    return elasticQuery;
+  }
 }

--- a/src/endpoints/process-nfts/process.nfts.service.ts
+++ b/src/endpoints/process-nfts/process.nfts.service.ts
@@ -10,6 +10,7 @@ import { Nft } from "../nfts/entities/nft";
 import { NftService } from "../nfts/nft.service";
 import { ProcessNftRequest } from "./entities/process.nft.request";
 import { ProcessNftSettings } from "./entities/process.nft.settings";
+import { NftFilter } from "../nfts/entities/nft.filter";
 
 @Injectable()
 export class ProcessNftsService {
@@ -70,7 +71,7 @@ export class ProcessNftsService {
   }
 
   public async processCollection(collection: string, settings: ProcessNftSettings): Promise<{ [key: string]: boolean }> {
-    const nfts = await this.nftService.getNfts({ from: 0, size: 10000 }, { collection });
+    const nfts = await this.nftService.getNfts({ from: 0, size: 10000 }, new NftFilter({ collection }));
 
     const results = await asyncPool(
       this.apiConfigService.getPoolLimit(),

--- a/src/endpoints/rounds/entities/round.filter.ts
+++ b/src/endpoints/rounds/entities/round.filter.ts
@@ -1,4 +1,4 @@
-import { QueryConditionOptions } from "@elrondnetwork/erdnest";
+import { AbstractQuery, ElasticQuery, QueryConditionOptions, QueryType } from "@elrondnetwork/erdnest";
 import { QueryPagination } from "src/common/entities/query.pagination";
 
 export class RoundFilter extends QueryPagination {
@@ -11,4 +11,28 @@ export class RoundFilter extends QueryPagination {
   validator: string | undefined;
   shard: number | undefined;
   epoch: number | undefined;
+
+  buildElasticQuery(blsIndex?: number): ElasticQuery {
+    const queries: AbstractQuery[] = [];
+
+    if (this.shard !== undefined) {
+      const shardIdQuery = QueryType.Match('shardId', this.shard);
+      queries.push(shardIdQuery);
+    }
+
+    if (this.epoch !== undefined) {
+      const epochQuery = QueryType.Match('epoch', this.epoch);
+      queries.push(epochQuery);
+    }
+
+    if (blsIndex !== undefined) {
+      const signersIndexesQuery = QueryType.Match('signersIndexes', blsIndex);
+      queries.push(signersIndexesQuery);
+    }
+
+    const elasticQuery: ElasticQuery = ElasticQuery.create()
+      .withCondition(this.condition ?? QueryConditionOptions.must, queries);
+
+    return elasticQuery;
+  }
 }

--- a/src/endpoints/tokens/entities/token.with.roles.filter.ts
+++ b/src/endpoints/tokens/entities/token.with.roles.filter.ts
@@ -1,3 +1,6 @@
+import { ElasticQuery, QueryConditionOptions, QueryType } from "@elrondnetwork/erdnest";
+import { TokenType } from "src/common/indexer/entities";
+
 export class TokenWithRolesFilter {
   constructor(init?: Partial<TokenWithRolesFilter>) {
     Object.assign(this, init);
@@ -12,4 +15,39 @@ export class TokenWithRolesFilter {
   canMint?: boolean;
 
   canBurn?: boolean;
+
+  buildElasticQuery(address: string): ElasticQuery {
+    let elasticQuery = ElasticQuery.create()
+      .withMustNotExistCondition('identifier')
+      .withMustCondition(QueryType.Should(
+        [
+          QueryType.Match('currentOwner', address),
+          QueryType.Nested('roles', { 'roles.ESDTRoleLocalMint': address }),
+          QueryType.Nested('roles', { 'roles.ESDTRoleLocalBurn': address }),
+        ]
+      ))
+      .withMustMatchCondition('type', TokenType.FungibleESDT)
+      .withMustMatchCondition('token', this.identifier)
+      .withMustMatchCondition('currentOwner', this.owner);
+
+    if (this.search) {
+      elasticQuery = elasticQuery
+        .withShouldCondition([
+          QueryType.Wildcard('token', this.search),
+          QueryType.Wildcard('name', this.search),
+        ]);
+    }
+
+    if (this.canMint !== undefined) {
+      const condition = this.canMint === true ? QueryConditionOptions.must : QueryConditionOptions.mustNot;
+      elasticQuery = elasticQuery.withCondition(condition, QueryType.Nested('roles', { 'roles.ESDTRoleLocalMint': address }));
+    }
+
+    if (this.canBurn !== undefined) {
+      const condition = this.canBurn === true ? QueryConditionOptions.must : QueryConditionOptions.mustNot;
+      elasticQuery = elasticQuery.withCondition(condition, QueryType.Nested('roles', { 'roles.ESDTRoleLocalBurn': address }));
+    }
+
+    return elasticQuery;
+  }
 }

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -486,7 +486,7 @@ export class TokenService {
   }
 
   async getTokenWithRolesForAddress(address: string, identifier: string): Promise<TokenWithRoles | undefined> {
-    const tokens = await this.getTokensWithRolesForAddress(address, { identifier }, { from: 0, size: 1 });
+    const tokens = await this.getTokensWithRolesForAddress(address, new TokenWithRolesFilter({ identifier }), { from: 0, size: 1 });
     if (tokens.length === 0) {
       return undefined;
     }

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -1,4 +1,4 @@
-import { QueryConditionOptions } from "@elrondnetwork/erdnest";
+import { AbstractQuery, ElasticQuery, QueryConditionOptions, QueryOperator, QueryType } from "@elrondnetwork/erdnest";
 import { SortOrder } from "src/common/entities/sort.order";
 import { TransactionStatus } from "./transaction.status";
 import { TransactionType } from "./transaction.type";
@@ -25,4 +25,69 @@ export class TransactionFilter {
   order?: SortOrder;
   type?: TransactionType;
   tokens?: string[];
+
+  buildElasticQuery(address?: string, indexerV3Active: boolean = false): ElasticQuery {
+    let elasticQuery = ElasticQuery.create()
+      .withMustMatchCondition('tokens', this.token, QueryOperator.AND)
+      .withMustMatchCondition('function', indexerV3Active ? this.function : undefined)
+      .withMustMatchCondition('senderShard', this.senderShard)
+      .withMustMatchCondition('receiverShard', this.receiverShard)
+      .withMustMatchCondition('miniBlockHash', this.miniBlockHash)
+      .withMustMultiShouldCondition(this.hashes, hash => QueryType.Match('_id', hash))
+      .withMustMatchCondition('status', this.status)
+      .withMustWildcardCondition('data', this.search)
+      .withMustMultiShouldCondition(this.tokens, token => QueryType.Match('tokens', token, QueryOperator.AND))
+      .withDateRangeFilter('timestamp', this.before, this.after);
+
+    if (this.condition === QueryConditionOptions.should) {
+      if (this.sender) {
+        elasticQuery = elasticQuery.withShouldCondition(QueryType.Match('sender', this.sender));
+      }
+
+      if (this.receivers) {
+        const keys = ['receiver'];
+        if (indexerV3Active) {
+          keys.push('receivers');
+        }
+
+        for (const receiver of this.receivers) {
+          for (const key of keys) {
+            elasticQuery = elasticQuery.withShouldCondition(QueryType.Match(key, receiver));
+          }
+        }
+      }
+    } else {
+      elasticQuery = elasticQuery.withMustMatchCondition('sender', this.sender);
+
+      if (this.receivers) {
+        const keys = ['receiver'];
+
+        if (indexerV3Active) {
+          keys.push('receivers');
+        }
+
+        const queries: AbstractQuery[] = [];
+
+        for (const receiver of this.receivers) {
+          for (const key of keys) {
+            queries.push(QueryType.Match(key, receiver));
+          }
+        }
+
+        elasticQuery = elasticQuery.withMustCondition(QueryType.Should(queries));
+      }
+    }
+
+    if (address) {
+      const keys: string[] = ['sender', 'receiver'];
+
+      if (indexerV3Active) {
+        keys.push('receivers');
+      }
+
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(keys, key => QueryType.Match(key, address));
+    }
+
+    return elasticQuery;
+  }
 }

--- a/src/endpoints/transactions/transaction.utils.ts
+++ b/src/endpoints/transactions/transaction.utils.ts
@@ -24,11 +24,11 @@ export class TransactionUtils {
       return false;
     }
 
-    const filterToCompareWith: TransactionFilter = {
+    const filterToCompareWith: TransactionFilter = new TransactionFilter({
       sender: filter.sender,
       receivers: filter.receivers,
       condition: QueryConditionOptions.should,
-    };
+    });
 
     return JSON.stringify(filter) === JSON.stringify(filterToCompareWith);
   }


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Elastic indexer services has too many responsabilities
- Elastic query builder functions are hard to unit test
  
## Proposed Changes
- Move elastic query builder functions in it's coresponding filter class
- Add some unit tests for filters

## How to test
- Check if elastic queries are not affected and return same results
