### PR TITLE
Updated locked tokens amount to be read dynamically

### DIFF
--- a/src/endpoints/accounts/account.service.ts
+++ b/src/endpoints/accounts/account.service.ts
@@ -101,7 +101,7 @@ export class AccountService {
     return await this.getAccountRaw(address);
   }
 
-  private async getAccountRaw(address: string, txCount: number = 0, scrCount: number = 0): Promise<AccountDetailed | null> {
+  async getAccountRaw(address: string, txCount: number = 0, scrCount: number = 0): Promise<AccountDetailed | null> {
     const assets = await this.assetsService.getAllAccountAssets();
 
     try {

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -166,7 +166,7 @@ export class NetworkService {
     if (this.apiConfigService.getNetwork() === 'mainnet') {
       const account = await this.accountService.getAccountRaw('erd195fe57d7fm5h33585sc7wl8trqhrmy85z3dg6f6mqd0724ymljxq3zjemc');
       if (account) {
-        locked = NumberUtils.denominate(BigInt(account.balance), 18);
+        locked = Math.round(NumberUtils.denominate(BigInt(account.balance), 18));
       }
     }
 

--- a/src/endpoints/network/network.service.ts
+++ b/src/endpoints/network/network.service.ts
@@ -126,7 +126,6 @@ export class NetworkService {
   }
 
   async getEconomicsRaw(): Promise<Economics> {
-    const locked = 1330000;
     const [
       {
         account: { balance },
@@ -162,6 +161,14 @@ export class NetworkService {
 
     const staked = parseInt((BigInt(balance) + totalWaitingStake).toString().slice(0, -18));
     const totalSupply = parseInt(erd_total_supply.slice(0, -18));
+
+    let locked: number = 0;
+    if (this.apiConfigService.getNetwork() === 'mainnet') {
+      const account = await this.accountService.getAccountRaw('erd195fe57d7fm5h33585sc7wl8trqhrmy85z3dg6f6mqd0724ymljxq3zjemc');
+      if (account) {
+        locked = NumberUtils.denominate(BigInt(account.balance), 18);
+      }
+    }
 
     const circulatingSupply = totalSupply - locked;
     const price = priceValue ? parseFloat(priceValue.toFixed(2)) : undefined;


### PR DESCRIPTION
## Reasoning
- Locked tokens had to be manually updated every time the team vesting account had outgoing transactions
  
## Proposed Changes
- Decrease circulating supply with a dynamically read value from the team vesting account

## How to test (mainnet)
- `/economics` should return ~23.6 mil. as circulating supply
