### PR TITLE
NFT apply transfer affected attribute

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -33,4 +33,5 @@ export enum GatewayComponentRequest {
   allFungibleTokens = 'allFungibleTokens',
   addressNftByNonce = 'addressNftByNonce',
   validatorAuction = 'validatorAuction',
+  oldStorageToken = 'oldStorageToken',
 }

--- a/src/endpoints/nfts/entities/nft.ts
+++ b/src/endpoints/nfts/entities/nft.ts
@@ -126,4 +126,8 @@ export class Nft {
   @Field(() => [UnlockMileStoneModel], { description: "Unlock mile stone model for the given NFT.", nullable: true })
   @ApiProperty({ type: [UnlockMileStoneModel], nullable: true })
   unlockSchedule?: UnlockMileStoneModel[] | undefined = undefined;
+
+  @Field(() => Boolean, { description: "Returns true if the transfer is affected.", nullable: true })
+  @ApiProperty({ type: Boolean, nullable: true })
+  isTransferAffected: boolean | undefined = undefined;
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -225,8 +225,7 @@ export class NftService {
         nft.isTransferAffected = true;
       }
     } catch (error) {
-      this.logger.error(`Unexpected error when fetching old storage token information for NFT with identifier '${nft.identifier}'`);
-      this.logger.error(error);
+      // probably old version of the gateway
     }
   }
 

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -445,6 +445,8 @@ export class NftService {
 
     for (const nft of nfts) {
       await this.applyUnlockSchedule(nft);
+
+      await this.applyTransferAffected(nft);
     }
 
     await this.pluginService.processNfts(nfts, queryOptions?.withScamInfo || queryOptions?.computeScamInfo);
@@ -503,6 +505,8 @@ export class NftService {
     const nft = nfts[0];
 
     await this.applyUnlockSchedule(nft);
+
+    await this.applyTransferAffected(nft);
 
     return nft;
   }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -24,6 +24,8 @@ import { IndexerService } from "src/common/indexer/indexer.service";
 import { LockedAssetService } from "../../common/locked-asset/locked-asset.service";
 import { CollectionAccount } from "../collections/entities/collection.account";
 import { OriginLogger } from "@elrondnetwork/erdnest";
+import { GatewayService } from "src/common/gateway/gateway.service";
+import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 
 @Injectable()
 export class NftService {
@@ -46,7 +48,7 @@ export class NftService {
     private readonly esdtAddressService: EsdtAddressService,
     private readonly mexTokenService: MexTokenService,
     private readonly lockedAssetService: LockedAssetService,
-
+    private readonly gatewayService: GatewayService,
   ) {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
     this.DEFAULT_MEDIA = [
@@ -209,9 +211,23 @@ export class NftService {
 
     await this.applyUnlockSchedule(nft);
 
+    await this.applyTransferAffected(nft);
+
     await this.processNft(nft);
 
     return nft;
+  }
+
+  private async applyTransferAffected(nft: Nft): Promise<void> {
+    try {
+      const result = await this.gatewayService.get(`node/old-storage-token/${nft.collection}/nonce/${nft.nonce}`, GatewayComponentRequest.oldStorageToken);
+      if (result?.isOldStorage) {
+        nft.isTransferAffected = true;
+      }
+    } catch (error) {
+      this.logger.error(`Unexpected error when fetching old storage token information for NFT with identifier '${nft.identifier}'`);
+      this.logger.error(error);
+    }
   }
 
   private async applyUnlockSchedule(nft: Nft): Promise<void> {

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1460,6 +1460,9 @@ type Nft {
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
 
+  """Returns true if the transfer is affected."""
+  isTransferAffected: Boolean
+
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!
 
@@ -1544,6 +1547,9 @@ type NftAccount {
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
 
+  """Returns true if the transfer is affected."""
+  isTransferAffected: Boolean
+
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!
 
@@ -1626,6 +1632,9 @@ type NftAccountFlat {
 
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
+
+  """Returns true if the transfer is affected."""
+  isTransferAffected: Boolean
 
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!


### PR DESCRIPTION
## Proposed Changes
- Set `isTransferAffected` boolean attribute on some NFT-related endpoints so that front-ends can temporarily react to it

## How to test (mainnet)
- `/nfts/CATSFAM-46c28f-0211` should return `isTransferAffected: true`
