### PR TITLE
transaction filter allow sender receiver to be metachain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.69",
+        "@elrondnetwork/erdnest": "^0.1.70",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.69.tgz",
-      "integrity": "sha512-4V7bdB3QgrtGbCkMh+yXnB73mMMPuIC0S0Rc2JM2gd9RsXPzU155zaxsdV48w0P9PPTvAaOSiWLMfrSokfBSTg==",
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.70.tgz",
+      "integrity": "sha512-uDVo5xj8zo7D5PCaOKVTJ4ewlrnW1/SM7w2Uw5boRjrq/mh8Z4BVRep3a/qhMS3LN4m8B4DnsYFhJqAIR5BZuw==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17298,9 +17298,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.69",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.69.tgz",
-      "integrity": "sha512-4V7bdB3QgrtGbCkMh+yXnB73mMMPuIC0S0Rc2JM2gd9RsXPzU155zaxsdV48w0P9PPTvAaOSiWLMfrSokfBSTg==",
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.70.tgz",
+      "integrity": "sha512-uDVo5xj8zo7D5PCaOKVTJ4ewlrnW1/SM7w2Uw5boRjrq/mh8Z4BVRep3a/qhMS3LN4m8B4DnsYFhJqAIR5BZuw==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.66",
+        "@elrondnetwork/erdnest": "^0.1.69",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.66.tgz",
-      "integrity": "sha512-hhHEhNuZCSK/F8q+7msZdlaYrbPEsPv3XNo3Gahb3zMF+bIMlzZFxnkMlDHcyxDlzOYVqCE/tLam1QEjuJbfvw==",
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.69.tgz",
+      "integrity": "sha512-4V7bdB3QgrtGbCkMh+yXnB73mMMPuIC0S0Rc2JM2gd9RsXPzU155zaxsdV48w0P9PPTvAaOSiWLMfrSokfBSTg==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17298,9 +17298,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.66",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.66.tgz",
-      "integrity": "sha512-hhHEhNuZCSK/F8q+7msZdlaYrbPEsPv3XNo3Gahb3zMF+bIMlzZFxnkMlDHcyxDlzOYVqCE/tLam1QEjuJbfvw==",
+      "version": "0.1.69",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.69.tgz",
+      "integrity": "sha512-4V7bdB3QgrtGbCkMh+yXnB73mMMPuIC0S0Rc2JM2gd9RsXPzU155zaxsdV48w0P9PPTvAaOSiWLMfrSokfBSTg==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.66",
+    "@elrondnetwork/erdnest": "^0.1.69",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.69",
+    "@elrondnetwork/erdnest": "^0.1.70",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -1,5 +1,5 @@
-import { ApplyComplexity, ParseAddressArrayPipe, ParseArrayPipe, QueryConditionOptions } from '@elrondnetwork/erdnest';
-import { ParseAddressPipe, ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
+import { AddressAndMetachainValidationPipe, ApplyComplexity, ParseAddressArrayPipe, ParseArrayPipe, QueryConditionOptions } from '@elrondnetwork/erdnest';
+import { ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
 import { BadRequestException, Body, Controller, DefaultValuePipe, Get, NotFoundException, Param, Post, Query } from '@nestjs/common';
 import { ApiCreatedResponse, ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { QueryPagination } from 'src/common/entities/query.pagination';
@@ -46,7 +46,7 @@ export class TransactionController {
   getTransactions(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -105,7 +105,7 @@ export class TransactionController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   getTransactionCount(
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -139,7 +139,7 @@ export class TransactionController {
   @Get("/transactions/c")
   @ApiExcludeEndpoint()
   getTransactionCountAlternative(
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,

--- a/src/endpoints/transactions/transaction.controller.ts
+++ b/src/endpoints/transactions/transaction.controller.ts
@@ -1,4 +1,4 @@
-import { AddressAndMetachainValidationPipe, ApplyComplexity, ParseAddressArrayPipe, ParseArrayPipe, QueryConditionOptions } from '@elrondnetwork/erdnest';
+import { ParseAddressAndMetachainPipe, ApplyComplexity, ParseAddressArrayPipe, ParseArrayPipe, QueryConditionOptions } from '@elrondnetwork/erdnest';
 import { ParseBlockHashPipe, ParseBoolPipe, ParseEnumPipe, ParseIntPipe, ParseTransactionHashPipe } from '@elrondnetwork/erdnest';
 import { BadRequestException, Body, Controller, DefaultValuePipe, Get, NotFoundException, Param, Post, Query } from '@nestjs/common';
 import { ApiCreatedResponse, ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
@@ -46,7 +46,7 @@ export class TransactionController {
   getTransactions(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
+    @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -105,7 +105,7 @@ export class TransactionController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   getTransactionCount(
-    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
+    @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -139,7 +139,7 @@ export class TransactionController {
   @Get("/transactions/c")
   @ApiExcludeEndpoint()
   getTransactionCountAlternative(
-    @Query('sender', AddressAndMetachainValidationPipe) sender?: string,
+    @Query('sender', ParseAddressAndMetachainPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,

--- a/src/test/integration/controllers/transactions.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/transactions.controller.e2e-spec.ts
@@ -3,361 +3,67 @@ import { Test } from '@nestjs/testing';
 import { PublicAppModule } from 'src/public.app.module';
 import request = require('supertest');
 
-describe.skip("Transactions Controller", () => {
+describe("Transactions Controller", () => {
   let app: INestApplication;
-  const route: string = "/transactions";
+  const path: string = "/transactions";
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     const moduleRef = await Test.createTestingModule({
       imports: [PublicAppModule],
     }).compile();
 
     app = moduleRef.createNestApplication();
-
     await app.init();
   });
 
-  it("/transactions - should return 200 status code and one list of transaction", async () => {
-    await request(app.getHttpServer())
-      .get(route)
-      .expect(200);
-  });
-
-  it("/transactions?from&size - should return 200 status code and one list of 100 transaction", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '100',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&withLogs&withOperations&withScResults - should return 400 status code Bad Request. Request is limited to 50 if withScResults, withOperations, withLogs flags are active", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '100',
-      'withScResults': 'true',
-      'withOperations': 'true',
-      'withLogs': 'true',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(400);
-  });
-
-  it("/transactions?from&size&withScResults - should return 200 status code and transactions with smart contract results active", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'withScResults': 'true',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&withOperations - should return 200 status code and transactions withOperations active", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'withOperations': 'true',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&withLogs - should return 200 status code and transactions withLogs active", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'withLogs': 'true',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&condition - should return 200 status code and 50 transactions from elastic", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'condition': 'elastic',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&condition - should return 200 status code and 50 transactions from gateway", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'condition': 'gateway',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&asc - should return 200 status code and 50 transactions sorted ascending", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'order': 'asc',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&asc - should return 200 status code and 50 transactions sorted descending", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'order': 'desc',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&status - should return 200 status code and 50 success transactions", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'status': 'success',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&status - should return 200 status code and 50 pending transactions", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'status': 'pending',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&status - should return 200 status code and 50 fail transactions", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '50',
-      'status': 'fail',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&hashes - should return 200 status code and two transactions based on hashes filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '2',
-      'hashes': 'e21331bbc309d106d94d80e363b8b8fbf90bb6a3c2120cd6ef9b68dfd0b68703,16eb7a247ae7da0ea38fe632a7c61a92ff7358349cd7d78d32d4d2347244ede0',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&miniBlockHash - should return 200 status code and 1 transactions based on miniBlockHash filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '1',
-      'miniBlockHash': '9d2e05143f57bdcd005589514e25057393650a001ef5f25743cb8313b8fd001d,16eb7a247ae7da0ea38fe632a7c61a92ff7358349cd7d78d32d4d2347244ede0',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&receiverHash - should return 200 status code and 1 transactions based on receiverShard filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '1',
-      'receiverHash': '1',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&senderShard - should return 200 status code and 1 transactions based on senderShard filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '1',
-      'senderShard': '1',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&senderShard&receiverHash - should return 200 status code and 1 transactions based on senderShard and receiverShard filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '1',
-      'senderShard': '1',
-      'receiverHash': '1',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?from&size&token - should return 200 status code and one list of transactions based on token filter", async () => {
-    const params = new URLSearchParams({
-      'from': '0',
-      'size': '1',
-      'token': 'WEGLD-bd4d79',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?token - should return 200 status code and transactions count for a specific token ", async () => {
-    const params = new URLSearchParams({
-      'token': 'WEGLD-bd4d79',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?status - should return 200 status code and transactions count for transaction with status success ", async () => {
-    const params = new URLSearchParams({
-      'status': 'success',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?status - should return 200 status code and transactions count for transaction with status pending ", async () => {
-    const params = new URLSearchParams({
-      'status': 'pending',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?status - should return 200 status code and transactions count for transaction with status fail ", async () => {
-    const params = new URLSearchParams({
-      'status': 'fail',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?status - should return 200 status code and transactions count for two hashes ", async () => {
-    const params = new URLSearchParams({
-      'hashes': 'e21331bbc309d106d94d80e363b8b8fbf90bb6a3c2120cd6ef9b68dfd0b68703,16eb7a247ae7da0ea38fe632a7c61a92ff7358349cd7d78d32d4d2347244ede0',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions&status - should return 200 status code and transactions count for sender shard 0 ", async () => {
-    const params = new URLSearchParams({
-      'senderShard': '0',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?senderShard - should return 200 status code and transactions count for sender shard 1 ", async () => {
-    const params = new URLSearchParams({
-      'senderShard': '1',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?senderShard - should return 200 status code and transactions count for sender shard 2 ", async () => {
-    const params = new URLSearchParams({
-      'senderShard': '2',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?senderShard&receiverShard - should return 200 status code and transactions count for sender shard 0 and receiver shard 0 ", async () => {
-    const params = new URLSearchParams({
-      'senderShard': '0',
-      'receiverShard': '0',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions?token - should return 200 status code and transactions count for a specific token ", async () => {
-    const params = new URLSearchParams({
-      'token': 'WEGLD-bd4d79',
-    });
-
-    await request(app.getHttpServer())
-      .get(route + "/count?" + params)
-      .expect(200);
-  });
-
-  it("/transactions/:txHash - should return 200 status code and transaction details for a specific txHash ", async () => {
-    const txHash: string = "0b1f62e44f4657182be6f6c263dbdeb0bf6d5efd603fe879027e9df2dec2192b";
-
-    await request(app.getHttpServer())
-      .get(route + "/" + txHash)
-      .expect(200);
-  });
-
-  it("/transactions/:txHash - should return 404 status code Error: Not Found ", async () => {
-    const txHash: string = "0b1f62e44f4657182be6f6c263dbdeb0bf6d5efd603fe879027e9df2dec2192bT";
-
-    await request(app.getHttpServer())
-      .get(route + "/" + txHash)
-      .expect(404)
-      .then(res => {
-        expect(res.body.message).toEqual("Transaction not found");
+  [
+    {
+      filter: 'sender',
+      value: '4294967295',
+    },
+    {
+      filter: 'sender',
+      value: 'erd1576w79rz7zq8jv5nuzrnntghrxjnzapjppcv6u7pya257gk9x9eq59qrhu',
+    },
+  ].forEach(({ filter, value }) => {
+    describe(`when filter ${filter} is applied`, () => {
+      it(`should return transaction sender with value ${value}`, async () => {
+        await request(app.getHttpServer())
+          .get(`${path}?${filter}=${value}`)
+          .expect(200)
+          .then(res => {
+            expect(res.body).toBeDefined();
+            expect(res.body[0].sender).toStrictEqual(value);
+          });
       });
+    });
+  });
+
+  [
+    {
+      filter: 'sender',
+      value: '4294967295',
+      count: 12900,
+    },
+    {
+      filter: 'sender',
+      value: 'erd1576w79rz7zq8jv5nuzrnntghrxjnzapjppcv6u7pya257gk9x9eq59qrhu',
+      count: 189,
+    },
+  ].forEach(({ filter, value, count }) => {
+    describe(`when filter ${filter} is applied`, () => {
+      it(`should return total number of transactions of sender ${value}`, async () => {
+        await request(app.getHttpServer())
+          .get(`${path}/count?${filter}=${value}`)
+          .expect(200)
+          .then(res => {
+            expect(+res.text).toBeGreaterThanOrEqual(count);
+          });
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 });


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- Transactions sender filter wasn't able to retrieve transactions from metachain 
  
## Proposed Changes
- Add new validation pipe to sender filter

## How to test
-  transactions/count?sender=4294967295 -> should return all transactions where sender is 4294967295 ( metachain )

-  transactions?sender=erd1a5q433u4a55qdfjkkslw9fa7h4pyvgn0t5zquws59t82tww2gnrsk5dern -> should return all transactions where sender is erd1a5q433u4a55qdfjkkslw9fa7h4pyvgn0t5zquws59t82tww2gnrsk5dern

- transactions/count?sender=4294967295 -> should return total transactions count for sender 4294967295 (metachain)

- transactions/c?sender=4294967295 -> should return total transactions count for sender 4294967295 (metachain)

- transactions?from=0&size=10000&receiver=erd1uuqwdgg66phtutjzfktcy0muhcaqselvnl4fpgtg6429t8d6hh5quzmjus&sender=4294967295
