### PR TITLE
Nft media processing improvements

### DIFF
--- a/src/endpoints/nfts/entities/media.mime.type.ts
+++ b/src/endpoints/nfts/entities/media.mime.type.ts
@@ -4,6 +4,8 @@ export enum MediaMimeTypeEnum {
   webp = 'image/webp',
   jpg = 'image/jpg',
   gif = 'image/gif',
+  svg = 'image/svg',
+  svgXml = 'image/svg+xml',
 
   aac = 'audio/aac',
   flac = 'audio/flac',

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -53,9 +53,9 @@ export class NftService {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
     this.DEFAULT_MEDIA = [
       {
-        url: 'https://media.elrond.com/nfts/thumbnail/default.png',
-        originalUrl: 'https://media.elrond.com/nfts/thumbnail/default.png',
-        thumbnailUrl: 'https://media.elrond.com/nfts/thumbnail/default.png',
+        url: NftMediaService.NFT_THUMBNAIL_DEFAULT,
+        originalUrl: NftMediaService.NFT_THUMBNAIL_DEFAULT,
+        thumbnailUrl: NftMediaService.NFT_THUMBNAIL_DEFAULT,
         fileType: 'image/png',
         fileSize: 29512,
       },

--- a/src/queue.worker/nft.worker/queue/job-services/media/entities/is.content.accepted.result.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/entities/is.content.accepted.result.ts
@@ -1,0 +1,5 @@
+export enum IsContentAcceptedResult {
+  accepted = 'accepted',
+  invalidContentType = 'invalidContentType',
+  invalidFileSize = 'invalidFileSize',
+}

--- a/src/queue.worker/nft.worker/queue/job-services/media/entities/is.content.accepted.result.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/entities/is.content.accepted.result.ts
@@ -1,5 +1,0 @@
-export enum IsContentAcceptedResult {
-  accepted = 'accepted',
-  invalidContentType = 'invalidContentType',
-  invalidFileSize = 'invalidFileSize',
-}

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -101,7 +101,9 @@ export class NftQueueController {
       }
 
       if (nft.media && !settings.skipRefreshThumbnail) {
-        await Promise.all(nft.media.map((media: any) => this.generateThumbnail(nft, media, settings.forceRefreshThumbnail)));
+        const mediaItems = nft.media.filter(x => x.thumbnailUrl !== NftMediaService.NFT_THUMBNAIL_DEFAULT);
+
+        await Promise.all(mediaItems.map(media => this.generateThumbnail(nft, media, settings.forceRefreshThumbnail)));
       }
 
       this.logger.log({ type: 'consumer end', identifier: data.identifier });

--- a/src/test/integration/services/nft.media.e2e-spec.ts
+++ b/src/test/integration/services/nft.media.e2e-spec.ts
@@ -60,7 +60,8 @@ describe('Nft Media Service', () => {
 
       const mediaRaw = await nftMediaService.refreshMedia(nft);
 
-      expect(mediaRaw?.length).toStrictEqual(0);
+      expect(mediaRaw?.length).toStrictEqual(1);
+      expect(mediaRaw?.at(0)?.thumbnailUrl).toStrictEqual(NftMediaService.NFT_THUMBNAIL_DEFAULT);
     });
 
     it('should not accept content (media mime type is not accepted)', async () => {


### PR DESCRIPTION
## Proposed Changes
- if content size exceeded, still generate media entries
- add support for `image/svg` & `image/svg+xml` content types

## How to test
- triggering nft media refresh for `TOERMALIJN-b9b9bc-01` should create media entries & default thumbnail
- triggering nft media refresh for `SFTFAN-0e36bc-01` should create media entries because it should now support content type `image/svg+xml`
