### PR TITLE
 transactions searchable by collection/nft

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -7,10 +7,17 @@ import { Nft } from "../nfts/entities/nft";
 import { NftService } from "../nfts/nft.service";
 import { NftFilter } from "../nfts/entities/nft.filter";
 import { NftQueryOptions } from "../nfts/entities/nft.query.options";
-import { ParseAddressPipe, ParseArrayPipe, ParseCollectionPipe, ParseBoolPipe, ParseEnumArrayPipe, ParseIntPipe, ApplyComplexity } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseArrayPipe, ParseCollectionPipe, ParseBoolPipe, ParseEnumArrayPipe, ParseIntPipe, ApplyComplexity, ParseAddressArrayPipe, ParseBlockHashPipe, ParseEnumPipe } from '@elrondnetwork/erdnest';
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { CollectionFilter } from "./entities/collection.filter";
 import { CollectionAccount } from "./entities/collection.account";
+import { TransactionDetailed } from "../transactions/entities/transaction.detailed";
+import { Transaction } from "../transactions/entities/transaction";
+import { TransactionStatus } from "../transactions/entities/transaction.status";
+import { SortOrder } from "src/common/entities/sort.order";
+import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
+import { TransactionService } from "../transactions/transaction.service";
+import { TransactionFilter } from "../transactions/entities/transaction.filter";
 
 @Controller()
 @ApiTags('collections')
@@ -18,6 +25,7 @@ export class CollectionController {
   constructor(
     private readonly collectionService: CollectionService,
     private readonly nftService: NftService,
+    private readonly transactionService: TransactionService,
   ) { }
 
   @Get("/collections")
@@ -203,7 +211,6 @@ export class CollectionController {
   @Get("/collections/:collection/nfts/count")
   @ApiOperation({ summary: 'Collection NFT count', description: 'Returns non-fungible/semi-fungible/meta-esdt token count that belong to a collection' })
   @ApiOkResponse({ type: Number })
-  @ApiNotFoundResponse({ description: 'Token collection not found' })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by token identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'name', description: 'Get all nfts by name', required: false })
@@ -246,5 +253,109 @@ export class CollectionController {
     }
 
     return owners;
+  }
+
+  @Get("/collections/:collection/transactions")
+  @ApiOperation({ summary: 'Collection transactions', description: `Returns a list of transactions for a specific collection.` })
+  @ApplyComplexity({ target: TransactionDetailed })
+  @ApiOkResponse({ type: [Transaction] })
+  @ApiQuery({ name: 'sender', description: 'Address of the transaction sender', required: false })
+  @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
+  @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
+  @ApiQuery({ name: 'receiverShard', description: 'Id of the shard the receiver address belongs to', required: false })
+  @ApiQuery({ name: 'miniBlockHash', description: 'Filter by miniblock hash', required: false })
+  @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of transaction hashes', required: false })
+  @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
+  @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
+  @ApiQuery({ name: 'function', description: 'Filter transactions by function name', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  @ApiQuery({ name: 'order', description: 'Sort order (asc/desc)', required: false, enum: SortOrder })
+  @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
+  @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
+  @ApiQuery({ name: 'withScResults', description: 'Return scResults for transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withOperations', description: 'Return operations for transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions', required: false, type: Boolean })
+  @ApiQuery({ name: 'withScamInfo', required: false, type: Boolean })
+  async getCollectionTransactions(
+    @Param('collection', ParseCollectionPipe) identifier: string,
+    @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
+    @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
+    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
+    @Query('senderShard', ParseIntPipe) senderShard?: number,
+    @Query('receiverShard', ParseIntPipe) receiverShard?: number,
+    @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
+    @Query('hashes', ParseArrayPipe) hashes?: string[],
+    @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
+    @Query('search') search?: string,
+    @Query('function') scFunction?: string,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+    @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
+    @Query('withScResults', new ParseBoolPipe) withScResults?: boolean,
+    @Query('withOperations', new ParseBoolPipe) withOperations?: boolean,
+    @Query('withLogs', new ParseBoolPipe) withLogs?: boolean,
+    @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
+  ) {
+    const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs, withScamInfo });
+
+    return await this.transactionService.getTransactions(new TransactionFilter({
+      sender,
+      receivers: receiver,
+      token: identifier,
+      function: scFunction,
+      senderShard,
+      receiverShard,
+      miniBlockHash,
+      hashes,
+      status,
+      search,
+      before,
+      after,
+      order,
+    }), new QueryPagination({ from, size }), options);
+  }
+
+  @Get("/collections/:collection/transactions/count")
+  @ApiOperation({ summary: 'NFT transactions count', description: 'Returns the total number of transactions for a specific collection' })
+  @ApiOkResponse({ type: Number })
+  @ApiQuery({ name: 'sender', description: 'Address of the transaction sender', required: false })
+  @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
+  @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
+  @ApiQuery({ name: 'receiverShard', description: 'Id of the shard the receiver address belongs to', required: false })
+  @ApiQuery({ name: 'miniBlockHash', description: 'Filter by miniblock hash', required: false })
+  @ApiQuery({ name: 'hashes', description: 'Filter by a comma-separated list of transaction hashes', required: false })
+  @ApiQuery({ name: 'status', description: 'Status of the transaction (success / pending / invalid / fail)', required: false, enum: TransactionStatus })
+  @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
+  @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
+  @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
+  async getCollectionTransactionsCount(
+    @Param('collection', ParseCollectionPipe) identifier: string,
+    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
+    @Query('senderShard', ParseIntPipe) senderShard?: number,
+    @Query('receiverShard', ParseIntPipe) receiverShard?: number,
+    @Query('miniBlockHash', ParseBlockHashPipe) miniBlockHash?: string,
+    @Query('hashes', ParseArrayPipe) hashes?: string[],
+    @Query('status', new ParseEnumPipe(TransactionStatus)) status?: TransactionStatus,
+    @Query('search') search?: string,
+    @Query('before', ParseIntPipe) before?: number,
+    @Query('after', ParseIntPipe) after?: number,
+  ) {
+
+    return await this.transactionService.getTransactionCount(new TransactionFilter({
+      sender,
+      receivers: receiver,
+      token: identifier,
+      senderShard,
+      receiverShard,
+      miniBlockHash,
+      hashes,
+      status,
+      search,
+      before,
+      after,
+    }));
   }
 }

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -155,7 +155,7 @@ export class CollectionController {
   ): Promise<NftCollection> {
     const token = await this.collectionService.getNftCollection(collection);
     if (token === undefined) {
-      throw new HttpException('NFT collection not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
     }
 
     return token;
@@ -197,7 +197,7 @@ export class CollectionController {
   ): Promise<Nft[]> {
     const isCollection = await this.collectionService.isCollection(collection);
     if (!isCollection) {
-      throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
     }
 
     const options = NftQueryOptions.enforceScamInfoFlag(size, new NftQueryOptions({ withOwner, withSupply, withScamInfo, computeScamInfo }));
@@ -211,6 +211,7 @@ export class CollectionController {
   @Get("/collections/:collection/nfts/count")
   @ApiOperation({ summary: 'Collection NFT count', description: 'Returns non-fungible/semi-fungible/meta-esdt token count that belong to a collection' })
   @ApiOkResponse({ type: Number })
+  @ApiNotFoundResponse({ description: 'Token collection not found' })
   @ApiQuery({ name: 'search', description: 'Search by collection identifier', required: false })
   @ApiQuery({ name: 'identifiers', description: 'Search by token identifiers, comma-separated', required: false })
   @ApiQuery({ name: 'name', description: 'Get all nfts by name', required: false })
@@ -230,7 +231,7 @@ export class CollectionController {
   ): Promise<number> {
     const isCollection = await this.collectionService.isCollection(collection);
     if (!isCollection) {
-      throw new HttpException('NFT Collection not found', HttpStatus.NOT_FOUND);
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
     }
 
     return await this.nftService.getNftCount(new NftFilter({ search, identifiers, collection, name, tags, creator, isWhitelistedStorage, hasUris }));
@@ -259,6 +260,7 @@ export class CollectionController {
   @ApiOperation({ summary: 'Collection transactions', description: `Returns a list of transactions for a specific collection.` })
   @ApplyComplexity({ target: TransactionDetailed })
   @ApiOkResponse({ type: [Transaction] })
+  @ApiNotFoundResponse({ description: 'Collection not found' })
   @ApiQuery({ name: 'sender', description: 'Address of the transaction sender', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -299,6 +301,10 @@ export class CollectionController {
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
   ) {
     const options = TransactionQueryOptions.enforceScamInfoFlag(size, { withScResults, withOperations, withLogs, withScamInfo });
+    const isCollection = await this.collectionService.isCollection(identifier);
+    if (!isCollection) {
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
+    }
 
     return await this.transactionService.getTransactions(new TransactionFilter({
       sender,
@@ -320,6 +326,7 @@ export class CollectionController {
   @Get("/collections/:collection/transactions/count")
   @ApiOperation({ summary: 'NFT transactions count', description: 'Returns the total number of transactions for a specific collection' })
   @ApiOkResponse({ type: Number })
+  @ApiNotFoundResponse({ description: 'Collection not found' })
   @ApiQuery({ name: 'sender', description: 'Address of the transaction sender', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -343,6 +350,10 @@ export class CollectionController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ) {
+    const isCollection = await this.collectionService.isCollection(identifier);
+    if (!isCollection) {
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
+    }
 
     return await this.transactionService.getTransactionCount(new TransactionFilter({
       sender,

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -270,7 +270,7 @@ export class NftController {
   @ApiQuery({ name: 'withOperations', description: 'Return operations for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withLogs', description: 'Return logs for transactions', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', required: false, type: Boolean })
-  async getTokenTransactions(
+  async getNftTransactions(
     @Param('identifier', ParseNftPipe) identifier: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
@@ -324,7 +324,7 @@ export class NftController {
   @ApiQuery({ name: 'search', description: 'Search in data object', required: false })
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
-  async getTokenTransactionsCount(
+  async getNftTransactionsCount(
     @Param('identifier', ParseNftPipe) identifier: string,
     @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],

--- a/src/endpoints/nfts/nft.controller.ts
+++ b/src/endpoints/nfts/nft.controller.ts
@@ -11,12 +11,12 @@ import { QueryPagination } from 'src/common/entities/query.pagination';
 import { NftQueryOptions } from './entities/nft.query.options';
 import { ParseAddressPipe, ParseBoolPipe, ParseArrayPipe, ParseIntPipe, ParseNftPipe, ParseCollectionPipe, ApplyComplexity, ParseAddressArrayPipe, ParseBlockHashPipe, ParseEnumPipe } from '@elrondnetwork/erdnest';
 import { TransactionDetailed } from '../transactions/entities/transaction.detailed';
-import { Transaction } from '@elrondnetwork/erdjs/out';
 import { TransactionStatus } from '../transactions/entities/transaction.status';
 import { SortOrder } from 'src/common/entities/sort.order';
 import { TransactionQueryOptions } from '../transactions/entities/transactions.query.options';
 import { TransactionService } from '../transactions/transaction.service';
 import { TransactionFilter } from '../transactions/entities/transaction.filter';
+import { Transaction } from '../transactions/entities/transaction';
 
 @Controller()
 @ApiTags('nfts')


### PR DESCRIPTION
## Proposed Changes
- Add nfts/:identifier/transactions endpoint to receive transactions details for a specific NFT .

## How to test
NFT Transactions: 
-  nfts/MKU-b945e6-14/transactions -> should return 2 transactions details for NFT with identifier  MKU-b945e6-14.
-  nfts/MKU-b945e6-14/transactions/count -> should return transaction count =  2

Collection Transactions:
- collections/MKU-b945e6/transactions -> should return 25 transactions details for collection MKU-b945e6
- collections/MKU-b945e6/transactions/count -> should return collection transactions count = 74
- collections/MKU-b145e6/transactions/count -> should return 404 "Collection not found"
