### PR TITLE
 add try/catch block to handle gateway "account was not found at block"

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -436,7 +436,10 @@ export class AccountController {
         options,
         source
       );
-    } catch (error) {
+    } catch (error: any) {
+      if (error.response.error.includes('account was not found at block')) {
+        throw new NotFoundException('Account not found');
+      }
       return [];
     }
   }

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -428,21 +428,13 @@ export class AccountController {
   ): Promise<NftAccount[]> {
     const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withSupply, withScamInfo, computeScamInfo }));
 
-    try {
-      return await this.nftService.getNftsForAddress(
-        address,
-        new QueryPagination({ from, size }),
-        new NftFilter({ search, identifiers, type, collection, name, collections, tags, creator, hasUris, includeFlagged }),
-        options,
-        source
-      );
-    } catch (error: any) {
-      if (error.response.error.includes('account was not found at block')) {
-        return [];
-      }
-
-      throw error;
-    }
+    return await this.nftService.getNftsForAddress(
+      address,
+      new QueryPagination({ from, size }),
+      new NftFilter({ search, identifiers, type, collection, name, collections, tags, creator, hasUris, includeFlagged }),
+      options,
+      source
+    );
   }
 
   @Get("/accounts/:address/nfts/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -428,13 +428,17 @@ export class AccountController {
   ): Promise<NftAccount[]> {
     const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withSupply, withScamInfo, computeScamInfo }));
 
-    return await this.nftService.getNftsForAddress(
-      address,
-      new QueryPagination({ from, size }),
-      new NftFilter({ search, identifiers, type, collection, name, collections, tags, creator, hasUris, includeFlagged }),
-      options,
-      source
-    );
+    try {
+      return await this.nftService.getNftsForAddress(
+        address,
+        new QueryPagination({ from, size }),
+        new NftFilter({ search, identifiers, type, collection, name, collections, tags, creator, hasUris, includeFlagged }),
+        options,
+        source
+      );
+    } catch (error) {
+      return [];
+    }
   }
 
   @Get("/accounts/:address/nfts/count")

--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -438,9 +438,10 @@ export class AccountController {
       );
     } catch (error: any) {
       if (error.response.error.includes('account was not found at block')) {
-        throw new NotFoundException('Account not found');
+        return [];
       }
-      return [];
+
+      throw error;
     }
   }
 

--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -200,7 +200,17 @@ export class EsdtAddressService {
       const nonceHex = identifier.split('-')[2];
       const nonceNumeric = BinaryUtils.hexToNumber(nonceHex);
 
-      const result = await this.gatewayService.get(`address/${address}/nft/${collection}/nonce/${nonceNumeric}`, GatewayComponentRequest.addressNftByNonce);
+      let result: any;
+      try {
+        result = await this.gatewayService.get(`address/${address}/nft/${collection}/nonce/${nonceNumeric}`, GatewayComponentRequest.addressNftByNonce);
+      } catch (error: any) {
+        if (error.response.error.includes('account was not found')) {
+          return [];
+        }
+
+        throw error;
+      }
+
       if (!result || !result.tokenData || result.tokenData.balance === '0') {
         return [];
       }


### PR DESCRIPTION

## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- When you search NFTs or SFTs by identifiers on an account than has never been used, the API respond error 500.
It should respond an empty array as when you make a search by collections or when you make this search on an used account but whithout the NFT searched.
  
## Proposed Changes
- Handle gateway error from controller accounts  level 
- Add try/catch block

accounts/erd1fex4n4qus76efz8cpjm734dfdyuw28m8ry3al6xyd7cmfml9259qq8l2y5/nfts?identifiers=AERMES-ac9886-0ad9 -> should return [] because this wallet does not contains AERMES-ac9886-0ad9  -> should return 500 Internal Server Error

## How to test
-  accounts/erd1fex4n4qus76efz8cpjm734dfdyuw28m8ry3al6xyd7cmfml9259qq8l2y5/nfts?identifiers=AERMES-ac9886-0ad9 -> should return [] because this wallet does not contains AERMES-ac9886-0ad9 

- /accounts/erd1nlgvg70r4er2jdnykkcxwskrmkvvfl46pjykqg6mmcw3qd69rkesh2py3k/nfts?identifiers=AERMES-ac9886-01f3 -> should return NFT details 
