### PR TITLE
Do not filter nodes when sorting

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -173,10 +173,6 @@ export class NodeService {
         }
       }
 
-      if (query.sort && (node[query.sort] === undefined || node[query.sort] === '')) {
-        return false;
-      }
-
       return true;
     });
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
-  nodes?fullHistory=true&sort=validatorIgnoredSignatures&order=desc returns empty array
  
## Proposed Changes
- remove sort condition from getFilteredNodes method

## How to test
-  nodes?fullHistory=true&sort=validatorIgnoredSignatures&order=desc should return 25 nodes
