### PR TITLE
Sort locked accounts by balance descending

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -459,7 +459,7 @@ export class TokenService {
       minted: denominated === true && result.minted ? NumberUtils.denominateString(result.minted, properties.decimals) : result.minted,
       burnt: denominated === true && result.burned ? NumberUtils.denominateString(result.burned, properties.decimals) : result.burned,
       initialMinted: denominated === true && result.initialMinted ? NumberUtils.denominateString(result.initialMinted, properties.decimals) : result.initialMinted,
-      lockedAccounts,
+      lockedAccounts: lockedAccounts?.sort((a1, a2) => (a2.balance as number) - (a1.balance as number)),
     };
   }
 

--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -459,7 +459,7 @@ export class TokenService {
       minted: denominated === true && result.minted ? NumberUtils.denominateString(result.minted, properties.decimals) : result.minted,
       burnt: denominated === true && result.burned ? NumberUtils.denominateString(result.burned, properties.decimals) : result.burned,
       initialMinted: denominated === true && result.initialMinted ? NumberUtils.denominateString(result.initialMinted, properties.decimals) : result.initialMinted,
-      lockedAccounts: lockedAccounts?.sort((a1, a2) => (a2.balance as number) - (a1.balance as number)),
+      lockedAccounts: lockedAccounts?.sortedDescending(lockedAccounts => lockedAccounts.balance as number),
     };
   }
 

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -13,6 +13,7 @@ import { QueryPagination } from 'src/common/entities/query.pagination';
 import { CachingService, ElasticQuery, ElasticService, FileUtils } from '@elrondnetwork/erdnest';
 import { GatewayModule } from 'src/common/gateway/gateway.module';
 import { TokenFilter } from 'src/endpoints/tokens/entities/token.filter';
+import { EsdtLockedAccount } from 'src/endpoints/esdt/entities/esdt.locked.account';
 
 describe('Token Service', () => {
   let tokenService: TokenService;
@@ -730,6 +731,23 @@ describe('Token Service', () => {
       }
 
       expect(result).toHaveProperties(['supply', 'circulatingSupply']);
+    });
+
+    it('should return totalSupply details for token in descending order', async () => {
+      const identifier: string = "RIDE-7d18e9";
+      const results = await tokenService.getTokenSupply(identifier);
+
+      function sorted(array: EsdtLockedAccount[]) {
+        return array.every(function (num: any, idx: any, arr: any) {
+          return (num <= arr[idx + 1]) || (idx === arr.length - 1) ? 1 : 0;
+        });
+      }
+
+      if (!results?.lockedAccounts) {
+        throw new Error('Property is not defined');
+      }
+
+      expect(sorted(results.lockedAccounts)).toBeTruthy();
     });
 
     it("should return undefined because test simulates that token properties are not defined", async () => {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- 
- 
- 
  
## Proposed Changes

Sort locked accounts by balance descending

## How to test

GET /tokens/RIDE-7d18e9/supply
