### PR TITLE
Sort collections by name

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -110,7 +110,8 @@ export class ElasticIndexerHelper {
       .withMustMultiShouldCondition(filter.identifiers, identifier => QueryType.Match('token', identifier, QueryOperator.AND))
       .withSearchWildcardCondition(filter.search, ['token', 'name'])
       .withMustMultiShouldCondition(filter.type, type => QueryType.Match('type', type))
-      .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type));
+      .withMustMultiShouldCondition([NftType.SemiFungibleESDT, NftType.NonFungibleESDT, NftType.MetaESDT], type => QueryType.Match('type', type))
+      .withMustMatchCondition('name', filter.name);
   }
 
   private getRoleCondition(query: ElasticQuery, name: string, address: string | undefined, value: string | boolean) {

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -26,6 +26,7 @@ export class CollectionController {
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
+  @ApiQuery({ name: 'name', description: 'Search by collection name', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by collection identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'type', description: 'Filter by type (NonFungibleESDT/SemiFungibleESDT/MetaESDT)', required: false })
   @ApiQuery({ name: 'creator', description: 'Filter collections where the given address has a creator role', required: false, deprecated: true })
@@ -41,6 +42,7 @@ export class CollectionController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('search') search?: string,
+    @Query('name') name?: string,
     @Query('identifiers', ParseArrayPipe) identifiers?: string[],
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('creator', ParseAddressPipe) creator?: string,
@@ -55,6 +57,7 @@ export class CollectionController {
   ): Promise<NftCollection[]> {
     return await this.collectionService.getNftCollections(new QueryPagination({ from, size }), new CollectionFilter({
       search,
+      name,
       type,
       identifiers,
       canCreate: canCreate ?? creator,
@@ -71,6 +74,7 @@ export class CollectionController {
   @Get("/collections/count")
   @ApiOperation({ summary: 'Collection count', description: 'Returns non-fungible/semi-fungible/meta-esdt collection count' })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
+  @ApiQuery({ name: 'name', description: 'Search by collection name', required: false })
   @ApiQuery({ name: 'type', description: 'Filter by type (NonFungibleESDT/SemiFungibleESDT/MetaESDT)', required: false })
   @ApiQuery({ name: 'creator', description: 'Filter collections where the given address has a creator role', required: false, deprecated: true })
   @ApiQuery({ name: 'before', description: 'Return all collections before given timestamp', required: false, type: Number })
@@ -84,6 +88,7 @@ export class CollectionController {
   @ApiOkResponse({ type: Number })
   async getCollectionCount(
     @Query('search') search?: string,
+    @Query('name') name?: string,
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('creator', ParseAddressPipe) creator?: string,
     @Query('before', new ParseIntPipe) before?: number,
@@ -97,6 +102,7 @@ export class CollectionController {
   ): Promise<number> {
     return await this.collectionService.getNftCollectionCount(new CollectionFilter({
       search,
+      name,
       type,
       canCreate: canCreate ?? creator,
       before,
@@ -113,6 +119,7 @@ export class CollectionController {
   @ApiExcludeEndpoint()
   async getCollectionCountAlternative(
     @Query('search') search?: string,
+    @Query('name') name?: string,
     @Query('type', new ParseEnumArrayPipe(NftType)) type?: NftType[],
     @Query('creator', ParseAddressPipe) creator?: string,
     @Query('before', new ParseIntPipe) before?: number,
@@ -126,6 +133,7 @@ export class CollectionController {
   ): Promise<number> {
     return await this.collectionService.getNftCollectionCount(new CollectionFilter({
       search,
+      name,
       type,
       canCreate: canCreate ?? creator,
       before,

--- a/src/endpoints/collections/entities/collection.filter.ts
+++ b/src/endpoints/collections/entities/collection.filter.ts
@@ -6,6 +6,7 @@ export class CollectionFilter {
   }
 
   collection?: string;
+  name?: string;
   identifiers?: string[];
   search?: string;
   type?: NftType[];

--- a/src/test/integration/services/collections.e2e-spec.ts
+++ b/src/test/integration/services/collections.e2e-spec.ts
@@ -75,6 +75,16 @@ describe.skip('Collection Service', () => {
       expect(collectionTypes.includes(NftType.MetaESDT)).toBeTruthy();
       expect(collectionTypes.includes(NftType.SemiFungibleESDT)).toBeTruthy();
     });
+
+    it('should return a list of collections with a specific name', async () => {
+      const filter = new CollectionFilter();
+      filter.name = "Sense";
+      const results = await collectionService.getNftCollections({ from: 0, size: 50 }, filter);
+
+      for (const collection of results) {
+        expect(collection.name).toStrictEqual("Sense");
+      }
+    });
   });
 
   describe('applyPropertiesToCollections', () => {


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Sort collections by name is missing
  
## Proposed Changes
- Add name property for CollectionFilter 

## How to test
- Use name parameter on /collections & /collections/count endpoints
- Check if collection name matches the value you provided as parameter
- Check if name filter still applies with multiple filters activated
