### PR TITLE
API call cpu usage metrics

### DIFF
--- a/src/common/metrics/api.metrics.service.ts
+++ b/src/common/metrics/api.metrics.service.ts
@@ -8,6 +8,7 @@ import { ProtocolService } from "../protocol/protocol.service";
 
 @Injectable()
 export class ApiMetricsService {
+  private static apiCpuTimeHistogram: Histogram<string>;
   private static vmQueriesHistogram: Histogram<string>;
   private static gatewayDurationHistogram: Histogram<string>;
   private static persistenceDurationHistogram: Histogram<string>;
@@ -23,6 +24,15 @@ export class ApiMetricsService {
     private readonly protocolService: ProtocolService,
     private readonly metricsService: MetricsService,
   ) {
+    if (!ApiMetricsService.apiCpuTimeHistogram) {
+      ApiMetricsService.apiCpuTimeHistogram = new Histogram({
+        name: 'api_cpu_time',
+        help: 'API CPU time',
+        labelNames: ['endpoint'],
+        buckets: [],
+      });
+    }
+
     if (!ApiMetricsService.vmQueriesHistogram) {
       ApiMetricsService.vmQueriesHistogram = new Histogram({
         name: 'vm_query',
@@ -74,6 +84,10 @@ export class ApiMetricsService {
         labelNames: ['shardId'],
       });
     }
+  }
+
+  setApiCpuTime(endpoint: string, duration: number) {
+    ApiMetricsService.apiCpuTimeHistogram.labels(endpoint).observe(duration);
   }
 
   setVmQuery(address: string, func: string, duration: number) {

--- a/src/interceptors/request.cpu.time.interceptor.ts
+++ b/src/interceptors/request.cpu.time.interceptor.ts
@@ -64,7 +64,6 @@ export class RequestCpuTimeInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
-    const request = context.switchToHttp().getRequest();
 
     const requestId = this.requestIndex++;
     const asyncId = async_hooks.executionAsyncId();
@@ -87,16 +86,12 @@ export class RequestCpuTimeInterceptor implements NestInterceptor {
           this.apiMetricsService.setApiCpuTime(apiFunction, duration);
 
           delete this.requestDict[requestId];
-
-          request.res.set('X-Request-Cpu-Time', duration);
         }),
         catchError(err => {
           const duration = this.requestDict[requestId].duration;
           this.apiMetricsService.setApiCpuTime(apiFunction, duration);
 
           delete this.requestDict[requestId];
-
-          request.res.set('X-Request-Cpu-Time', duration);
 
           return throwError(() => err);
         })

--- a/src/interceptors/request.cpu.time.interceptor.ts
+++ b/src/interceptors/request.cpu.time.interceptor.ts
@@ -1,0 +1,100 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { Observable, throwError } from "rxjs";
+import { catchError, tap } from 'rxjs/operators';
+import async_hooks from 'async_hooks';
+import { ApiMetricsService } from "src/common/metrics/api.metrics.service";
+
+@Injectable()
+export class RequestCpuTimeInterceptor implements NestInterceptor {
+  private readonly asyncHookDict: Record<number, { requestId: number, timestamp: number }> = {};
+  private readonly requestDict: Record<number, { apiFunction: string, duration: number }> = {};
+  private requestIndex = 0;
+
+  private now() {
+    const hrTime = process.hrtime();
+    return hrTime[0] * 1000 + hrTime[1] / 1000000;
+  }
+
+  constructor(
+    private readonly apiMetricsService: ApiMetricsService,
+  ) {
+    async_hooks.createHook({ init: onInit, destroy: onDestroy, before: onBefore, after: onAfter }).enable();
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    function onInit(asyncId: number, _: string, triggerAsyncId: number) {
+      const previousValue = self.asyncHookDict[triggerAsyncId];
+      if (previousValue) {
+        self.asyncHookDict[asyncId] = {
+          requestId: previousValue.requestId,
+          timestamp: 0,
+        };
+      }
+    }
+
+    function onDestroy(asyncId: number) {
+      const value = self.asyncHookDict[asyncId];
+      if (value) {
+        delete self.asyncHookDict[asyncId];
+      }
+
+    }
+
+    function onBefore(asyncId: number) {
+      const value = self.asyncHookDict[asyncId];
+      if (value) {
+        value.timestamp = self.now();
+      }
+    }
+
+    function onAfter(asyncId: number) {
+      const asyncHookItem = self.asyncHookDict[asyncId];
+      if (asyncHookItem) {
+        const requestId = asyncHookItem.requestId;
+        const requestItem = self.requestDict[requestId];
+        if (requestItem && asyncHookItem.timestamp > 0) {
+          self.requestDict[requestId].duration += self.now() - asyncHookItem.timestamp;
+        }
+
+        delete self.asyncHookDict[asyncId];
+      }
+    }
+  }
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const apiFunction = context.getClass().name + '.' + context.getHandler().name;
+
+    const requestId = this.requestIndex++;
+    const asyncId = async_hooks.executionAsyncId();
+
+    this.requestDict[requestId] = {
+      apiFunction,
+      duration: 0,
+    };
+
+    this.asyncHookDict[asyncId] = {
+      requestId,
+      timestamp: 0,
+    };
+
+    return next
+      .handle()
+      .pipe(
+        tap(() => {
+          const duration = this.requestDict[requestId].duration;
+          this.apiMetricsService.setApiCpuTime(apiFunction, duration);
+
+          delete this.requestDict[requestId];
+        }),
+        catchError(err => {
+          const duration = this.requestDict[requestId].duration;
+          this.apiMetricsService.setApiCpuTime(apiFunction, duration);
+
+          delete this.requestDict[requestId];
+
+          return throwError(() => err);
+        })
+      );
+  }
+}

--- a/src/interceptors/request.cpu.time.interceptor.ts
+++ b/src/interceptors/request.cpu.time.interceptor.ts
@@ -64,6 +64,7 @@ export class RequestCpuTimeInterceptor implements NestInterceptor {
 
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
+    const request = context.switchToHttp().getRequest();
 
     const requestId = this.requestIndex++;
     const asyncId = async_hooks.executionAsyncId();
@@ -86,12 +87,16 @@ export class RequestCpuTimeInterceptor implements NestInterceptor {
           this.apiMetricsService.setApiCpuTime(apiFunction, duration);
 
           delete this.requestDict[requestId];
+
+          request.res.set('X-Request-Cpu-Time', duration);
         }),
         catchError(err => {
           const duration = this.requestDict[requestId].duration;
           this.apiMetricsService.setApiCpuTime(apiFunction, duration);
 
           delete this.requestDict[requestId];
+
+          request.res.set('X-Request-Cpu-Time', duration);
 
           return throwError(() => err);
         })

--- a/src/interceptors/transaction.logging.interceptor.ts
+++ b/src/interceptors/transaction.logging.interceptor.ts
@@ -1,83 +1,16 @@
 import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from "@nestjs/common";
-import { Observable, throwError } from "rxjs";
+import { Observable } from "rxjs";
 import { ProxyController } from "src/endpoints/proxy/proxy.controller";
 import { TransactionController } from "src/endpoints/transactions/transaction.controller";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
-import { catchError, tap } from 'rxjs/operators';
-import async_hooks from 'async_hooks';
 
 @Injectable()
 export class TransactionLoggingInterceptor implements NestInterceptor {
   private readonly transactionLogger: winston.Logger;
   private readonly logger: Logger;
 
-  private counter = 0;
-  private readonly dict: Record<number, { function: string, duration: number, timestamp: number }> = {};
-
-  private now() {
-    const hrTime = process.hrtime();
-    return hrTime[0] * 1000 + hrTime[1] / 1000000;
-  }
-
   constructor() {
-    const asyncHook = async_hooks.createHook({ init, destroy, promiseResolve, before, after });
-    asyncHook.enable();
-
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this;
-    // @ts-ignore
-    function init(asyncId: number, type: string, triggerAsyncId: number, resource: any) {
-      const previousValue = self.dict[triggerAsyncId];
-      if (previousValue) {
-        // console.log({ event: 'init', asyncId, type, triggerAsyncId });
-        self.dict[asyncId] = {
-          function: previousValue.function,
-          duration: 0,
-          timestamp: 0,
-        };
-
-        // console.log({ value: self.dict[asyncId], asyncId, triggerAsyncId });
-        console.log({ d: previousValue.duration.toRounded(4), asyncId, triggerAsyncId });
-
-        self.counter += previousValue.duration;
-      }
-    }
-
-    function destroy(asyncId: number) {
-      const value = self.dict[asyncId];
-      if (value) {
-        // console.log({ event: 'destroy', asyncId });
-        delete self.dict[asyncId];
-      }
-
-    }
-
-    function promiseResolve(asyncId: number) {
-      const value = self.dict[asyncId];
-      if (value) {
-        // console.log({ event: 'destroy', asyncId });
-        value.timestamp = self.now();
-      }
-
-    }
-
-    // @ts-ignore
-    function before(asyncId: number) {
-      const value = self.dict[asyncId];
-      if (value && value.timestamp === 0) {
-        // console.log({ event: 'before', asyncId });
-        value.timestamp = self.now();
-      }
-    }
-
-    function after(asyncId: number) {
-      const value = self.dict[asyncId];
-      if (value) {
-        value.duration = value.duration + self.now() - value.timestamp;
-      }
-    }
-
     this.transactionLogger = winston.createLogger({
       format: winston.format.json({
         replacer: (key: string, value: any) => {
@@ -111,16 +44,6 @@ export class TransactionLoggingInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
 
-    console.log({ status: 'start', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
-
-    const start = this.now();
-
-    this.dict[async_hooks.executionAsyncId()] = {
-      function: apiFunction,
-      duration: 0,
-      timestamp: this.now(),
-    };
-
     const request = context.getArgByIndex(0);
 
     const isCreateTransactionCall = context.getClass().name === TransactionController.name && context.getHandler().name === 'createTransaction';
@@ -139,20 +62,6 @@ export class TransactionLoggingInterceptor implements NestInterceptor {
     }
 
     return next
-      .handle()
-      .pipe(
-        tap(() => {
-          console.log({ status: 'finish', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
-
-          console.log({ elapsed: this.now() - start, value: this.dict[async_hooks.triggerAsyncId()], counter: this.counter });
-
-          // console.log({ dict: this.dict });
-        }),
-        catchError(err => {
-          console.log({ status: 'error', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
-
-          return throwError(() => err);
-        })
-      );
+      .handle();
   }
 }

--- a/src/interceptors/transaction.logging.interceptor.ts
+++ b/src/interceptors/transaction.logging.interceptor.ts
@@ -1,16 +1,83 @@
 import { CallHandler, ExecutionContext, Injectable, Logger, NestInterceptor } from "@nestjs/common";
-import { Observable } from "rxjs";
+import { Observable, throwError } from "rxjs";
 import { ProxyController } from "src/endpoints/proxy/proxy.controller";
 import { TransactionController } from "src/endpoints/transactions/transaction.controller";
 import winston from "winston";
 import DailyRotateFile from "winston-daily-rotate-file";
+import { catchError, tap } from 'rxjs/operators';
+import async_hooks from 'async_hooks';
 
 @Injectable()
 export class TransactionLoggingInterceptor implements NestInterceptor {
   private readonly transactionLogger: winston.Logger;
   private readonly logger: Logger;
 
+  private counter = 0;
+  private readonly dict: Record<number, { function: string, duration: number, timestamp: number }> = {};
+
+  private now() {
+    const hrTime = process.hrtime();
+    return hrTime[0] * 1000 + hrTime[1] / 1000000;
+  }
+
   constructor() {
+    const asyncHook = async_hooks.createHook({ init, destroy, promiseResolve, before, after });
+    asyncHook.enable();
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    // @ts-ignore
+    function init(asyncId: number, type: string, triggerAsyncId: number, resource: any) {
+      const previousValue = self.dict[triggerAsyncId];
+      if (previousValue) {
+        // console.log({ event: 'init', asyncId, type, triggerAsyncId });
+        self.dict[asyncId] = {
+          function: previousValue.function,
+          duration: 0,
+          timestamp: 0,
+        };
+
+        // console.log({ value: self.dict[asyncId], asyncId, triggerAsyncId });
+        console.log({ d: previousValue.duration.toRounded(4), asyncId, triggerAsyncId });
+
+        self.counter += previousValue.duration;
+      }
+    }
+
+    function destroy(asyncId: number) {
+      const value = self.dict[asyncId];
+      if (value) {
+        // console.log({ event: 'destroy', asyncId });
+        delete self.dict[asyncId];
+      }
+
+    }
+
+    function promiseResolve(asyncId: number) {
+      const value = self.dict[asyncId];
+      if (value) {
+        // console.log({ event: 'destroy', asyncId });
+        value.timestamp = self.now();
+      }
+
+    }
+
+    // @ts-ignore
+    function before(asyncId: number) {
+      const value = self.dict[asyncId];
+      if (value && value.timestamp === 0) {
+        // console.log({ event: 'before', asyncId });
+        value.timestamp = self.now();
+      }
+    }
+
+    function after(asyncId: number) {
+      const value = self.dict[asyncId];
+      if (value) {
+        value.duration = value.duration + self.now() - value.timestamp;
+      }
+    }
+
     this.transactionLogger = winston.createLogger({
       format: winston.format.json({
         replacer: (key: string, value: any) => {
@@ -44,6 +111,16 @@ export class TransactionLoggingInterceptor implements NestInterceptor {
   intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
     const apiFunction = context.getClass().name + '.' + context.getHandler().name;
 
+    console.log({ status: 'start', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
+
+    const start = this.now();
+
+    this.dict[async_hooks.executionAsyncId()] = {
+      function: apiFunction,
+      duration: 0,
+      timestamp: this.now(),
+    };
+
     const request = context.getArgByIndex(0);
 
     const isCreateTransactionCall = context.getClass().name === TransactionController.name && context.getHandler().name === 'createTransaction';
@@ -62,6 +139,20 @@ export class TransactionLoggingInterceptor implements NestInterceptor {
     }
 
     return next
-      .handle();
+      .handle()
+      .pipe(
+        tap(() => {
+          console.log({ status: 'finish', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
+
+          console.log({ elapsed: this.now() - start, value: this.dict[async_hooks.triggerAsyncId()], counter: this.counter });
+
+          // console.log({ dict: this.dict });
+        }),
+        catchError(err => {
+          console.log({ status: 'error', apiFunction, executionAsyncId: async_hooks.executionAsyncId(), triggerAsyncId: async_hooks.triggerAsyncId() });
+
+          return throwError(() => err);
+        })
+      );
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,8 @@ import { ErdnestConfigServiceImpl } from './common/api-config/erdnest.config.ser
 import { RabbitMqModule } from './common/rabbitmq/rabbitmq.module';
 import { GraphQlModule } from 'src/graphql/graphql.module';
 import { TransactionLoggingInterceptor } from './interceptors/transaction.logging.interceptor';
+import { RequestCpuTimeInterceptor } from './interceptors/request.cpu.time.interceptor';
+import { ApiMetricsService } from './common/metrics/api.metrics.service';
 
 async function bootstrap() {
   const apiConfigApp = await NestFactory.create(ApiConfigModule);
@@ -143,6 +145,7 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   publicApp.useStaticAssets(join(__dirname, 'public/assets'));
 
   const metricsService = publicApp.get<MetricsService>(MetricsService);
+  const apiMetricsService = publicApp.get<ApiMetricsService>(ApiMetricsService);
   const pluginService = publicApp.get<PluginService>(PluginService);
   const httpAdapterHostService = publicApp.get<HttpAdapterHost>(HttpAdapterHost);
 
@@ -182,6 +185,7 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   // @ts-ignore
   globalInterceptors.push(new QueryCheckInterceptor(httpAdapterHostService));
   globalInterceptors.push(new TransactionLoggingInterceptor());
+  globalInterceptors.push(new RequestCpuTimeInterceptor(apiMetricsService));
 
   await pluginService.bootstrapPublicApp(publicApp);
 

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -364,7 +364,7 @@ describe("NFT Controller", () => {
         .get(path + "?" + params)
         .expect(400)
         .then(res => {
-          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'withScamInfo'");
+          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner', 'withSupply', 'withScamInfo' or 'computeScamInfo'");
         });
     });
   });


### PR DESCRIPTION
## Reasoning
- CPU usage is difficult to correlate to api calls
  
## Proposed Changes
- Created an interceptor to track cpu usage per api call
- Metrics for api call cpu usage

## How to test
- metrics should export api_cpu_time
