### PR TITLE
Fix keybase & mex token fields issue

### DIFF
--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -163,10 +163,10 @@ export class KeybaseService {
       blses.push(bls);
     }
 
-    const providersRegex = new RegExp("https:\/\/keybase.pub\/" + identity + "\/elrond\/" + networkRegex + "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{13}", 'g');
+    const providersRegex = new RegExp("https:\/\/keybase.pub\/" + identity + "\/elrond\/" + networkRegex + "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{14}", 'g');
     const addresses: string[] = [];
     for (const keybaseUrl of html.match(providersRegex) || []) {
-      const bls = keybaseUrl.match(/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{13}/)[0];
+      const bls = keybaseUrl.match(/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{14}/)[0];
       addresses.push(bls);
     }
 

--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -166,7 +166,7 @@ export class KeybaseService {
     const providersRegex = new RegExp("https:\/\/keybase.pub\/" + identity + "\/elrond\/" + networkRegex + "erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{13}", 'g');
     const addresses: string[] = [];
     for (const keybaseUrl of html.match(providersRegex) || []) {
-      const bls = keybaseUrl.match(/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{13}/)[0];
+      const bls = keybaseUrl.match(/erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqq[0-9a-z]{13}/)[0];
       addresses.push(bls);
     }
 

--- a/src/endpoints/mex/mex.token.service.ts
+++ b/src/endpoints/mex/mex.token.service.ts
@@ -41,7 +41,8 @@ export class MexTokenService {
 
   async getMexTokens(queryPagination: QueryPagination): Promise<MexToken[]> {
     const { from, size } = queryPagination;
-    const allMexTokens = await this.getAllMexTokens();
+    let allMexTokens = await this.getAllMexTokens();
+    allMexTokens = JSON.parse(JSON.stringify(allMexTokens));
 
     return allMexTokens.slice(from, from + size);
   }


### PR DESCRIPTION
## Proposed Changes
- Fix keybase regex
- Fix mex token fields issue

## How to test (mainnet)
- Provider `erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqpqhllllsqdxn4p` should be fetched from keybase (regex should match)
- After calling `/mex/tokens?fields=id`, `/mex/tokens` should return all fields and not the filtered ones