### PR TITLE
Randomized & resilient keybase.pub fetching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.57",
+        "@elrondnetwork/erdnest": "^0.1.65",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.57",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.57.tgz",
-      "integrity": "sha512-ByKqh0W/m0gUAh0q0sfg8ej1AF/PBAhTKpzdnZ1cbX+TRYBof3cEfyLA8Eyz+Z+FGwHcPl6DbMD4xOeqGQ8Y6g==",
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.65.tgz",
+      "integrity": "sha512-cwQBK4g50geYmr+9BdddKNCIxc0eHl2tO+rJaU39kvakzXFjgA/+zYE00CdxFf31ARspMT1U3w11p8h+m6dCmQ==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17298,9 +17298,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.57",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.57.tgz",
-      "integrity": "sha512-ByKqh0W/m0gUAh0q0sfg8ej1AF/PBAhTKpzdnZ1cbX+TRYBof3cEfyLA8Eyz+Z+FGwHcPl6DbMD4xOeqGQ8Y6g==",
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.65.tgz",
+      "integrity": "sha512-cwQBK4g50geYmr+9BdddKNCIxc0eHl2tO+rJaU39kvakzXFjgA/+zYE00CdxFf31ARspMT1U3w11p8h+m6dCmQ==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -19467,7 +19467,9 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {}
+      "requires": {
+        "ajv": "^8.0.0"
+      }
     },
     "amqp-connection-manager": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.57",
+    "@elrondnetwork/erdnest": "^0.1.65",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",


### PR DESCRIPTION
## Reasoning
- keybase.pub slow & unreliable; cache warmer failing often, most recent providers were not updated
  
## Proposed Changes
- randomize providers to be fetched from keybase.pub
- apply retry strategy with backoff

## How to test (mainnet)
- Start with `fastWarm` setting activated, then make sure all providers are properly loaded from keybase.pub
