### PR TITLE
create collection roles endpoint

### DIFF
--- a/src/common/indexer/entities/collection.ts
+++ b/src/common/indexer/entities/collection.ts
@@ -7,4 +7,5 @@ export interface Collection {
   type: string;
   timestamp: number;
   ownersHistory: { address: string, timestamp: number }[];
+  roles: any
 }

--- a/src/common/indexer/entities/token.ts
+++ b/src/common/indexer/entities/token.ts
@@ -3,5 +3,4 @@ import { Collection } from "./collection";
 export interface Token extends Collection {
   identifier: string;
   balance: string;
-  roles: any;
 }

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -18,6 +18,7 @@ import { SortOrder } from "src/common/entities/sort.order";
 import { TransactionQueryOptions } from "../transactions/entities/transactions.query.options";
 import { TransactionService } from "../transactions/transaction.service";
 import { TransactionFilter } from "../transactions/entities/transaction.filter";
+import { CollectionRoles } from "../tokens/entities/collection.roles";
 
 @Controller()
 @ApiTags('collections')
@@ -382,5 +383,26 @@ export class CollectionController {
       before,
       after,
     }));
+  }
+
+  @Get("/collections/:identifier/roles")
+  @ApiOperation({ summary: 'Collection roles', description: 'Returns a list of accounts that can perform various actions on a specific collection' })
+  @ApiOkResponse({ type: [CollectionRoles] })
+  @ApiNotFoundResponse({ description: 'Collection not found' })
+  async getCollectionRoles(
+    @Param('identifier', ParseCollectionPipe) identifier: string,
+  ): Promise<CollectionRoles[]> {
+    const isCollection = await this.collectionService.isCollection(identifier);
+    const roles = await this.collectionService.getCollectionRoles(identifier);
+
+    if (!isCollection) {
+      throw new HttpException('Collection not found', HttpStatus.NOT_FOUND);
+    }
+
+    if (!roles) {
+      throw new HttpException('Collection roles not found', HttpStatus.NOT_FOUND);
+    }
+
+    return roles;
   }
 }

--- a/src/test/integration/services/collections.e2e-spec.ts
+++ b/src/test/integration/services/collections.e2e-spec.ts
@@ -8,6 +8,7 @@ import { IndexerService } from "src/common/indexer/indexer.service";
 import { NftCollection } from 'src/endpoints/collections/entities/nft.collection';
 import { ElasticService, TokenUtils } from '@elrondnetwork/erdnest';
 import { EsdtAddressService } from 'src/endpoints/esdt/esdt.address.service';
+import { ApiConfigService } from 'src/common/api-config/api.config.service';
 
 describe('Collection Service', () => {
   let collectionService: CollectionService;
@@ -202,6 +203,31 @@ describe('Collection Service', () => {
       const address: string = 'erd126y66ear20cdskrdky0kpzr9agjul7pcut7ktlr6p0eu8syxhvrq0gsqdj';
       const result = await collectionService.getCollectionCountForAddressWithRoles(address, new CollectionFilter());
       expect(result).toStrictEqual(4);
+    });
+  });
+
+  describe('getCollectionRoles', () => {
+    it('should return collection roles details for a specific collection', async () => {
+      jest.spyOn(ApiConfigService.prototype, 'getIsIndexerV3FlagActive')
+        // eslint-disable-next-line require-await
+        .mockImplementation(jest.fn(() => true));
+
+      const collectionIdentifier: string = "MEDAL-ae074f";
+      const results = await collectionService.getCollectionRoles(collectionIdentifier);
+
+      expect(results).toEqual(expect.arrayContaining([
+        expect.objectContaining({
+          address: "erd1qqqqqqqqqqqqqpgq8ne37ed06034qxfhm09f03ykjfqwx8s7hvrqackmzt",
+          canCreate: true,
+          canBurn: false,
+          canAddQuantity: false,
+          canUpdateAttributes: false,
+          canAddUri: false,
+          canTransferRole: false,
+          roles: ['ESDTRoleNFTCreate'],
+        }),
+      ]));
+
     });
   });
 });


### PR DESCRIPTION
## Proposed Changes
-  Create an endpoint for returning collection roles

## How to test
-  collections/CITIZEN-375553/roles -> should return collection roles

```
    {
        "address": "erd1qqqqqqqqqqqqqpgq6ggn6j69c8x3808zt0rudnlh4hrqzf20sdpsdmmta5",
        "canCreate": true,
        "canBurn": false,
        "canAddQuantity": false,
        "canUpdateAttributes": false,
        "canAddUri": false,
        "canTransferRole": false,
        "roles": [
            "ESDTRoleNFTCreate"
        ]
    }
```
