### PR TITLE
 remove support for indexer v3

### DIFF
--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -1,7 +1,6 @@
 import { ParseAddressPipe, ParseBlockHashPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseAddressArrayPipe } from "@elrondnetwork/erdnest";
-import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Query } from "@nestjs/common";
+import { Controller, DefaultValuePipe, Get, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { SortOrder } from "src/common/entities/sort.order";
 import { Transaction } from "../transactions/entities/transaction";
@@ -12,10 +11,7 @@ import { TransferService } from "./transfer.service";
 @Controller()
 @ApiTags('transfers')
 export class TransferController {
-  constructor(
-    private readonly apiConfigService: ApiConfigService,
-    private readonly transferService: TransferService,
-  ) { }
+  constructor(private readonly transferService: TransferService) { }
 
   @Get("/transfers")
   @ApiOperation({ summary: 'Value transfers', description: 'Returns both transfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult), thus providing a full picture of all in/out value transfers for a given account' })
@@ -50,10 +46,6 @@ export class TransferController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Transaction[]> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfers(new TransactionFilter({
       sender,
       receivers: receiver,
@@ -99,10 +91,6 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfersCount(new TransactionFilter({
       sender,
       receivers: receiver,
@@ -135,10 +123,6 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfersCount(new TransactionFilter({
       sender,
       receivers: receiver,

--- a/src/graphql/entities/transfers/transfers.query.ts
+++ b/src/graphql/entities/transfers/transfers.query.ts
@@ -1,6 +1,4 @@
-import { HttpException, HttpStatus } from "@nestjs/common";
 import { Args, Float, Query, Resolver } from "@nestjs/graphql";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { Transaction } from "src/endpoints/transactions/entities/transaction";
 import { TransactionFilter } from "src/endpoints/transactions/entities/transaction.filter";
@@ -10,14 +8,10 @@ import { GetTransfersCountInput, GetTransfersInput } from "./transfers.input";
 @Resolver()
 export class TransferQuery {
   constructor(
-    protected readonly transferService: TransferService,
-    protected readonly apiConfigService: ApiConfigService) { }
+    protected readonly transferService: TransferService) { }
 
   @Query(() => [Transaction], { name: "transfers", description: "Retrieve all transfers for the given input." })
   public async getTransfers(@Args("input", { description: "Input to retreive the given transfers for." }) input: GetTransfersInput): Promise<Transaction[]> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
     return await this.transferService.getTransfers(
       new TransactionFilter({
         sender: input.sender,
@@ -36,10 +30,6 @@ export class TransferQuery {
 
   @Query(() => Float, { name: "transfersCount", description: "Retrieve all transfers count for the given input." })
   public async getTransfersCount(@Args("input", { description: "Input to retrieve the given transfers count for." }) input: GetTransfersCountInput): Promise<number> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfersCount(GetTransfersCountInput.resolve(input));
   }
 }

--- a/src/graphql/entities/transfers/transfers.resolver.ts
+++ b/src/graphql/entities/transfers/transfers.resolver.ts
@@ -1,13 +1,11 @@
 import { Resolver } from "@nestjs/graphql";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { Transaction } from "src/endpoints/transactions/entities/transaction";
 import { TransferService } from "src/endpoints/transfers/transfer.service";
 import { TransferQuery } from "./transfers.query";
 
 @Resolver(() => Transaction)
 export class TransferResolver extends TransferQuery {
-  constructor(transferService: TransferService,
-    apiConfigService: ApiConfigService) {
-    super(transferService, apiConfigService);
+  constructor(transferService: TransferService) {
+    super(transferService);
   }
 }


### PR DESCRIPTION
  
## Proposed Changes
-  Remove Indexer-v3 support for transfers service

## How to test
-  execute unit&e2e tranfers tests: npm run test:e2e
-  execute transfers graphql query