### PR TITLE
Daily cron to refresh nft metadata & media

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.1.70",
+        "@elrondnetwork/erdnest": "^0.1.80",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2499,9 +2499,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.70.tgz",
-      "integrity": "sha512-uDVo5xj8zo7D5PCaOKVTJ4ewlrnW1/SM7w2Uw5boRjrq/mh8Z4BVRep3a/qhMS3LN4m8B4DnsYFhJqAIR5BZuw==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.80.tgz",
+      "integrity": "sha512-UsMp6ovyneiI6Qtcx0VgAtpsLYlG7OvEwYNiNqaXMyrRAp9/xYpTCQC4DB1jXjtrXh8MT98XOzJbVLnjF9862Q==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17298,9 +17298,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.1.70",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.70.tgz",
-      "integrity": "sha512-uDVo5xj8zo7D5PCaOKVTJ4ewlrnW1/SM7w2Uw5boRjrq/mh8Z4BVRep3a/qhMS3LN4m8B4DnsYFhJqAIR5BZuw==",
+      "version": "0.1.80",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.1.80.tgz",
+      "integrity": "sha512-UsMp6ovyneiI6Qtcx0VgAtpsLYlG7OvEwYNiNqaXMyrRAp9/xYpTCQC4DB1jXjtrXh8MT98XOzJbVLnjF9862Q==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.1.70",
+    "@elrondnetwork/erdnest": "^0.1.80",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -83,7 +83,12 @@ export class NftCronService {
 
       nfts = nfts.sortedDescending(x => x.timestamp ?? 0);
 
-      for (const nft of nfts) {
+      for (const [index, nft] of nfts.entries()) {
+        if (index % 100 === 0) {
+          // yield for 100ms every 100 records, to solve potential issues with synchronous execution
+          await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
         if (nft.identifier && !nftIdentifiers.has(nft.identifier)) {
           try {
             const neededProcessing = await handler(nft);

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -69,6 +69,8 @@ export class NftCronService {
     const nftIdentifiers = new Set<string>();
     let totalProcessedNfts = 0;
 
+    const total = await this.nftService.getNftCount({ before, after });
+
     while (true) {
       let nfts = await this.nftService.getNfts({ from: 0, size: 10000 }, { before, after });
 
@@ -89,6 +91,8 @@ export class NftCronService {
           }
         }
       }
+
+      this.logger.log(`Completed processing ${totalProcessedNfts} / ${total} NFTs`);
 
       if (nfts.length < 10000) {
         break;

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -86,7 +86,7 @@ export class NftCronService {
       for (const [index, nft] of nfts.entries()) {
         if (index % 100 === 0) {
           // yield for 100ms every 100 records, to solve potential issues with synchronous execution
-          await new Promise(resolve => setTimeout(resolve, 100));
+          await new Promise(resolve => setTimeout(resolve, 10));
         }
 
         if (nft.identifier && !nftIdentifiers.has(nft.identifier)) {

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -49,7 +49,7 @@ export class NftCronService {
     }, true);
   }
 
-  @Cron(CronExpression.EVERY_HOUR)
+  @Cron(CronExpression.EVERY_DAY_AT_2AM)
   async triggerProcessNftsForLastYear() {
     if (!this.apiConfigService.getIsProcessNftsFlagActive()) {
       return;

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -46,8 +46,7 @@ export class NftCronService {
     }
 
     await Locker.lock('Process NFTs minted in the last year', async () => {
-      const yearBefore = Math.floor(Date.now() / 1000) - (Constants.oneDay() * 365);
-      await this.processNfts(yearBefore, async nft => {
+      await this.processNfts(undefined, async nft => {
         let needsRefreshMetadataProcessing: boolean = false;
 
         if (nft.attributes) {
@@ -70,7 +69,7 @@ export class NftCronService {
     }, true);
   }
 
-  private async processNfts(after: number, handler: (nft: Nft) => Promise<boolean>): Promise<void> {
+  private async processNfts(after: number | undefined, handler: (nft: Nft) => Promise<boolean>): Promise<void> {
     let before = Math.floor(Date.now() / 1000) - (Constants.oneMinute() * 10);
 
     const nftIdentifiers = new Set<string>();

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -53,9 +53,18 @@ export class NftCronService {
           await this.nftWorkerService.addProcessNftQueueJob(nft, new ProcessNftSettings({ uploadAsset: true }));
         }
 
-        const metadataLink = this.nftExtendedAttributesService.getMetadataFromBase64EncodedAttributes(nft.attributes);
-        if (metadataLink && (!nft.metadata || Object.keys(nft.metadata).length === 0)) {
-          await this.nftWorkerService.addProcessNftQueueJob(nft, new ProcessNftSettings({ forceRefreshMetadata: true }));
+        if (nft.attributes) {
+          let metadataLink: string | undefined = undefined;
+          try {
+            metadataLink = this.nftExtendedAttributesService.getMetadataFromBase64EncodedAttributes(nft.attributes);
+          } catch (error) {
+            this.logger.error(`An unhandled exception occurred when parsing metadata from attributes for NFT with identifier '${nft.identifier}'`);
+            this.logger.error(error);
+          }
+
+          if (metadataLink && (!nft.metadata || Object.keys(nft.metadata).length === 0)) {
+            await this.nftWorkerService.addProcessNftQueueJob(nft, new ProcessNftSettings({ forceRefreshMetadata: true }));
+          }
         }
 
         return needsAssetProcessing;

--- a/src/crons/nft/nft.cron.service.ts
+++ b/src/crons/nft/nft.cron.service.ts
@@ -39,7 +39,7 @@ export class NftCronService {
     }, true);
   }
 
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_HOUR)
   async triggerProcessNftsForLastYear() {
     if (!this.apiConfigService.getIsProcessNftsFlagActive()) {
       return;

--- a/src/endpoints/nfts/nft.extendedattributes.service.ts
+++ b/src/endpoints/nfts/nft.extendedattributes.service.ts
@@ -91,7 +91,7 @@ export class NftExtendedAttributesService {
     return match.groups['tags'].split(',');
   }
 
-  private getMetadataFromBase64EncodedAttributes(attributes: string): string | undefined {
+  getMetadataFromBase64EncodedAttributes(attributes: string): string | undefined {
     const match = MatchUtils.getMetadataFromBase64Attributes(attributes);
     if (!match || !match.groups) {
       return undefined;

--- a/src/queue.worker/nft.worker/nft.worker.service.ts
+++ b/src/queue.worker/nft.worker/nft.worker.service.ts
@@ -9,12 +9,9 @@ import { NftMessage } from "./queue/entities/nft.message";
 import { NftType } from "src/endpoints/nfts/entities/nft.type";
 import { NftAssetService } from "./queue/job-services/assets/nft.asset.service";
 import { PersistenceService } from "src/common/persistence/persistence.service";
-import { OriginLogger } from "@elrondnetwork/erdnest";
 
 @Injectable()
 export class NftWorkerService {
-  private readonly logger = new OriginLogger(NftWorkerService.name);
-
   constructor(
     private readonly nftThumbnailService: NftThumbnailService,
     private readonly nftMetadataService: NftMetadataService,
@@ -30,7 +27,6 @@ export class NftWorkerService {
 
     const needsProcessing = await this.needsProcessing(nft, settings);
     if (!needsProcessing) {
-      this.logger.log(`No processing is needed for nft with identifier '${nft.identifier}'`);
       return false;
     }
 

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -83,7 +83,7 @@ export class NftQueueController {
       return;
     }
 
-    this.logger.log(`Processing NFT with identifier '${data.identifier}' and flags ${this.getProcessNftActivatedSettings(data.settings).join(', ')}`);
+    this.logger.log(`Started Processing NFT with identifier '${data.identifier}' and flags ${this.getProcessNftActivatedSettings(data.settings).join(', ')}`);
 
     try {
       const nft = await this.nftService.getSingleNft(data.identifier);

--- a/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.controller.ts
@@ -12,6 +12,7 @@ import { GenerateThumbnailResult } from "./job-services/thumbnails/entities/gene
 import { NftThumbnailService } from "./job-services/thumbnails/nft.thumbnail.service";
 import { NftAssetService } from "./job-services/assets/nft.asset.service";
 import { OriginLogger } from "@elrondnetwork/erdnest";
+import { ProcessNftSettings } from "src/endpoints/process-nfts/entities/process.nft.settings";
 
 @Controller()
 export class NftQueueController {
@@ -44,6 +45,32 @@ export class NftQueueController {
     return attempt;
   }
 
+  private getProcessNftActivatedSettings(settings: ProcessNftSettings) {
+    const result = [];
+
+    if (settings.forceRefreshMedia) {
+      result.push('forceRefreshMedia');
+    }
+
+    if (settings.forceRefreshMetadata) {
+      result.push('forceRefreshMetadata');
+    }
+
+    if (settings.forceRefreshThumbnail) {
+      result.push('forceRefreshThumbnail');
+    }
+
+    if (settings.skipRefreshThumbnail) {
+      result.push('skipRefreshThumbnail');
+    }
+
+    if (settings.uploadAsset) {
+      result.push('uploadAsset');
+    }
+
+    return result;
+  }
+
   @MessagePattern({ cmd: 'api-process-nfts' })
   async onNftCreated(@Payload() data: NftMessage, @Ctx() context: RmqContext) {
     const channel = context.getChannelRef();
@@ -56,7 +83,7 @@ export class NftQueueController {
       return;
     }
 
-    this.logger.log({ type: 'consumer start', identifier: data.identifier, attempt });
+    this.logger.log(`Processing NFT with identifier '${data.identifier}' and flags ${this.getProcessNftActivatedSettings(data.settings).join(', ')}`);
 
     try {
       const nft = await this.nftService.getSingleNft(data.identifier);
@@ -70,12 +97,13 @@ export class NftQueueController {
 
       if (nft.metadata && settings.forceRefreshMetadata) {
         const oldMetadata = nft.metadata;
+        this.logger.log(`Started Refreshing metadata for NFT with identifier '${nft.identifier}'`);
         nft.metadata = await this.nftMetadataService.refreshMetadata(nft);
         const newMetadata = nft.metadata;
         if (newMetadata) {
-          this.logger.log(`Refreshed NFT metadata. Old: '${JSON.stringify(oldMetadata)}', New: '${JSON.stringify(newMetadata)}'`);
+          this.logger.log(`Completed Refreshing metadata for NFT with identifier. Old: '${JSON.stringify(oldMetadata)}', New: '${JSON.stringify(newMetadata)}'`);
         } else {
-          this.logger.log(`Refreshed NFT metadata. Old: '${JSON.stringify(oldMetadata)}', New is empty`);
+          this.logger.log(`Completed Refreshing metadata for NFT with identifier. Old: '${JSON.stringify(oldMetadata)}', New is empty`);
         }
 
         this.clientProxy.emit('deleteCacheKeys', [CacheInfo.NftMetadata(nft.identifier).key]);
@@ -86,14 +114,18 @@ export class NftQueueController {
       nft.media = await this.nftMediaService.getMedia(nft.identifier) ?? undefined;
 
       if (settings.forceRefreshMedia || !nft.media) {
+        this.logger.log(`Started Refreshing media for NFT with identifier '${nft.identifier}'`);
         nft.media = await this.nftMediaService.refreshMedia(nft);
+        this.logger.log(`Completed Refreshing media for NFT with identifier '${nft.identifier}'`);
       }
 
       if (nft.media && settings.uploadAsset) {
         for (const media of nft.media) {
           const isAssetUploaded = await this.nftAssetService.isAssetUploaded(media);
           if (!isAssetUploaded) {
+            this.logger.log(`Started Uploading asset for NFT with identifier '${nft.identifier}', original url '${media.originalUrl}' and file type '${media.fileType}'`);
             await this.nftAssetService.uploadAsset(nft.identifier, media.originalUrl, media.fileType);
+            this.logger.log(`Completed Uploading asset for NFT with identifier '${nft.identifier}', original url '${media.originalUrl}' and file type '${media.fileType}'`);
           } else {
             this.logger.log(`Asset already uploaded for NFT with identifier '${nft.identifier}' and media url '${media.url}'`);
           }
@@ -106,7 +138,7 @@ export class NftQueueController {
         await Promise.all(mediaItems.map(media => this.generateThumbnail(nft, media, settings.forceRefreshThumbnail)));
       }
 
-      this.logger.log({ type: 'consumer end', identifier: data.identifier });
+      this.logger.log(`Completed Processing NFT with identifier '${data.identifier}' and flags ${this.getProcessNftActivatedSettings(data.settings).join(', ')}`);
 
       channel.ack(message);
     } catch (error: any) {


### PR DESCRIPTION
## Reasoning 
- a lot of NFTs minted a long time ago still don't have media & metadata associated with them
  
## Proposed Changes
- Include the ability for the api to re-index metadata & media for nfts, however "old" they may be
- hourly sync that attempts to forcefully refresh nft media & metadata for NFTs minted in the last 24h if the data is proven to be indexed incorrectly

## How to test
- manually run 24h sync and verify whether NFTs with missing media & metadata in the db (mongo) are triggerred to be indexed
- manually run hourly sync and verify whether NFTs where media / metadata should exist but is saved in the db as default (empty object / empty array) are forcefully refreshed
