### PR TITLE
 function filter in account transactions transfers endpoint

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -549,6 +549,7 @@ export class AccountController {
   @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of transaction hashes', required: false })
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
   @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
@@ -570,6 +571,7 @@ export class AccountController {
     @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('search') search?: string,
+    @Query('function') scFunction?: string,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
@@ -584,6 +586,7 @@ export class AccountController {
       sender,
       receivers: receiver,
       token,
+      function: scFunction,
       senderShard,
       receiverShard,
       miniBlockHash,
@@ -657,6 +660,7 @@ export class AccountController {
   @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of transfer hashes', required: false })
   @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
   @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
   @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
@@ -673,6 +677,7 @@ export class AccountController {
     @Query('hashes', ParseArrayPipe) hashes?: string[],
     @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
     @Query('search') search?: string,
+    @Query('function') scFunction?: string,
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
@@ -686,6 +691,7 @@ export class AccountController {
       sender,
       receivers: receiver,
       token,
+      function: scFunction,
       senderShard,
       receiverShard,
       miniBlockHash,

--- a/src/test/integration/services/transactions.e2e-spec.ts
+++ b/src/test/integration/services/transactions.e2e-spec.ts
@@ -278,6 +278,16 @@ describe('Transaction Service', () => {
           expect(transaction.miniBlockHash).toStrictEqual(transactionDetails.miniBlockHash);
         }
       });
+
+      it(`should return transactions details with "function" filter applied`, async () => {
+        const transactionFilter = new TransactionFilter();
+        transactionFilter.function = "sendOffer";
+
+        const transactions = await transactionService.getTransactions(transactionFilter, { from: 0, size: 25 });
+        for (const transaction of transactions) {
+          expect(transaction.function).toStrictEqual("sendOffer");
+        }
+      });
     });
   });
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
  
## Proposed Changes
-  add function filter for accounts/:address/transactions and accounts/:address/transfers

## How to test
-  accounts/erd1c9lcvjs0qhdhfk7jn8hsshrcfxmq0ulk2ea3mxu9xh79l8n646gscchq6x/transfers?function=sendOffer -> all account transactions should contain function: "sendOffer" 
-  accounts/erd1c9lcvjs0qhdhfk7jn8hsshrcfxmq0ulk2ea3mxu9xh79l8n646gscchq6x/transfers/count?function=sendOffer -> should return ~9
