### PR TITLE
Set node offline if no online property set

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -574,6 +574,10 @@ export class NodeService {
         node.shard = undefined;
       }
 
+      if (node.online === undefined) {
+        node.online = false;
+      }
+
       node.issues = this.getIssues(node, config.erd_latest_tag_software_version);
 
       nodes.push(node);


### PR DESCRIPTION
## Reasoning
- Some nodes do not have the online attribute at all
  
## Proposed Changes
- Absence of online attribute should set it to `false`

## How to test
- `/nodes/count` should be `/nodes/count?online=true` + `/nodes/count?online=false`
