### PR TITLE
Do not apply transfer affected on multiple nfts endpoint

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -444,8 +444,6 @@ export class NftService {
 
     for (const nft of nfts) {
       await this.applyUnlockSchedule(nft);
-
-      await this.applyTransferAffected(nft);
     }
 
     await this.pluginService.processNfts(nfts, queryOptions?.withScamInfo || queryOptions?.computeScamInfo);

--- a/src/test/integration/services/nft.e2e-spec.ts
+++ b/src/test/integration/services/nft.e2e-spec.ts
@@ -705,6 +705,17 @@ describe('Nft Service', () => {
       }
     });
 
+    it("should return a list of NonFungibleESDT based on a specific identifier for a specific address and isTransferAffected should not be defined", async () => {
+      const address: string = "erd1ar8gg37lu2reg5zpmtmqawqe65fzfsjd2v3p4m993xxjnu8azssq86f24k";
+      const filter = new NftFilter({ identifiers: ['CATSFAM-46c28f-0944'] });
+
+      const nfts = await nftService.getNftsForAddress(address, { from: 0, size: 1 }, filter);
+
+      for (const nft of nfts) {
+        expect(nft.isTransferAffected).not.toBeDefined();
+      }
+    });
+
     it("should return scam info for NFT", async () => {
       const identifier = 'LOTTERY-7cae2f-01';
 


### PR DESCRIPTION
## Proposed Changes
- Do not apply transfer affected on multiple nfts endpoint

## How to test
- `/accounts/:account/nfts` should not apply `isTransferAffected` attribute
