### PR TITLE
include metadata from the input image in the output when generating thumbnail

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -33,6 +33,7 @@ export class NftThumbnailService {
             fit: fit.cover,
           }
         )
+        .withMetadata()
         .jpeg({ progressive: true })
         .toBuffer();
     } catch (error: any) {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Generated thumbnail don't include input image metadata
  
## Proposed Changes
- Use same metadata flags for input & output images
