### PR TITLE
Remove isTransferAffected flag for nfts

### DIFF
--- a/src/endpoints/nfts/entities/nft.ts
+++ b/src/endpoints/nfts/entities/nft.ts
@@ -126,8 +126,4 @@ export class Nft {
   @Field(() => [UnlockMileStoneModel], { description: "Unlock mile stone model for the given NFT.", nullable: true })
   @ApiProperty({ type: [UnlockMileStoneModel], nullable: true })
   unlockSchedule?: UnlockMileStoneModel[] | undefined = undefined;
-
-  @Field(() => Boolean, { description: "Returns true if the transfer is affected.", nullable: true })
-  @ApiProperty({ type: Boolean, nullable: true })
-  isTransferAffected: boolean | undefined = undefined;
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -24,8 +24,6 @@ import { IndexerService } from "src/common/indexer/indexer.service";
 import { LockedAssetService } from "../../common/locked-asset/locked-asset.service";
 import { CollectionAccount } from "../collections/entities/collection.account";
 import { OriginLogger } from "@elrondnetwork/erdnest";
-import { GatewayService } from "src/common/gateway/gateway.service";
-import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 
 @Injectable()
 export class NftService {
@@ -48,7 +46,6 @@ export class NftService {
     private readonly esdtAddressService: EsdtAddressService,
     private readonly mexTokenService: MexTokenService,
     private readonly lockedAssetService: LockedAssetService,
-    private readonly gatewayService: GatewayService,
   ) {
     this.NFT_THUMBNAIL_PREFIX = this.apiConfigService.getExternalMediaUrl() + '/nfts/asset';
     this.DEFAULT_MEDIA = [
@@ -211,22 +208,9 @@ export class NftService {
 
     await this.applyUnlockSchedule(nft);
 
-    await this.applyTransferAffected(nft);
-
     await this.processNft(nft);
 
     return nft;
-  }
-
-  private async applyTransferAffected(nft: Nft): Promise<void> {
-    try {
-      const result = await this.gatewayService.get(`node/old-storage-token/${nft.collection}/nonce/${nft.nonce}`, GatewayComponentRequest.oldStorageToken);
-      if (result?.isOldStorage) {
-        nft.isTransferAffected = true;
-      }
-    } catch (error) {
-      // probably old version of the gateway
-    }
   }
 
   private async applyUnlockSchedule(nft: Nft): Promise<void> {
@@ -502,8 +486,6 @@ export class NftService {
     const nft = nfts[0];
 
     await this.applyUnlockSchedule(nft);
-
-    await this.applyTransferAffected(nft);
 
     return nft;
   }

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1581,9 +1581,6 @@ type Nft {
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
 
-  """Returns true if the transfer is affected."""
-  isTransferAffected: Boolean
-
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!
 
@@ -1668,9 +1665,6 @@ type NftAccount {
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
 
-  """Returns true if the transfer is affected."""
-  isTransferAffected: Boolean
-
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!
 
@@ -1753,9 +1747,6 @@ type NftAccountFlat {
 
   """Is NSFW for the given NFT."""
   isNsfw: Boolean
-
-  """Returns true if the transfer is affected."""
-  isTransferAffected: Boolean
 
   """Is whitelisted storage for the given NFT."""
   isWhitelistedStorage: Boolean!

--- a/src/test/data/esdt/nft/nft.example.ts
+++ b/src/test/data/esdt/nft/nft.example.ts
@@ -39,7 +39,6 @@ const nftCollection = [{
   score: undefined,
   isNsfw: undefined,
   rank: undefined,
-  isTransferAffected: true,
 },
 ];
 export default nftCollection;

--- a/src/test/integration/graphql/nfts.graph-spec.ts
+++ b/src/test/integration/graphql/nfts.graph-spec.ts
@@ -49,7 +49,6 @@ describe('Nfts', () => {
               }
               supply
               ticker
-              isTransferAffected
           }
           }`,
         })

--- a/src/test/integration/services/nft.e2e-spec.ts
+++ b/src/test/integration/services/nft.e2e-spec.ts
@@ -52,7 +52,6 @@ describe('Nft Service', () => {
     score: undefined,
     isNsfw: undefined,
     rank: undefined,
-    isTransferAffected: true,
   };
 
   beforeAll(async () => {
@@ -537,17 +536,6 @@ describe('Nft Service', () => {
       expect(result.creator).toBeDefined();
     });
 
-    it("should returns NFT details for a specific NonFungibleESDT identifier and isTransferAffected property should be defined", async () => {
-      const identifier: string = "CATSFAM-46c28f-0211";
-      const result = await nftService.getSingleNft(identifier);
-
-      if (!result) {
-        throw new Error("Properties are not defined");
-      }
-
-      expect(result.isTransferAffected).toBeDefined();
-    });
-
     it('should return undefined', async () => {
       jest.spyOn(NftService.prototype, 'getNftsInternal')
         // eslint-disable-next-line require-await
@@ -712,17 +700,6 @@ describe('Nft Service', () => {
 
       for (const nft of nfts) {
         expect(nft.scamInfo).toBeDefined();
-      }
-    });
-
-    it("should return a list of NonFungibleESDT based on a specific identifier for a specific address and isTransferAffected should not be defined", async () => {
-      const address: string = "erd1ar8gg37lu2reg5zpmtmqawqe65fzfsjd2v3p4m993xxjnu8azssq86f24k";
-      const filter = new NftFilter({ identifiers: ['CATSFAM-46c28f-0944'] });
-
-      const nfts = await nftService.getNftsForAddress(address, { from: 0, size: 1 }, filter);
-
-      for (const nft of nfts) {
-        expect(nft.isTransferAffected).not.toBeDefined();
       }
     });
 

--- a/src/test/integration/services/process.nfts.e2e-spec.ts
+++ b/src/test/integration/services/process.nfts.e2e-spec.ts
@@ -55,7 +55,6 @@ describe('Process Nft Service', () => {
     score: undefined,
     isNsfw: undefined,
     rank: undefined,
-    isTransferAffected: true,
   };
 
   beforeAll(async () => {


### PR DESCRIPTION
## Proposed Changes
- Remove isTransferAffected flag for nfts

## How to test (mainnet)
- `/nfts/EGIRL-443b95-0647` should not have `isTransferAffected` flag set
