### PR TITLE
Customizable ES max window size

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -58,6 +58,7 @@ urls:
   socket: 'devnet-socket-fra.elrond.com'
 indexer:
   type: 'elastic'
+  maxPagination: 10000
 database:
   enabled: false
   url: 'mongodb://127.0.0.1:27017/api?authSource=admin'

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -59,6 +59,7 @@ urls:
   socket: 'socket-fra.elrond.com'
 indexer:
   type: 'elastic'
+  maxPagination: 10000
 database:
   enabled: false
   url: 'mongodb://127.0.0.1:27017/api?authSource=admin'

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -66,6 +66,7 @@ database:
   database: 'api'
 indexer:
   type: 'elastic'
+  maxPagination: 10000
 caching:
   cacheTtl: 6
   processTtl: 600

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.65",
+        "@elrondnetwork/erdnest": "^0.1.66",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.65.tgz",
-      "integrity": "sha512-cwQBK4g50geYmr+9BdddKNCIxc0eHl2tO+rJaU39kvakzXFjgA/+zYE00CdxFf31ARspMT1U3w11p8h+m6dCmQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.66.tgz",
+      "integrity": "sha512-hhHEhNuZCSK/F8q+7msZdlaYrbPEsPv3XNo3Gahb3zMF+bIMlzZFxnkMlDHcyxDlzOYVqCE/tLam1QEjuJbfvw==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17298,9 +17298,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.65",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.65.tgz",
-      "integrity": "sha512-cwQBK4g50geYmr+9BdddKNCIxc0eHl2tO+rJaU39kvakzXFjgA/+zYE00CdxFf31ARspMT1U3w11p8h+m6dCmQ==",
+      "version": "0.1.66",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.66.tgz",
+      "integrity": "sha512-hhHEhNuZCSK/F8q+7msZdlaYrbPEsPv3XNo3Gahb3zMF+bIMlzZFxnkMlDHcyxDlzOYVqCE/tLam1QEjuJbfvw==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.65",
+    "@elrondnetwork/erdnest": "^0.1.66",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -701,4 +701,8 @@ export class ApiConfigService {
       database: this.getIndexerName(),
     };
   }
+
+  getIndexerMaxPagination(): number {
+    return this.configService.get<number>('indexer.maxPagination') ?? 10000;
+  }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -185,7 +185,7 @@ async function configurePublicApp(publicApp: NestExpressApplication, apiConfigSe
   globalInterceptors.push(new FieldsInterceptor());
   globalInterceptors.push(new ExtractInterceptor());
   globalInterceptors.push(new CleanupInterceptor());
-  globalInterceptors.push(new PaginationInterceptor());
+  globalInterceptors.push(new PaginationInterceptor(apiConfigService.getIndexerMaxPagination()));
   // @ts-ignore
   globalInterceptors.push(new QueryCheckInterceptor(httpAdapterHostService));
   globalInterceptors.push(new TransactionLoggingInterceptor());


### PR DESCRIPTION
## Reasoning
- The underlying elasticsearch instance can be configured to have a maximum window size greater than 10000 (e.g. 50000) and our interceptors do not allow larger windows
  
## Proposed Changes
- Allow a configurable value for max window size in the pagination interceptor

## How to test
- set the `indexer.maxPagination` value to 5000
- GET `/accounts?size=5001` should throw error
- GET `/accounts?from=1000&size=5000` should also throw error
