### PR TITLE
Collection NFTs trait filter

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -1,4 +1,4 @@
-import { AbstractQuery, AddressUtils, ElasticQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan } from "@elrondnetwork/erdnest";
+import { AbstractQuery, AddressUtils, BinaryUtils, ElasticQuery, QueryConditionOptions, QueryOperator, QueryType, RangeGreaterThanOrEqual, RangeLowerThan } from "@elrondnetwork/erdnest";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
@@ -174,7 +174,7 @@ export class ElasticIndexerHelper {
 
     if (filter.traits !== undefined) {
       for (const [key, value] of Object.entries(filter.traits)) {
-        elasticQuery = elasticQuery.withMustMatchCondition('nft_traitValues', `${key}_${value}`);
+        elasticQuery = elasticQuery.withMustMatchCondition('nft_traitValues', BinaryUtils.base64Encode(`${key}_${value}`));
       }
     }
 

--- a/src/common/indexer/entities/collection.trait.summary.attribute.ts
+++ b/src/common/indexer/entities/collection.trait.summary.attribute.ts
@@ -1,0 +1,5 @@
+export class CollectionTraitSummaryAttribute {
+  name: string = '';
+  occurrenceCount: number = 0;
+  occurrencePercentage: number = 0;
+}

--- a/src/common/indexer/entities/collection.trait.summary.ts
+++ b/src/common/indexer/entities/collection.trait.summary.ts
@@ -1,0 +1,8 @@
+import { CollectionTraitSummaryAttribute } from "./collection.trait.summary.attribute";
+
+export class CollectionTraitSummary {
+  name: string = '';
+  occurrenceCount: number = 0;
+  occurrencePercenta: number = 0;
+  attributes: CollectionTraitSummaryAttribute[] = [];
+}

--- a/src/common/indexer/entities/collection.trait.summary.ts
+++ b/src/common/indexer/entities/collection.trait.summary.ts
@@ -3,6 +3,6 @@ import { CollectionTraitSummaryAttribute } from "./collection.trait.summary.attr
 export class CollectionTraitSummary {
   name: string = '';
   occurrenceCount: number = 0;
-  occurrencePercenta: number = 0;
+  occurrencePercentage: number = 0;
   attributes: CollectionTraitSummaryAttribute[] = [];
 }

--- a/src/common/indexer/entities/collection.ts
+++ b/src/common/indexer/entities/collection.ts
@@ -1,3 +1,5 @@
+import { CollectionTraitSummary } from "./collection.trait.summary";
+
 export interface Collection {
   name: string;
   ticker: string;
@@ -7,4 +9,5 @@ export interface Collection {
   type: string;
   timestamp: number;
   ownersHistory: { address: string, timestamp: number }[];
+  nft_traitSummary?: CollectionTraitSummary[];
 }

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -7,7 +7,7 @@ import { Nft } from "../nfts/entities/nft";
 import { NftService } from "../nfts/nft.service";
 import { NftFilter } from "../nfts/entities/nft.filter";
 import { NftQueryOptions } from "../nfts/entities/nft.query.options";
-import { ParseAddressPipe, ParseArrayPipe, ParseCollectionPipe, ParseBoolPipe, ParseEnumArrayPipe, ParseIntPipe, ApplyComplexity, ParseAddressArrayPipe, ParseBlockHashPipe, ParseEnumPipe } from '@elrondnetwork/erdnest';
+import { ParseAddressPipe, ParseArrayPipe, ParseCollectionPipe, ParseBoolPipe, ParseEnumArrayPipe, ParseIntPipe, ApplyComplexity, ParseAddressArrayPipe, ParseBlockHashPipe, ParseEnumPipe, ParseRecordPipe } from '@elrondnetwork/erdnest';
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { CollectionFilter } from "./entities/collection.filter";
 import { CollectionAccount } from "./entities/collection.account";
@@ -175,6 +175,7 @@ export class CollectionController {
   @ApiQuery({ name: 'creator', description: 'Return all NFTs associated with a given creator', required: false })
   @ApiQuery({ name: 'isWhitelistedStorage', description: 'Return all NFTs that are whitelisted in storage', required: false, type: Boolean })
   @ApiQuery({ name: 'hasUris', description: 'Return all NFTs that have one or more uris', required: false, type: Boolean })
+  @ApiQuery({ name: 'traits', description: 'Filter NFTs by traits. Key-value format (<key1>:<value1>;<key2>:<value2>)', required: false, type: Boolean })
   @ApiQuery({ name: 'withOwner', description: 'Return owner where type = NonFungibleESDT', required: false, type: Boolean })
   @ApiQuery({ name: 'withSupply', description: 'Return supply where type = SemiFungibleESDT', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', required: false, type: Boolean })
@@ -190,6 +191,7 @@ export class CollectionController {
     @Query('creator', ParseAddressPipe) creator?: string,
     @Query('isWhitelistedStorage', new ParseBoolPipe) isWhitelistedStorage?: boolean,
     @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
+    @Query('traits', new ParseRecordPipe) traits?: Record<string, string>,
     @Query('withOwner', new ParseBoolPipe) withOwner?: boolean,
     @Query('withSupply', new ParseBoolPipe) withSupply?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
@@ -204,7 +206,7 @@ export class CollectionController {
 
     return await this.nftService.getNfts(
       new QueryPagination({ from, size }),
-      new NftFilter({ search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage }),
+      new NftFilter({ search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage, traits }),
       options);
   }
 
@@ -219,6 +221,7 @@ export class CollectionController {
   @ApiQuery({ name: 'creator', description: 'Return all NFTs associated with a given creator', required: false })
   @ApiQuery({ name: 'isWhitelistedStorage', description: 'Return all NFTs that are whitelisted in storage', required: false, type: Boolean })
   @ApiQuery({ name: 'hasUris', description: 'Return all NFTs that have one or more uris', required: false, type: Boolean })
+  @ApiQuery({ name: 'traits', description: 'Filter NFTs by traits. Key-value format (<key1>:<value1>;<key2>:<value2>)', required: false, type: Boolean })
   async getNftCount(
     @Param('collection', ParseCollectionPipe) collection: string,
     @Query('search') search?: string,
@@ -228,13 +231,14 @@ export class CollectionController {
     @Query('creator', ParseAddressPipe) creator?: string,
     @Query('isWhitelistedStorage', new ParseBoolPipe) isWhitelistedStorage?: boolean,
     @Query('hasUris', new ParseBoolPipe) hasUris?: boolean,
+    @Query('traits', new ParseRecordPipe) traits?: Record<string, string>,
   ): Promise<number> {
     const isCollection = await this.collectionService.isCollection(collection);
     if (!isCollection) {
       throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
     }
 
-    return await this.nftService.getNftCount(new NftFilter({ search, identifiers, collection, name, tags, creator, isWhitelistedStorage, hasUris }));
+    return await this.nftService.getNftCount(new NftFilter({ search, identifiers, collection, name, tags, creator, isWhitelistedStorage, hasUris, traits }));
   }
 
   @Get('/collections/:identifier/accounts')

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -161,6 +161,7 @@ export class CollectionService {
     collection.type = elasticCollection.type as NftType;
     collection.timestamp = elasticCollection.timestamp;
     collection.roles = await this.getNftCollectionRoles(elasticCollection);
+    collection.traits = elasticCollection.nft_traitSummary ?? [];
 
     return collection;
   }

--- a/src/endpoints/collections/entities/collection.trait.attribute.ts
+++ b/src/endpoints/collections/entities/collection.trait.attribute.ts
@@ -1,5 +1,17 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+
+@ObjectType("CollectionTraitAttribute", { description: "NFT collection trait attribute type." })
 export class CollectionTraitAttribute {
+  @Field(() => String, { description: 'Name of the attribute.', nullable: true })
+  @ApiProperty({ type: String })
   name: string = '';
+
+  @Field(() => Number, { description: 'Number of times the attribute appears in the nft list.' })
+  @ApiProperty({ type: Number })
   occurrenceCount: number = 0;
+
+  @Field(() => Number, { description: 'Percentage for the occurrence of the attribute in the nft list.' })
+  @ApiProperty({ type: Number })
   occurrencePercentage: number = 0;
 }

--- a/src/endpoints/collections/entities/collection.trait.attribute.ts
+++ b/src/endpoints/collections/entities/collection.trait.attribute.ts
@@ -1,0 +1,5 @@
+export class CollectionTraitAttribute {
+  name: string = '';
+  occurrenceCount: number = 0;
+  occurrencePercentage: number = 0;
+}

--- a/src/endpoints/collections/entities/collection.trait.ts
+++ b/src/endpoints/collections/entities/collection.trait.ts
@@ -1,0 +1,8 @@
+import { CollectionTraitAttribute } from "./collection.trait.attribute";
+
+export class CollectionTrait {
+  name: string = '';
+  occurrenceCount: number = 0;
+  occurrencePercenta: number = 0;
+  attributes: CollectionTraitAttribute[] = [];
+}

--- a/src/endpoints/collections/entities/collection.trait.ts
+++ b/src/endpoints/collections/entities/collection.trait.ts
@@ -1,8 +1,22 @@
+import { Field, ObjectType } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
 import { CollectionTraitAttribute } from "./collection.trait.attribute";
 
+@ObjectType("CollectionTrait", { description: "NFT collection trait type." })
 export class CollectionTrait {
+  @Field(() => String, { description: 'Name of the trait.' })
+  @ApiProperty({ type: String })
   name: string = '';
+
+  @Field(() => Number, { description: 'Number of times the trait appears in the nft list.' })
+  @ApiProperty({ type: Number })
   occurrenceCount: number = 0;
-  occurrencePercenta: number = 0;
+
+  @Field(() => Number, { description: 'Percentage for the occurrence of the trait in the nft list.' })
+  @ApiProperty({ type: Number })
+  occurrencePercentage: number = 0;
+
+  @Field(() => [CollectionTraitAttribute], { description: 'Distinct attributes for the given trait.' })
+  @ApiProperty({ type: CollectionTraitAttribute, isArray: true })
   attributes: CollectionTraitAttribute[] = [];
 }

--- a/src/endpoints/collections/entities/nft.collection.ts
+++ b/src/endpoints/collections/entities/nft.collection.ts
@@ -4,6 +4,7 @@ import { NftType } from "../../nfts/entities/nft.type";
 import { CollectionRoles } from "src/endpoints/tokens/entities/collection.roles";
 import { Field, Float, ID, ObjectType } from "@nestjs/graphql";
 import { Account } from "src/endpoints/accounts/entities/account";
+import { CollectionTrait } from "./collection.trait";
 
 @ObjectType("NftCollection", { description: "NFT collection object type." })
 export class NftCollection {
@@ -60,6 +61,10 @@ export class NftCollection {
   assets: TokenAssets | undefined = undefined;
 
   @Field(() => [CollectionRoles], { description: 'Roles list for the given NFT collection.', nullable: true })
-  @ApiProperty({ type: CollectionRoles })
+  @ApiProperty({ type: CollectionRoles, isArray: true })
   roles: CollectionRoles[] = [];
+
+  @Field(() => [CollectionTrait], { description: 'Trait list for the given NFT collection.', nullable: true })
+  @ApiProperty({ type: CollectionTrait, isArray: true })
+  traits: CollectionTrait[] = [];
 }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -281,6 +281,33 @@ type CollectionRoles {
   roles: [String!]!
 }
 
+"""NFT collection trait type."""
+type CollectionTrait {
+  """Distinct attributes for the given trait."""
+  attributes: [CollectionTraitAttribute!]!
+
+  """Name of the trait."""
+  name: String!
+
+  """Number of times the trait appears in the nft list."""
+  occurrenceCount: Float!
+
+  """Percentage for the occurrence of the trait in the nft list."""
+  occurrencePercentage: Float!
+}
+
+"""NFT collection trait attribute type."""
+type CollectionTraitAttribute {
+  """Name of the attribute."""
+  name: String
+
+  """Number of times the attribute appears in the nft list."""
+  occurrenceCount: Float!
+
+  """Percentage for the occurrence of the attribute in the nft list."""
+  occurrencePercentage: Float!
+}
+
 """DappConfig object type."""
 type DappConfig {
   """Api url details"""
@@ -1735,6 +1762,9 @@ type NftCollection {
   """Timestamp for the given NFT collection."""
   timestamp: Float!
 
+  """Trait list for the given NFT collection."""
+  traits: [CollectionTrait!]
+
   """NFT type for the given NFT collection."""
   type: NftType!
 }
@@ -1780,6 +1810,9 @@ type NftCollectionAccount {
   """Timestamp for the given NFT collection."""
   timestamp: Float!
 
+  """Trait list for the given NFT collection."""
+  traits: [CollectionTrait!]
+
   """NFT type for the given NFT collection."""
   type: NftType!
 }
@@ -1820,6 +1853,9 @@ type NftCollectionAccountFlat {
 
   """Timestamp for the given NFT collection."""
   timestamp: Float!
+
+  """Trait list for the given NFT collection."""
+  traits: [CollectionTrait!]
 
   """NFT type for the given NFT collection."""
   type: NftType!

--- a/src/test/integration/controllers/collections.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/collections.controller.e2e-spec.ts
@@ -59,6 +59,7 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             roles: [],
+            traits: [],
           }];
 
       await request(app.getHttpServer())
@@ -88,6 +89,7 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             roles: [],
+            traits: [],
           },
           {
             collection: "EROBOT-527a29",
@@ -101,6 +103,7 @@ describe("collections Controller", () => {
             canPause: false,
             canTransferNftCreateRole: false,
             roles: [],
+            traits: [],
           },
         ];
 
@@ -267,6 +270,7 @@ describe("collections Controller", () => {
             ],
           },
         ],
+        traits: [],
       };
 
       await request(app.getHttpServer())


### PR DESCRIPTION
## Proposed Changes
- Filter collection NFTs by trait as well
- use base64 encoding for values to be searched

## How to test (devnet)
- `/collections/MAFIA-7c0abf/nfts?traits=Backgrounds:Green%20Bills;Clothes:Prisoneer%20Shirt` should return 2 NFTs
- `/collections/MAFIA-7c0abf/nfts/count?traits=Backgrounds:Green%20Bills;Clothes:Prisoneer%20Shirt` should return `2`