### PR TITLE
Transaction log decoder fix

### DIFF
--- a/src/endpoints/tokens/token.transfer.service.ts
+++ b/src/endpoints/tokens/token.transfer.service.ts
@@ -162,7 +162,7 @@ export class TokenTransferService {
       operation.data = BinaryUtils.base64Decode(event.data);
     }
 
-    if (event.topics.length > 1) {
+    if (event.topics.length > 1 && event.topics[1]) {
       operation.message = BinaryUtils.base64Decode(event.topics[1]);
     }
 


### PR DESCRIPTION
## Proposed Changes
- Check event for null when decoding transaction

## How to test
- `/transactions?withScResults=true&withOperations=true&withLogs=true&size=50&hashes=d4e42a1f3378b01189926c2220e644d3f457299fe886f51b6ac04890f048ee2c` should not throw 500 Internal Server Error
