### PR TITLE
invert type verification for operation

### DIFF
--- a/src/endpoints/transfers/transfer.service.ts
+++ b/src/endpoints/transfers/transfer.service.ts
@@ -51,7 +51,7 @@ export class TransferService {
     const assets = await this.assetsService.getAllAccountAssets();
     for (const elasticOperation of elasticOperations) {
       const transaction = ApiUtils.mergeObjects(new Transaction(), elasticOperation);
-      transaction.type = elasticOperation.type === 'unsigned' ? TransactionType.SmartContractResult : TransactionType.Transaction;
+      transaction.type = elasticOperation.type === 'normal' ? TransactionType.Transaction : TransactionType.SmartContractResult;
 
       if (transaction.type === TransactionType.SmartContractResult) {
         delete transaction.gasLimit;


### PR DESCRIPTION
## Reasoning
- Operation might not have `type` defined at all for certain SmartContractResults
  
## Proposed Changes
- invert logic for verifying `type` in operation from ES result

## How to test (mainnet)
-`/tokens/WEGLD-bd4d79/transfers?size=1000&receiver=erd1tsuu9jf4pn8rsus9knrw4ju39ukyp247gug8gahsfdjzdzewd0eqcwgl30&before=1642373550&after=1642373550` should have type `SmartContractResult`
