### PR TITLE
withScamInfo support for transactions

### DIFF
--- a/src/common/plugins/plugin.service.ts
+++ b/src/common/plugins/plugin.service.ts
@@ -6,15 +6,15 @@ import { Transaction } from "src/endpoints/transactions/entities/transaction";
 
 @Injectable()
 export class PluginService {
-  async processTransaction(_: Transaction): Promise<void> { }
+  async processTransaction(_transaction: Transaction, _withScamInfo?: boolean): Promise<void> { }
 
-  async processTransactionSend(_: any): Promise<any> { }
+  async processTransactionSend(_transaction: any): Promise<any> { }
 
-  async processNft(_: Nft): Promise<void> { }
+  async processNft(_nft: Nft): Promise<void> { }
 
-  async batchProcessNfts(_: Nft[], __?: boolean): Promise<void> { }
+  async batchProcessNfts(_nft: Nft[], _withScamInfo?: boolean): Promise<void> { }
 
-  async processAccount(_: AccountDetailed): Promise<void> { }
+  async processAccount(_account: AccountDetailed): Promise<void> { }
 
-  async bootstrapPublicApp(_: NestExpressApplication): Promise<void> { }
+  async bootstrapPublicApp(_application: NestExpressApplication): Promise<void> { }
 }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -568,6 +568,8 @@ export class AccountController {
       throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs'`);
     }
 
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
+
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,
       receivers: receiver,
@@ -581,7 +583,7 @@ export class AccountController {
       before,
       after,
       order,
-    }), new QueryPagination({ from, size }), new TransactionQueryOptions({ withScResults, withOperations, withLogs }), address);
+    }), new QueryPagination({ from, size }), options, address);
   }
 
   @Get("/accounts/:address/transactions/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -563,12 +563,13 @@ export class AccountController {
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
   ) {
-    if ((withScResults === true || withOperations === true || withLogs) && size > 50) {
-      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs'`);
+    if ((withScResults === true || withOperations === true || withLogs || withScamInfo) && size > 50) {
+      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs' or 'withScamInfo'`);
     }
 
-    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs, withScamInfo });
 
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,

--- a/src/endpoints/nfts/entities/nft.query.options.ts
+++ b/src/endpoints/nfts/entities/nft.query.options.ts
@@ -1,6 +1,7 @@
-const SIZE_LIMIT: number = 100;
 
 export class NftQueryOptions {
+  private static readonly SIZE_LIMIT: number = 100;
+
   constructor(init?: Partial<NftQueryOptions>) {
     Object.assign(this, init);
   }
@@ -12,7 +13,7 @@ export class NftQueryOptions {
 
   //TODO: Remove this function when enforce is no longer needed
   static enforceScamInfoFlag(size: number, options: NftQueryOptions): NftQueryOptions {
-    if (size <= SIZE_LIMIT) {
+    if (size <= NftQueryOptions.SIZE_LIMIT) {
       options.withScamInfo = true;
       options.computeScamInfo = true;
     }

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -215,6 +215,8 @@ export class TokenController {
       throw new NotFoundException('Token not found');
     }
 
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
+
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,
       receivers: receiver,
@@ -229,7 +231,7 @@ export class TokenController {
       before,
       after,
       order,
-    }), new QueryPagination({ from, size }), new TransactionQueryOptions({ withScResults, withOperations, withLogs }));
+    }), new QueryPagination({ from, size }), options);
   }
 
   @Get("/tokens/:identifier/transactions/count")

--- a/src/endpoints/tokens/token.controller.ts
+++ b/src/endpoints/tokens/token.controller.ts
@@ -205,17 +205,18 @@ export class TokenController {
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
   ) {
-    if ((withScResults === true || withOperations === true || withLogs) && size > 50) {
-      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs'`);
+    if ((withScResults === true || withOperations === true || withLogs || withScamInfo) && size > 50) {
+      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs' or 'withScamInfo'`);
     }
+
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs, withScamInfo });
 
     const isToken = await this.tokenService.isToken(identifier);
     if (!isToken) {
       throw new NotFoundException('Token not found');
     }
-
-    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
 
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -1,4 +1,6 @@
 export class TransactionQueryOptions {
+  private static readonly SIZE_LIMIT: number = 100;
+
   constructor(init?: Partial<TransactionQueryOptions>) {
     Object.assign(this, init);
   }
@@ -7,4 +9,14 @@ export class TransactionQueryOptions {
   withOperations?: boolean = true;
   withLogs?: boolean = true;
   withScResultLogs?: boolean = true;
+  withScamInfo?: boolean;
+
+  //TODO: Remove this function when enforce is no longer needed
+  static enforceScamInfoFlag(size: number, options: TransactionQueryOptions): TransactionQueryOptions {
+    if (size <= TransactionQueryOptions.SIZE_LIMIT) {
+      options.withScamInfo = true;
+    }
+
+    return options;
+  }
 }

--- a/src/endpoints/transactions/entities/transactions.query.options.ts
+++ b/src/endpoints/transactions/entities/transactions.query.options.ts
@@ -1,5 +1,5 @@
 export class TransactionQueryOptions {
-  private static readonly SIZE_LIMIT: number = 100;
+  private static readonly SIZE_LIMIT: number = 50;
 
   constructor(init?: Partial<TransactionQueryOptions>) {
     Object.assign(this, init);

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -61,12 +61,13 @@ export class TransactionController {
     @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
     @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
     @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
-  ): Promise<Transaction[]> {
-    if ((withScResults === true || withOperations === true || withLogs) && size > 50) {
-      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs'`);
+    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
+  ) {
+    if ((withScResults === true || withOperations === true || withLogs || withScamInfo) && size > 50) {
+      throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs' or 'withScamInfo'`);
     }
 
-    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs, withScamInfo });
 
     return this.transactionService.getTransactions(new TransactionFilter({
       sender,

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -66,6 +66,8 @@ export class TransactionController {
       throw new BadRequestException(`Maximum size of 50 is allowed when activating flags 'withScResults', 'withOperations' or 'withLogs'`);
     }
 
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs });
+
     return this.transactionService.getTransactions(new TransactionFilter({
       sender,
       receivers: receiver,
@@ -81,7 +83,10 @@ export class TransactionController {
       after,
       condition,
       order,
-    }), new QueryPagination({ from, size }), new TransactionQueryOptions({ withScResults, withOperations, withLogs }));
+    }),
+      new QueryPagination({ from, size }),
+      options,
+    );
   }
 
   @Get("/transactions/count")

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -104,7 +104,7 @@ export class TransactionService {
 
     const assets = await this.assetsService.getAllAccountAssets();
     for (const transaction of transactions) {
-      await this.processTransaction(transaction, assets);
+      await this.processTransaction(transaction, queryOptions?.withScamInfo ?? false, assets);
     }
 
     return transactions;
@@ -120,7 +120,7 @@ export class TransactionService {
     if (transaction !== null) {
       const [price] = await Promise.all([
         this.getTransactionPrice(transaction),
-        this.processTransaction(transaction),
+        this.processTransaction(transaction, true),
       ]);
       transaction.price = price;
 
@@ -232,9 +232,9 @@ export class TransactionService {
     }
   }
 
-  async processTransaction(transaction: Transaction, assets?: Record<string, AccountAssets>): Promise<void> {
+  async processTransaction(transaction: Transaction, withScamInfo: boolean, assets?: Record<string, AccountAssets>): Promise<void> {
     try {
-      await this.pluginsService.processTransaction(transaction);
+      await this.pluginsService.processTransaction(transaction, withScamInfo);
 
       transaction.action = await this.transactionActionService.getTransactionAction(transaction);
 

--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -61,7 +61,7 @@ export class TransferService {
         delete transaction.round;
       }
 
-      await this.transactionService.processTransaction(transaction, assets);
+      await this.transactionService.processTransaction(transaction, pagination.size <= 100, assets);
 
       transactions.push(transaction);
     }

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -364,7 +364,7 @@ describe("NFT Controller", () => {
         .get(path + "?" + params)
         .expect(400)
         .then(res => {
-          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner' or 'withSupply' or 'withScamInfo'");
+          expect(res.body.message).toEqual("Maximum size of 100 is allowed when activating flags 'withOwner', 'withSupply', 'withScamInfo' or 'computeScamInfo'");
         });
     });
   });


### PR DESCRIPTION
## Reasoning
- Transaction list uses a lot of CPU to determine whether scam or not
  
## Proposed Changes
- scamInfo appears automatically for <= 100 entries and not permitted over 100 entries

## How to test (mainnet)
- `/transactions?size=100` should compute scam info
- `/transactions?size=101` should not compute scam info
- `/transactions?withScamInfo=true&size=101` should throw error
