### PR TITLE
Support any mypinata.cloud url as whitelisted storage

### DIFF
--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -17,6 +17,7 @@ export class TokenHelpers {
     uri = ApiUtils.replaceUri(uri, 'https://gateway.pinata.cloud/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'https://dweb.link/ipfs', prefix);
     uri = ApiUtils.replaceUri(uri, 'ipfs:/', prefix);
+    uri = uri.replace(/https\:\/\/\w*\.mypinata\.cloud\/ipfs/, prefix);
 
     if (uri.endsWith('.ipfs.dweb.link')) {
       const id = uri.removeSuffix('.ipfs.dweb.link').removePrefix('https://');


### PR DESCRIPTION
## Proposed Changes
- Support *.mypinata.cloud as supported whitelisted storage

## How to test (mainnet)
- `/nfts?collection=SRB-61daf7` should all have `whitelistedStorage: true`
