### PR TITLE
NFT content length limit

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -9,6 +9,7 @@ import { ThumbnailType } from "./entities/thumbnail.type";
 import { AWSService } from "./aws.service";
 import { ApiService, Constants, FileUtils } from "@elrondnetwork/erdnest";
 import { TokenHelpers } from "src/utils/token.helpers";
+import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 
 @Injectable()
 export class NftThumbnailService {
@@ -175,11 +176,6 @@ export class NftThumbnailService {
 
     this.logger.log(`Generating thumbnail for NFT with identifier '${nftIdentifier}', url '${fileUrl}' and url hash '${urlHash}'`);
 
-    if (!fileUrl || !fileUrl.startsWith('https://')) {
-      this.logger.log(`NFT with identifier '${nftIdentifier}' and url hash '${urlHash}' has no urls`);
-      return GenerateThumbnailResult.noUrl;
-    }
-
     const fileResult: any = await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS });
     const file = fileResult.data;
 
@@ -242,5 +238,21 @@ export class NftThumbnailService {
 
   private getThumbnailUrlSuffix(urlIdentifier: string): string {
     return `${this.STANDARD_PATH}/${urlIdentifier}`;
+  }
+
+  canGenerateThumbnail(identifier: string, media: NftMedia): boolean {
+    const CONTENT_LENGTH_LIMIT: number = 2000;
+    if (media.fileSize > CONTENT_LENGTH_LIMIT) {
+      this.logger.log(`Content length excedded for NFT with identifier '${identifier}'`);
+      return false;
+    }
+
+    const urlHash = TokenHelpers.getUrlHash(media.url);
+    if (!media.url || !media.url.startsWith('https://')) {
+      this.logger.log(`NFT with identifier '${identifier}' and url hash '${urlHash}' has no urls`);
+      return false;
+    }
+
+    return true;
   }
 }

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -117,6 +117,12 @@ export class NftQueueController {
 
   private async generateThumbnail(nft: Nft, media: NftMedia, forceRefresh: boolean = false): Promise<void> {
     let result: GenerateThumbnailResult;
+
+    if (!this.nftThumbnailService.canGenerateThumbnail(nft.identifier, media)) {
+      this.logger.log(`Can't generate thumbnail for NFT with identifier '${nft.identifier}'`);
+      return;
+    }
+
     try {
       result = await this.nftThumbnailService.generateThumbnail(nft, media.url, media.fileType, forceRefresh);
     } catch (error) {

--- a/src/test/integration/services/nft.thumbnail.e2e-spec.ts
+++ b/src/test/integration/services/nft.thumbnail.e2e-spec.ts
@@ -1,6 +1,7 @@
 import { Test } from "@nestjs/testing";
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { NftFilter } from "src/endpoints/nfts/entities/nft.filter";
+import { NftMedia } from "src/endpoints/nfts/entities/nft.media";
 import { NftService } from "src/endpoints/nfts/nft.service";
 import { PublicAppModule } from "src/public.app.module";
 import { GenerateThumbnailResult } from "src/queue.worker/nft.worker/queue/job-services/thumbnails/entities/generate.thumbnail.result";
@@ -57,6 +58,23 @@ describe('Nft Queue Service', () => {
         false);
 
       expect(thumbnail).toBe(GenerateThumbnailResult.success);
+    });
+  });
+
+  describe(`canGenerateThumbnail`, () => {
+    it('should return false, content length limit excedded', () => {
+      const media = new NftMedia({ fileSize: 10000 });
+      expect(nftQueueService.canGenerateThumbnail('some_identifier', media)).toStrictEqual(false);
+    });
+
+    it('should return false, media is not a valid url', () => {
+      const media = new NftMedia({ fileSize: 1000, url: 'invalid_url' });
+      expect(nftQueueService.canGenerateThumbnail('some_identifier', media)).toStrictEqual(false);
+    });
+
+    it('should return true, thumbnail can be generated', () => {
+      const media = new NftMedia({ fileSize: 1000, url: 'https://media.elrond.com/nfts/asset/bafybeiddv4a5op5hraf2ljyg5gacbaqkjbyxgfme3jxh6vzy7vtg7au5gm/2.mp4' });
+      expect(nftQueueService.canGenerateThumbnail('some_identifier', media)).toStrictEqual(true);
     });
   });
 });


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- NFTs with content length larger than 2MB populate rabbit queue even if thumbnail can't be generated
- 
- 
  
## Proposed Changes
- Add a function that checks if thumbnail can be generated before
- Add unit tests for canGenerate thumbnail functionality

## How to test
- Create an NFT with content length larger than 2MB but lower than 64MB
- It should have media and metadata generated, but thumbnail should be the default one
