### PR TITLE
add transfers query

### DIFF
--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -110,7 +110,7 @@ export class Transaction {
   @ApiProperty({ enum: TransactionType, nullable: true })
   type: TransactionType | undefined = undefined;
 
-  @Field(() => String, { description: "Original tx hasg for the given transaction.", nullable: true })
+  @Field(() => String, { description: "Original tx hash for the given transaction.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   originalTxHash: string | undefined = undefined;
 

--- a/src/endpoints/transactions/entities/transaction.ts
+++ b/src/endpoints/transactions/entities/transaction.ts
@@ -43,9 +43,11 @@ export class Transaction {
   @Field(() => Account, { description: "Receiver account for the given transaction." })
   receiverAccount: Account | undefined = undefined;
 
+  @Field(() => AccountAssets, { name: "receiverAssets", description: "Receiver assets for the given transaction." })
   @ApiProperty({ type: AccountAssets, nullable: true })
   receiverAssets: AccountAssets | undefined = undefined;
 
+  @Field(() => String, { name: "receiverShard", description: "Receiver account shard for the given transaction." })
   @ApiProperty({ type: Number })
   receiverShard: number = 0;
 
@@ -60,9 +62,11 @@ export class Transaction {
   @Field(() => Account, { description: "Sender account for the given transaction." })
   senderAccount: Account | undefined = undefined;
 
+  @Field(() => AccountAssets, { name: "senderAssets", description: "Sender assets for the given transaction." })
   @ApiProperty({ type: AccountAssets, nullable: true })
   senderAssets: AccountAssets | undefined = undefined;
 
+  @Field(() => Float, { name: "senderShard", description: "Sender account shard for the given transaction." })
   @ApiProperty({ type: Number })
   senderShard: number = 0;
 
@@ -102,9 +106,11 @@ export class Transaction {
   @ApiProperty({ type: ScamInfo, nullable: true })
   scamInfo: ScamInfo | undefined = undefined;
 
+  @Field(() => TransactionType, { description: "Transaction type.", nullable: true })
   @ApiProperty({ enum: TransactionType, nullable: true })
   type: TransactionType | undefined = undefined;
 
+  @Field(() => String, { description: "Original tx hasg for the given transaction.", nullable: true })
   @ApiProperty({ type: String, nullable: true })
   originalTxHash: string | undefined = undefined;
 

--- a/src/endpoints/transactions/entities/transaction.type.ts
+++ b/src/endpoints/transactions/entities/transaction.type.ts
@@ -1,4 +1,20 @@
+import { registerEnumType } from "@nestjs/graphql";
+
 export enum TransactionType {
   Transaction = 'Transaction',
   SmartContractResult = 'SmartContractResult'
 }
+
+registerEnumType(TransactionType, {
+  name: 'TransactionType',
+  description: 'Transaction type object type.',
+  valuesMap: {
+    Transaction: {
+      description: 'Transaction type.',
+    },
+    SmartContractResult: {
+      description: 'SmartContractResult type.',
+    },
+
+  },
+});

--- a/src/graphql/entities/graphql.services.module.ts
+++ b/src/graphql/entities/graphql.services.module.ts
@@ -24,6 +24,7 @@ import { StakeModule } from "src/graphql/entities/stake/stake.module";
 import { MexModule } from "src/graphql/entities/maiar.exchange/mex.token.module";
 import { TokenModule } from "src/graphql/entities/tokens/tokens.module";
 import { WebsocketModule } from "src/graphql/entities/web.socket/web.socket.module";
+import { TransferModule } from "src/graphql/entities/transfers/transfers.module";
 
 
 @Module({
@@ -53,12 +54,13 @@ import { WebsocketModule } from "src/graphql/entities/web.socket/web.socket.modu
     MexModule,
     TokenModule,
     WebsocketModule,
+    TransferModule,
   ],
   exports: [
     AccountDetailedModule, AccountModule, NftModule, NftCollectionModule, SmartContractResultModule, TransactionDetailedModule,
     TransactionModule, TagModule, DelegationModule, DappConfigModule, WaitingListModule, UsernameModule, BlockModule,
     MiniBlockModule, NetworkModule, ShardModule, DelegationLegacyModule, IdentitiesModule, NodeModule, RoundModule, ProviderModule,
-    StakeModule, MexModule, TokenModule, WebsocketModule,
+    StakeModule, MexModule, TokenModule, WebsocketModule, TransferModule,
   ],
 })
 export class GraphQLServicesModule { }

--- a/src/graphql/entities/transfers/transfers.input.ts
+++ b/src/graphql/entities/transfers/transfers.input.ts
@@ -3,7 +3,7 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
 import { TransactionStatus } from "src/endpoints/transactions/entities/transaction.status";
 
-@InputType({ description: "Input to retreive the given transfers count for." })
+@InputType({ description: "Input to retrieve the given transfers count for." })
 export class GetTransfersCountInput {
   constructor(partial?: Partial<GetTransfersCountInput>) {
     Object.assign(this, partial);

--- a/src/graphql/entities/transfers/transfers.input.ts
+++ b/src/graphql/entities/transfers/transfers.input.ts
@@ -1,0 +1,77 @@
+import { Field, Float, InputType } from "@nestjs/graphql";
+import { SortOrder } from "src/common/entities/sort.order";
+import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
+import { TransactionStatus } from "src/endpoints/transactions/entities/transaction.status";
+
+@InputType({ description: "Input to retreive the given transfers count for." })
+export class GetTransfersCountInput {
+  constructor(partial?: Partial<GetTransfersCountInput>) {
+    Object.assign(this, partial);
+  }
+
+  @Field(() => String, { name: "sender", description: "Sender for the given result set.", nullable: true })
+  sender: string | undefined = undefined;
+
+  @Field(() => String, { name: "receiver", description: "Receiver for the given result set.", nullable: true })
+  receiver: string | undefined = undefined;
+
+  @Field(() => String, { name: "token", description: "Token identfier for the given result set.", nullable: true })
+  token: string | undefined = undefined;
+
+  @Field(() => Float, { name: "senderShard", description: "Sender shard for the given result set.", nullable: true })
+  senderShard: number | undefined = undefined;
+
+  @Field(() => Float, { name: "receiverShard", description: "Receiver shard for the given result set.", nullable: true })
+  receiverShard: number | undefined = undefined;
+
+  @Field(() => String, { name: "miniBlockHash", description: "Mini block hash for the given result set.", nullable: true })
+  miniBlockHash: string | undefined = undefined;
+
+  @Field(() => [String], { name: "hashes", description: "Filter by a comma-separated list of transaction hashes for the given result set.", nullable: true })
+  hashes: Array<string> | undefined = undefined;
+
+  @Field(() => TransactionStatus, { name: "status", description: "Status of the transaction for the given result set.", nullable: true })
+  status: TransactionStatus | undefined = undefined;
+
+  @Field(() => String, { name: "search", description: "Search in data object for the given result set.", nullable: true })
+  search: string | undefined = undefined;
+
+  @Field(() => Float, { name: "before", description: "Before timestamp for the given result set.", nullable: true })
+  before: number | undefined = undefined;
+
+  @Field(() => Float, { name: "after", description: "After timestamp for the given result set.", nullable: true })
+  after: number | undefined = undefined;
+
+  @Field(() => SortOrder, { name: "order", description: "SortOrder data transfers for the given result set.", nullable: true })
+  order: SortOrder | undefined = undefined;
+
+  public static resolve(input: GetTransfersCountInput): TransactionFilter {
+    return new TransactionFilter({
+      sender: input.sender,
+      receivers: input.receiver ? [input.receiver] : [],
+      token: input.token,
+      senderShard: input.senderShard,
+      receiverShard: input.receiverShard,
+      miniBlockHash: input.miniBlockHash,
+      hashes: input.hashes,
+      status: input.status,
+      search: input.search,
+      before: input.before,
+      after: input.after,
+      order: input.order,
+    });
+  }
+}
+@InputType({ description: "Input to retrieve the given transfers for." })
+export class GetTransfersInput extends GetTransfersCountInput {
+  constructor(partial?: Partial<GetTransfersInput>) {
+    super();
+    Object.assign(this, partial);
+  }
+
+  @Field(() => Float, { name: "from", description: "Number of transfers to skip for the given result set.", nullable: true, defaultValue: 0 })
+  from: number = 0;
+
+  @Field(() => Float, { name: "size", description: "Number of transfers to retrieve for the given result set.", nullable: true, defaultValue: 25 })
+  size: number = 25;
+}

--- a/src/graphql/entities/transfers/transfers.module.ts
+++ b/src/graphql/entities/transfers/transfers.module.ts
@@ -1,0 +1,9 @@
+import { Module } from "@nestjs/common";
+import { TransferModule as InternalTransferModule } from "src/endpoints/transfers/transfer.module";
+import { TransferResolver } from "./transfers.resolver";
+
+@Module({
+  imports: [InternalTransferModule],
+  providers: [TransferResolver],
+})
+export class TransferModule { }

--- a/src/graphql/entities/transfers/transfers.query.ts
+++ b/src/graphql/entities/transfers/transfers.query.ts
@@ -1,0 +1,45 @@
+import { HttpException, HttpStatus } from "@nestjs/common";
+import { Args, Float, Query, Resolver } from "@nestjs/graphql";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { QueryPagination } from "src/common/entities/query.pagination";
+import { Transaction } from "src/endpoints/transactions/entities/transaction";
+import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
+import { TransferService } from "src/endpoints/transfers/transfer.service";
+import { GetTransfersCountInput, GetTransfersInput } from "./transfers.input";
+
+@Resolver()
+export class TransferQuery {
+  constructor(
+    protected readonly transferService: TransferService,
+    protected readonly apiConfigService: ApiConfigService) { }
+
+  @Query(() => [Transaction], { name: "transfers", description: "Retrieve all transfers for the given input." })
+  public async getTransfers(@Args("input", { description: "Input to retreive the given transfers for." }) input: GetTransfersInput): Promise<Transaction[]> {
+    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
+      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
+    }
+    return await this.transferService.getTransfers(
+      new TransactionFilter({
+        sender: input.sender,
+        token: input.token,
+        senderShard: input.senderShard,
+        receiverShard: input.receiverShard,
+        miniBlockHash: input.miniBlockHash,
+        hashes: input.hashes,
+        status: input.status,
+        search: input.search,
+        before: input.before,
+        after: input.after,
+      }), new QueryPagination({ from: input.from, size: input.size })
+    );
+  }
+
+  @Query(() => Float, { name: "transfersCount", description: "Retrieve all transfers count for the given input." })
+  public async getTransfersCount(@Args("input", { description: "Input to retrieve the given transfers count for." }) input: GetTransfersCountInput): Promise<number> {
+    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
+      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    return await this.transferService.getTransfersCount(GetTransfersCountInput.resolve(input));
+  }
+}

--- a/src/graphql/entities/transfers/transfers.resolver.ts
+++ b/src/graphql/entities/transfers/transfers.resolver.ts
@@ -1,0 +1,13 @@
+import { Resolver } from "@nestjs/graphql";
+import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { Transaction } from "src/endpoints/transactions/entities/transaction";
+import { TransferService } from "src/endpoints/transfers/transfer.service";
+import { TransferQuery } from "./transfers.query";
+
+@Resolver(() => Transaction)
+export class TransferResolver extends TransferQuery {
+  constructor(transferService: TransferService,
+    apiConfigService: ApiConfigService) {
+    super(transferService, apiConfigService);
+  }
+}

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1159,6 +1159,94 @@ input GetTransactionsInput {
   token: String
 }
 
+"""Input to retreive the given transfers count for."""
+input GetTransfersCountInput {
+  """After timestamp for the given result set."""
+  after: Float
+
+  """Before timestamp for the given result set."""
+  before: Float
+
+  """
+  Filter by a comma-separated list of transaction hashes for the given result set.
+  """
+  hashes: [String!]
+
+  """Mini block hash for the given result set."""
+  miniBlockHash: String
+
+  """SortOrder data transfers for the given result set."""
+  order: SortOrder
+
+  """Receiver for the given result set."""
+  receiver: String
+
+  """Receiver shard for the given result set."""
+  receiverShard: Float
+
+  """Search in data object for the given result set."""
+  search: String
+
+  """Sender for the given result set."""
+  sender: String
+
+  """Sender shard for the given result set."""
+  senderShard: Float
+
+  """Status of the transaction for the given result set."""
+  status: TransactionStatus
+
+  """Token identfier for the given result set."""
+  token: String
+}
+
+"""Input to retrieve the given transfers for."""
+input GetTransfersInput {
+  """After timestamp for the given result set."""
+  after: Float
+
+  """Before timestamp for the given result set."""
+  before: Float
+
+  """Number of transfers to skip for the given result set."""
+  from: Float = 0
+
+  """
+  Filter by a comma-separated list of transaction hashes for the given result set.
+  """
+  hashes: [String!]
+
+  """Mini block hash for the given result set."""
+  miniBlockHash: String
+
+  """SortOrder data transfers for the given result set."""
+  order: SortOrder
+
+  """Receiver for the given result set."""
+  receiver: String
+
+  """Receiver shard for the given result set."""
+  receiverShard: Float
+
+  """Search in data object for the given result set."""
+  search: String
+
+  """Sender for the given result set."""
+  sender: String
+
+  """Sender shard for the given result set."""
+  senderShard: Float
+
+  """Number of transfers to retrieve for the given result set."""
+  size: Float = 25
+
+  """Status of the transaction for the given result set."""
+  status: TransactionStatus
+
+  """Token identfier for the given result set."""
+  token: String
+}
+
 """Input to retrieve the given account details for."""
 input GetUsernameInput {
   """Herotag"""
@@ -2418,6 +2506,18 @@ type Query {
     input: GetTransactionsCountInput!
   ): Float!
 
+  """Retrieve all transfers for the given input."""
+  transfers(
+    """Input to retreive the given transfers for."""
+    input: GetTransfersInput!
+  ): [Transaction!]!
+
+  """Retrieve all transfers count for the given input."""
+  transfersCount(
+    """Input to retrieve the given transfers count for."""
+    input: GetTransfersCountInput!
+  ): Float!
+
   """Retrive account detailed for a given herotag"""
   username(
     """Input to retrieve the given detailed account for."""
@@ -2789,6 +2889,90 @@ enum TokenType {
   SemiFungibleESDT
 }
 
+"""Transaction object type."""
+type Transaction {
+  """Transaction action for the given transaction."""
+  action: TransactionAction
+
+  """Data for the given transaction."""
+  data: String
+
+  """Fee for the given transaction."""
+  fee: String
+
+  """Function for the given transaction."""
+  function: String
+
+  """Gas limit for the given transaction."""
+  gasLimit: Float
+
+  """Gas price for the given transaction."""
+  gasPrice: Float
+
+  """Gas used for the given transaction."""
+  gasUsed: Float
+
+  """Mini block hash for the given transaction."""
+  miniBlockHash: String
+
+  """Nonce for the given transaction."""
+  nonce: Float
+
+  """Original tx hasg for the given transaction."""
+  originalTxHash: String
+
+  """Pending results for the given transaction."""
+  pendingResults: Boolean
+
+  """Receiver account for the given transaction."""
+  receiverAccount: Account!
+
+  """Receiver account for the given transaction."""
+  receiverAddress: String!
+
+  """Receiver assets for the given transaction."""
+  receiverAssets: AccountAssets!
+
+  """Receiver account shard for the given transaction."""
+  receiverShard: String!
+
+  """Round for the given transaction."""
+  round: Float
+
+  """Scam information for the given transaction."""
+  scamInfo: ScamInformation
+
+  """Sender account for the given transaction."""
+  senderAccount: Account!
+
+  """Sender account for the given transaction."""
+  senderAddress: String!
+
+  """Sender assets for the given transaction."""
+  senderAssets: AccountAssets!
+
+  """Sender account shard for the given transaction."""
+  senderShard: Float!
+
+  """Signature for the given transaction."""
+  signature: String
+
+  """Status for the given transaction."""
+  status: String!
+
+  """Timestamp for the given transaction."""
+  timestamp: Float!
+
+  """Hash for the given transaction."""
+  txHash: ID!
+
+  """Transaction type."""
+  type: TransactionType
+
+  """Value for the given transaction."""
+  value: String!
+}
+
 """Transaction action object type."""
 type TransactionAction {
   """Description for the given transaction action."""
@@ -2839,6 +3023,9 @@ type TransactionDetailed {
   """Transaction operations for the given detailed transaction."""
   operations: [TransactionOperation!]
 
+  """Original tx hasg for the given transaction."""
+  originalTxHash: String
+
   """Pending results for the given transaction."""
   pendingResults: Boolean
 
@@ -2853,6 +3040,12 @@ type TransactionDetailed {
 
   """Receiver account for the given transaction."""
   receiverAddress: String!
+
+  """Receiver assets for the given transaction."""
+  receiverAssets: AccountAssets!
+
+  """Receiver account shard for the given transaction."""
+  receiverShard: String!
 
   """Smart contract results for the given detailed transaction."""
   results: [SmartContractResult!]
@@ -2869,6 +3062,12 @@ type TransactionDetailed {
   """Sender account for the given transaction."""
   senderAddress: String!
 
+  """Sender assets for the given transaction."""
+  senderAssets: AccountAssets!
+
+  """Sender account shard for the given transaction."""
+  senderShard: Float!
+
   """Signature for the given transaction."""
   signature: String
 
@@ -2880,6 +3079,9 @@ type TransactionDetailed {
 
   """Hash for the given transaction."""
   txHash: ID!
+
+  """Transaction type."""
+  type: TransactionType
 
   """Value for the given transaction."""
   value: String!
@@ -3054,6 +3256,15 @@ enum TransactionStatus {
 
   """Success status."""
   success
+}
+
+"""Transaction type object type."""
+enum TransactionType {
+  """SmartContractResult type."""
+  SmartContractResult
+
+  """Transaction type."""
+  Transaction
 }
 
 """Unlock mile stone model object type."""


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
-  Add Transfers Query Graphql

  
## Proposed Changes
- Create transfers graphql query - transfers & transfersCount

## How to test
-  `graphql: true`
-  `indexer-v3: true`
Run query:
```
query{
  transfers(input:{
  }){
    txHash
    gasLimit
    gasPrice
    gasUsed
    miniBlockHash
    nonce
    receiverAddress
    receiverShard
    round
    senderAddress
    senderShard
    signature
    status
    value
    fee
    timestamp
    data
    type
    originalTxHash
  }
}
```
