### PR TITLE
remove query pagination from rounds count endpoint

### DIFF
--- a/src/endpoints/rounds/round.controller.ts
+++ b/src/endpoints/rounds/round.controller.ts
@@ -34,34 +34,28 @@ export class RoundController {
   @Get("/rounds/count")
   @ApiOperation({ summary: 'Rounds count', description: 'Returns total number of rounds' })
   @ApiOkResponse({ type: Number })
-  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
-  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
   @ApiQuery({ name: 'validator', description: 'Filter by validator', required: false })
   @ApiQuery({ name: 'condition', description: 'Filter by condition', required: false })
   @ApiQuery({ name: 'shard', description: 'Filter by shard identifier', required: false })
   @ApiQuery({ name: 'epoch', description: 'Filter by epoch number', required: false })
   getRoundCount(
-    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
-    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query("validator", ParseBlsHashPipe) validator?: string,
     @Query('condition', new ParseEnumPipe(QueryConditionOptions)) condition?: QueryConditionOptions,
     @Query("shard", new ParseIntPipe) shard?: number,
     @Query("epoch", new ParseIntPipe) epoch?: number,
   ): Promise<number> {
-    return this.roundService.getRoundCount(new RoundFilter({ from, size, condition, validator, shard, epoch }));
+    return this.roundService.getRoundCount(new RoundFilter({ condition, validator, shard, epoch }));
   }
 
   @Get("/rounds/c")
   @ApiExcludeEndpoint()
   getRoundCountAlternative(
-    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
-    @Query("size", new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query("validator", ParseBlsHashPipe) validator?: string,
     @Query('condition', new ParseEnumPipe(QueryConditionOptions)) condition?: QueryConditionOptions,
     @Query("shard", new ParseIntPipe) shard?: number,
     @Query("epoch", new ParseIntPipe) epoch?: number,
   ): Promise<number> {
-    return this.roundService.getRoundCount(new RoundFilter({ from, size, condition, validator, shard, epoch }));
+    return this.roundService.getRoundCount(new RoundFilter({ condition, validator, shard, epoch }));
   }
 
   @Get("/rounds/:shard/:round")


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
-  remove query pagination from rounds/count and rounds/c

## How to test
-  rounds/count endpoint should return rounds count even without from and size filters
- rounds/c endpoint should return rounds count even without from and size filters