### PR TITLE
Nft rarities ES mappings

### DIFF
--- a/src/common/assets/entities/nft.rank.algorithm.ts
+++ b/src/common/assets/entities/nft.rank.algorithm.ts
@@ -2,6 +2,6 @@ export enum NftRankAlgorithm {
   trait = 'trait',
   statistical = 'statistical',
   openRarity = 'openRarity',
-  jaccardDistance = 'jaccardDistance',
+  jaccardDistances = 'jaccardDistances',
   custom = 'custom',
 }

--- a/src/common/assets/entities/token.assets.ts
+++ b/src/common/assets/entities/token.assets.ts
@@ -44,7 +44,7 @@ export class TokenAssets {
   @ApiProperty({ type: String, isArray: true })
   extraTokens: string[] | undefined = undefined;
 
-  @Field(() => String, { description: 'Preferred ranking algorithm for NFT collections. Supported values are "trait", "statistic", "jaccardDistance", "openRarity" and "custom".', nullable: true })
+  @Field(() => String, { description: 'Preferred ranking algorithm for NFT collections. Supported values are "trait", "statistical", "jaccardDistances", "openRarity" and "custom".', nullable: true })
   @ApiProperty({ type: String, nullable: true })
   preferredRankAlgorithm: NftRankAlgorithm | undefined = undefined;
 }

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -476,13 +476,19 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getNfts(pagination: QueryPagination, filter: NftFilter, identifier?: string): Promise<any[]> {
-    const elasticQuery = this.indexerHelper.buildElasticNftFilter(filter, identifier);
-    elasticQuery
-      .withPagination(pagination)
-      .withSort([
+    let elasticQuery = this.indexerHelper.buildElasticNftFilter(filter, identifier)
+      .withPagination(pagination);
+
+    if (filter.sort) {
+      elasticQuery = elasticQuery.withSort([
+        { name: filter.sort, order: filter.order === SortOrder.desc ? ElasticSortOrder.descending : ElasticSortOrder.ascending },
+      ]);
+    } else {
+      elasticQuery = elasticQuery.withSort([
         { name: 'timestamp', order: ElasticSortOrder.descending },
         { name: 'nonce', order: ElasticSortOrder.descending },
       ]);
+    }
 
     let elasticNfts = await this.elasticService.getList('tokens', 'identifier', elasticQuery);
     if (elasticNfts.length === 0 && identifier !== undefined) {

--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -19,6 +19,7 @@ import { TransactionQueryOptions } from "../transactions/entities/transactions.q
 import { TransactionService } from "../transactions/transaction.service";
 import { TransactionFilter } from "../transactions/entities/transaction.filter";
 import { NftRank } from "src/common/assets/entities/nft.rank";
+import { SortCollectionNfts } from "./entities/sort.collection.nfts";
 
 @Controller()
 @ApiTags('collections')
@@ -199,6 +200,8 @@ export class CollectionController {
   @ApiQuery({ name: 'withSupply', description: 'Return supply where type = SemiFungibleESDT', required: false, type: Boolean })
   @ApiQuery({ name: 'withScamInfo', required: false, type: Boolean })
   @ApiQuery({ name: 'computeScamInfo', required: false, type: Boolean })
+  @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false, enum: SortCollectionNfts })
+  @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   async getNfts(
     @Param('collection', ParseCollectionPipe) collection: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
@@ -218,6 +221,8 @@ export class CollectionController {
     @Query('withSupply', new ParseBoolPipe) withSupply?: boolean,
     @Query('withScamInfo', new ParseBoolPipe) withScamInfo?: boolean,
     @Query('computeScamInfo', new ParseBoolPipe) computeScamInfo?: boolean,
+    @Query('sort', new ParseEnumPipe(SortCollectionNfts)) sort?: SortCollectionNfts,
+    @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Nft[]> {
     const isCollection = await this.collectionService.isCollection(collection);
     if (!isCollection) {
@@ -228,7 +233,7 @@ export class CollectionController {
 
     return await this.nftService.getNfts(
       new QueryPagination({ from, size }),
-      new NftFilter({ search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage, isNsfw, traits, nonceBefore, nonceAfter }),
+      new NftFilter({ search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage, isNsfw, traits, nonceBefore, nonceAfter, sort, order }),
       options
     );
   }

--- a/src/endpoints/collections/entities/sort.collection.nfts.ts
+++ b/src/endpoints/collections/entities/sort.collection.nfts.ts
@@ -1,0 +1,5 @@
+export enum SortCollectionNfts {
+  timestamp = 'timestamp',
+  rank = 'rank',
+  nonce = 'nonce',
+}

--- a/src/endpoints/nfts/entities/nft.filter.ts
+++ b/src/endpoints/nfts/entities/nft.filter.ts
@@ -1,3 +1,5 @@
+import { SortOrder } from "src/common/entities/sort.order";
+import { SortCollectionNfts } from "src/endpoints/collections/entities/sort.collection.nfts";
 import { NftType } from "./nft.type";
 
 export class NftFilter {
@@ -22,4 +24,7 @@ export class NftFilter {
   isWhitelistedStorage?: boolean;
   isNsfw?: boolean;
   traits?: Record<string, string>;
+
+  sort?: SortCollectionNfts | string;
+  order?: SortOrder;
 }

--- a/src/endpoints/nfts/entities/nft.rarities.ts
+++ b/src/endpoints/nfts/entities/nft.rarities.ts
@@ -1,0 +1,29 @@
+import { Field } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+import { NftRarity } from "./nft.rarity";
+
+export class NftRarities {
+  constructor(init?: Partial<NftRarities>) {
+    Object.assign(this, init);
+  }
+
+  @Field(() => NftRarity, { description: "Statistical rarity information." })
+  @ApiProperty({ type: NftRarity })
+  statistical: NftRarity | undefined;
+
+  @Field(() => NftRarity, { description: "Trait-based rarity information." })
+  @ApiProperty({ type: NftRarity })
+  trait: NftRarity | undefined;
+
+  @Field(() => NftRarity, { description: "Jaccard distances rarity information." })
+  @ApiProperty({ type: NftRarity })
+  jaccardDistances: NftRarity | undefined;
+
+  @Field(() => NftRarity, { description: "OpenRarity information." })
+  @ApiProperty({ type: NftRarity })
+  openRarity: NftRarity | undefined;
+
+  @Field(() => NftRarity, { description: "Custom rarity information." })
+  @ApiProperty({ type: NftRarity })
+  custom: NftRarity | undefined;
+}

--- a/src/endpoints/nfts/entities/nft.rarity.ts
+++ b/src/endpoints/nfts/entities/nft.rarity.ts
@@ -6,11 +6,11 @@ export class NftRarity {
     Object.assign(this, init);
   }
 
-  @Field(() => Number, { description: "Score for the given algorithm." })
-  @ApiProperty({ type: Number })
-  score: number = 0;
-
   @Field(() => Number, { description: "Rank for the given algorithm." })
   @ApiProperty({ type: Number })
   rank: number = 0;
+
+  @Field(() => Number, { description: "Score for the given algorithm." })
+  @ApiProperty({ type: Number })
+  score: number = 0;
 }

--- a/src/endpoints/nfts/entities/nft.rarity.ts
+++ b/src/endpoints/nfts/entities/nft.rarity.ts
@@ -1,0 +1,16 @@
+import { Field } from "@nestjs/graphql";
+import { ApiProperty } from "@nestjs/swagger";
+
+export class NftRarity {
+  constructor(init?: Partial<NftRarity>) {
+    Object.assign(this, init);
+  }
+
+  @Field(() => Number, { description: "Score for the given algorithm." })
+  @ApiProperty({ type: Number })
+  score: number = 0;
+
+  @Field(() => Number, { description: "Rank for the given algorithm." })
+  @ApiProperty({ type: Number })
+  rank: number = 0;
+}

--- a/src/endpoints/nfts/entities/nft.ts
+++ b/src/endpoints/nfts/entities/nft.ts
@@ -9,6 +9,7 @@ import { Field, Float, ID, ObjectType } from "@nestjs/graphql";
 import { NftCollection } from "src/endpoints/collections/entities/nft.collection";
 import { UnlockMileStoneModel } from "../../../common/entities/unlock-schedule";
 import { Account } from "src/endpoints/accounts/entities/account";
+import { NftRarities } from "./nft.rarities";
 
 @ObjectType("Nft", { description: "NFT object type." })
 export class Nft {
@@ -118,6 +119,10 @@ export class Nft {
   @Field(() => Float, { description: "Rank for the given NFT.", nullable: true })
   @ApiProperty({ type: Number, nullable: true })
   rank: number | undefined = undefined;
+
+  @Field(() => Float, { description: "Rarities according to all possible algorithms for the given NFT.", nullable: true })
+  @ApiProperty({ type: NftRarities, nullable: true })
+  rarities: NftRarities | undefined = undefined;
 
   @Field(() => Boolean, { description: "Is NSFW for the given NFT.", nullable: true })
   @ApiProperty({ type: Boolean, nullable: true })

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -26,6 +26,9 @@ import { CollectionAccount } from "../collections/entities/collection.account";
 import { OriginLogger } from "@elrondnetwork/erdnest";
 import { GatewayService } from "src/common/gateway/gateway.service";
 import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
+import { NftRankAlgorithm } from "src/common/assets/entities/nft.rank.algorithm";
+import { NftRarity } from "./entities/nft.rarity";
+import { NftRarities } from "./entities/nft.rarities";
 
 @Injectable()
 export class NftService {
@@ -541,10 +544,32 @@ export class NftService {
     return await this.indexerService.getAccountsEsdtByCollection([identifier], pagination);
   }
 
-  applyExtendedAttributes(nft: Nft, elasticNft: any) {
-    nft.score = elasticNft.nft_rarity_score;
-    nft.rank = elasticNft.nft_rarity_rank;
+  private getNftRarity(elasticNft: any, algorithm: NftRankAlgorithm): NftRarity | undefined {
+    const score = elasticNft[`nft_score_${algorithm}`];
+    const rank = elasticNft[`nft_rank_${algorithm}`];
 
+    if (!score && !rank) {
+      return undefined;
+    }
+
+    return new NftRarity({ score, rank });
+  }
+
+  applyExtendedAttributes(nft: Nft, elasticNft: any) {
+    const algorithm = nft.assets?.preferredRankAlgorithm ?? NftRankAlgorithm.jaccardDistances;
+
+    nft.score = elasticNft[`nft_score_${algorithm}`];
+    nft.rank = elasticNft[`nft_rank_${algorithm}`];
+
+    nft.rarities = new NftRarities({
+      trait: this.getNftRarity(elasticNft, NftRankAlgorithm.trait),
+      statistical: this.getNftRarity(elasticNft, NftRankAlgorithm.statistical),
+      jaccardDistances: this.getNftRarity(elasticNft, NftRankAlgorithm.jaccardDistances),
+      openRarity: this.getNftRarity(elasticNft, NftRankAlgorithm.openRarity),
+      custom: this.getNftRarity(elasticNft, NftRankAlgorithm.custom),
+    });
+
+    nft.assets?.preferredRankAlgorithm;
     if (elasticNft.nft_nsfw_mark !== undefined) {
       nft.isNsfw = elasticNft.nft_nsfw_mark >= this.apiConfigService.getNftExtendedAttributesNsfwThreshold();
     }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -322,7 +322,7 @@ export class NftService {
       nft.nonce = parseInt('0x' + nft.identifier.split('-')[2]);
       nft.timestamp = elasticNft.timestamp;
 
-      this.applyExtendedAttributes(nft, elasticNft);
+      await this.applyExtendedAttributes(nft, elasticNft);
 
       const elasticNftData = elasticNft.data;
       if (elasticNftData) {
@@ -563,8 +563,9 @@ export class NftService {
     return new NftRarity({ score, rank });
   }
 
-  applyExtendedAttributes(nft: Nft, elasticNft: any) {
-    const algorithm = this.getNftRankAlgorithmFromAssets(nft.assets);
+  private async applyExtendedAttributes(nft: Nft, elasticNft: any) {
+    const collectionAssets = await this.assetsService.getTokenAssets(nft.collection);
+    const algorithm = this.getNftRankAlgorithmFromAssets(collectionAssets);
 
     nft.score = elasticNft[this.getNftScoreElasticKey(algorithm)];
     nft.rank = elasticNft[this.getNftRankElasticKey(algorithm)];
@@ -577,7 +578,6 @@ export class NftService {
       custom: this.getNftRarity(elasticNft, NftRankAlgorithm.custom),
     });
 
-    nft.assets?.preferredRankAlgorithm;
     if (elasticNft.nft_nsfw_mark !== undefined) {
       nft.isNsfw = elasticNft.nft_nsfw_mark >= this.apiConfigService.getNftExtendedAttributesNsfwThreshold();
     }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -24,8 +24,6 @@ import { IndexerService } from "src/common/indexer/indexer.service";
 import { LockedAssetService } from "../../common/locked-asset/locked-asset.service";
 import { CollectionAccount } from "../collections/entities/collection.account";
 import { OriginLogger } from "@elrondnetwork/erdnest";
-import { GatewayService } from "src/common/gateway/gateway.service";
-import { GatewayComponentRequest } from "src/common/gateway/entities/gateway.component.request";
 import { NftRankAlgorithm } from "src/common/assets/entities/nft.rank.algorithm";
 import { NftRarity } from "./entities/nft.rarity";
 import { NftRarities } from "./entities/nft.rarities";

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1602,6 +1602,9 @@ type Nft {
   """Rank for the given NFT."""
   rank: Float
 
+  """Rarities according to all possible algorithms for the given NFT."""
+  rarities: Float
+
   """Royalties for the given NFT."""
   royalties: Float
 
@@ -1689,6 +1692,9 @@ type NftAccount {
   """Rank for the given NFT."""
   rank: Float
 
+  """Rarities according to all possible algorithms for the given NFT."""
+  rarities: Float
+
   """Royalties for the given NFT."""
   royalties: Float
 
@@ -1768,6 +1774,9 @@ type NftAccountFlat {
 
   """Rank for the given NFT."""
   rank: Float
+
+  """Rarities according to all possible algorithms for the given NFT."""
+  rarities: Float
 
   """Royalties for the given NFT."""
   royalties: Float
@@ -2745,7 +2754,7 @@ type TokenAssets {
   pngUrl: String!
 
   """
-  Preferred ranking algorithm for NFT collections. Supported values are "trait", "statistic", "jaccardDistance", "openRarity" and "custom".
+  Preferred ranking algorithm for NFT collections. Supported values are "trait", "statistical", "jaccardDistances", "openRarity" and "custom".
   """
   preferredRankAlgorithm: String
 

--- a/src/test/data/esdt/nft/nft.example.ts
+++ b/src/test/data/esdt/nft/nft.example.ts
@@ -39,6 +39,7 @@ const nftCollection = [{
   score: undefined,
   isNsfw: undefined,
   rank: undefined,
+  rarities: undefined,
 },
 ];
 export default nftCollection;

--- a/src/test/integration/services/nft.e2e-spec.ts
+++ b/src/test/integration/services/nft.e2e-spec.ts
@@ -52,6 +52,7 @@ describe('Nft Service', () => {
     score: undefined,
     isNsfw: undefined,
     rank: undefined,
+    rarities: undefined,
   };
 
   beforeAll(async () => {

--- a/src/test/integration/services/process.nfts.e2e-spec.ts
+++ b/src/test/integration/services/process.nfts.e2e-spec.ts
@@ -55,6 +55,7 @@ describe('Process Nft Service', () => {
     score: undefined,
     isNsfw: undefined,
     rank: undefined,
+    rarities: undefined,
   };
 
   beforeAll(async () => {


### PR DESCRIPTION
## Proposed Changes
- Read rarities according to all supported algorithms from ES
- Support for sorting nfts by rank, timestamp, nonce

## How to test (devnet)
- `/collections/TEST-b0fe13/nfts` should return `rank`, `score` but also `rarites` with all ranks & scores from other algorithms
- `/collections/TEST-b0fe13/nfts?sort=rank` should display the records sorted by rank ascending
- `/collections/TEST-b0fe13/nfts?sort=rank&order=desc` should display the records sorted by rank descending
- `/collections/TEST-b0fe13/nfts?sort=nonce` should display the records sorted by rank ascending
- `/collections/TEST-b0fe13/nfts?sort=nonce&order=desc` should display the records sorted by rank descending
- `/collections/TEST-b0fe13/nfts?sort=timestamp` should display the records sorted by rank ascending
- `/collections/TEST-b0fe13/nfts?sort=timestamp&order=desc` should display the records sorted by rank descending
