### PR TITLE
SERVICES-795 rename scResults queries

### DIFF
--- a/src/graphql/entities/smart.contract.result/smart.contract.result.query.ts
+++ b/src/graphql/entities/smart.contract.result/smart.contract.result.query.ts
@@ -10,7 +10,7 @@ import { NotFoundException } from "@nestjs/common";
 export class SmartContractResultQuery {
   constructor(protected readonly smartContractResultService: SmartContractResultService) { }
 
-  @Query(() => [SmartContractResult], { name: "scResults", description: "Retrieve all smart contract results for the given input." })
+  @Query(() => [SmartContractResult], { name: "results", description: "Retrieve all smart contract results for the given input." })
   public async getScResults(@Args("input", { description: "Input to retrieve the given smart contract results for." }) input: GetSmartContractResultInput): Promise<SmartContractResult[]> {
     return await this.smartContractResultService.getScResults(
       new QueryPagination({
@@ -24,12 +24,12 @@ export class SmartContractResultQuery {
     );
   }
 
-  @Query(() => Float, { name: "scResultsCount", description: "Returns total number of smart contracts." })
+  @Query(() => Float, { name: "resultsCount", description: "Returns total number of smart contracts." })
   public async getScResultsCount(): Promise<number> {
     return await this.smartContractResultService.getScResultsCount();
   }
 
-  @Query(() => SmartContractResult, { name: "scResult", description: "Retrieve the smart contract details for the given input.", nullable: true })
+  @Query(() => SmartContractResult, { name: "result", description: "Retrieve the smart contract details for the given input.", nullable: true })
   public async getScResult(@Args("input", { description: "Input to retrieve the given smart contract for." }) input: GetSmartContractHashInput): Promise<SmartContractResult | undefined> {
     try {
       return await this.smartContractResultService.getScResult(input.scHash);

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1159,7 +1159,7 @@ input GetTransactionsInput {
   token: String
 }
 
-"""Input to retreive the given transfers count for."""
+"""Input to retrieve the given transfers count for."""
 input GetTransfersCountInput {
   """After timestamp for the given result set."""
   after: Float
@@ -2401,6 +2401,21 @@ type Query {
     input: GetProviderInput!
   ): [Provider!]!
 
+  """Retrieve the smart contract details for the given input."""
+  result(
+    """Input to retrieve the given smart contract for."""
+    input: GetSmartContractHashInput!
+  ): SmartContractResult
+
+  """Retrieve all smart contract results for the given input."""
+  results(
+    """Input to retrieve the given smart contract results for."""
+    input: GetSmartContractResultInput!
+  ): [SmartContractResult!]!
+
+  """Returns total number of smart contracts."""
+  resultsCount: Float!
+
   """Retrieve the round details for the given input."""
   round(
     """Input to retrieve the given node for."""
@@ -2418,21 +2433,6 @@ type Query {
     """Input to retrieve the given rounds count for."""
     input: GetRoundsCountInput!
   ): Float
-
-  """Retrieve the smart contract details for the given input."""
-  scResult(
-    """Input to retrieve the given smart contract for."""
-    input: GetSmartContractHashInput!
-  ): SmartContractResult
-
-  """Retrieve all smart contract results for the given input."""
-  scResults(
-    """Input to retrieve the given smart contract results for."""
-    input: GetSmartContractResultInput!
-  ): [SmartContractResult!]!
-
-  """Returns total number of smart contracts."""
-  scResultsCount: Float!
 
   """Retrieve all shards for the given input."""
   shards(
@@ -2938,7 +2938,7 @@ type Transaction {
   """Nonce for the given transaction."""
   nonce: Float
 
-  """Original tx hasg for the given transaction."""
+  """Original tx hash for the given transaction."""
   originalTxHash: String
 
   """Pending results for the given transaction."""
@@ -3043,7 +3043,7 @@ type TransactionDetailed {
   """Transaction operations for the given detailed transaction."""
   operations: [TransactionOperation!]
 
-  """Original tx hasg for the given transaction."""
+  """Original tx hash for the given transaction."""
   originalTxHash: String
 
   """Pending results for the given transaction."""

--- a/src/test/integration/graphql/smart.contract.result.graph-spec.ts
+++ b/src/test/integration/graphql/smart.contract.result.graph-spec.ts
@@ -22,7 +22,7 @@ describe('Smart Contract Results', () => {
         .post(gql)
         .send({
           query: `{
-            scResults(input:{
+            results(input:{
               size: 5
             }){
               hash
@@ -77,7 +77,7 @@ describe('Smart Contract Results', () => {
             .post(gql)
             .send({
               query: `{
-                scResults(input:{
+                results(input:{
                  ${filter}: ${value}
                 }){
                   hash
@@ -120,7 +120,7 @@ describe('Smart Contract Results', () => {
         .post(gql)
         .send({
           query: `{
-            scResultsCount
+            resultsCount
           }`,
         })
         .expect(200)
@@ -137,7 +137,7 @@ describe('Smart Contract Results', () => {
         .post(gql)
         .send({
           query: `{
-            scResult(input:{
+            result(input:{
               scHash: "a5c935b7639a40e7d0e169f2053dcff3ebcbf04c8ee38799bb2075f1fa3f1688"
             }){
               hash

--- a/src/test/integration/graphql/smart.contract.result.graph-spec.ts
+++ b/src/test/integration/graphql/smart.contract.result.graph-spec.ts
@@ -53,7 +53,7 @@ describe('Smart Contract Results', () => {
         })
         .expect(200)
         .then(res => {
-          expect(res.body.data.scResults).toBeDefined();
+          expect(res.body.data.results).toBeDefined();
         });
     });
   });
@@ -107,7 +107,7 @@ describe('Smart Contract Results', () => {
               }`,
             })
             .then(res => {
-              expect(res.body.data.scResults[0].miniBlockHash).toStrictEqual(miniBlockHash);
+              expect(res.body.data.results[0].miniBlockHash).toStrictEqual(miniBlockHash);
             });
         });
       });
@@ -125,7 +125,7 @@ describe('Smart Contract Results', () => {
         })
         .expect(200)
         .then(res => {
-          expect(res.body.data.scResultsCount).toBeGreaterThanOrEqual(110372303);
+          expect(res.body.data.resultsCount).toBeGreaterThanOrEqual(110372303);
         });
     });
   });
@@ -157,8 +157,8 @@ describe('Smart Contract Results', () => {
         })
         .expect(200)
         .then(res => {
-          expect(res.body.data.scResult).toBeDefined();
-          expect(res.body.data.scResult.hash).toStrictEqual(scHash);
+          expect(res.body.data.result).toBeDefined();
+          expect(res.body.data.result.hash).toStrictEqual(scHash);
         });
     });
   });


### PR DESCRIPTION

  
## Proposed Changes
- Rename smart contract queries (scResults => results)

## How to test
-  run smart.contract.graph-e2e-spec.ts tests 
