### PR TITLE
 add senders filter to tranfers

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -236,8 +236,14 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('type', filter.type === TransactionType.Transaction ? 'normal' : 'unsigned'));
     }
 
-    if (filter.sender) {
-      elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('sender', filter.sender));
+    if (filter.senders) {
+      const queries: AbstractQuery[] = [];
+      for (const receiver of filter.senders) {
+        queries.push(QueryType.Match('sender', receiver));
+        queries.push(QueryType.Match('senders', receiver));
+      }
+
+      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(queries));
     }
 
     if (filter.receivers) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -237,13 +237,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.senders) {
-      const queries: AbstractQuery[] = [];
-      for (const receiver of filter.senders) {
-        queries.push(QueryType.Match('sender', receiver));
-        queries.push(QueryType.Match('senders', receiver));
-      }
-
-      elasticQuery = elasticQuery.withMustCondition(QueryType.Should(queries));
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.senders, sender => QueryType.Match('sender', sender));
     }
 
     if (filter.receivers) {

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -10,6 +10,7 @@ export class TransactionFilter {
 
   address?: string;
   sender?: string;
+  senders?: string[] = [];
   receivers?: string[] = [];
   token?: string;
   function?: string;

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -20,7 +20,7 @@ export class TransferController {
   @ApiOkResponse({ type: [Transaction] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
-  @ApiQuery({ name: 'senders', description: 'Search by multiple sender addresses, comma-separated', required: false })
+  @ApiQuery({ name: 'sender', description: 'Search by multiple sender addresses, comma-separated', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'token', description: 'Identifier of the token', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -36,7 +36,7 @@ export class TransferController {
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
-    @Query('senders', ParseAddressArrayPipe) senders?: string[],
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -49,7 +49,7 @@ export class TransferController {
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Transaction[]> {
     return await this.transferService.getTransfers(new TransactionFilter({
-      senders,
+      senders: sender,
       receivers: receiver,
       token,
       senderShard,
@@ -67,7 +67,7 @@ export class TransferController {
   @Get("/transfers/count")
   @ApiOperation({ summary: 'Account transfer count', description: 'Return total count of tranfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult)' })
   @ApiOkResponse({ type: Number })
-  @ApiQuery({ name: 'senders', description: 'Search by multiple sender addresses, comma-separated', required: false })
+  @ApiQuery({ name: 'sender', description: 'Search by multiple sender addresses, comma-separated', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'token', description: 'Identifier of the token', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -80,7 +80,7 @@ export class TransferController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getAccountTransfersCount(
-    @Query('senders', ParseAddressArrayPipe) senders?: string[],
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -94,7 +94,7 @@ export class TransferController {
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      senders,
+      senders: sender,
       receivers: receiver,
       token,
       function: scFunction,
@@ -112,7 +112,7 @@ export class TransferController {
   @Get("/transfers/c")
   @ApiExcludeEndpoint()
   async getAccountTransfersCountAlternative(
-    @Query('senders', ParseAddressArrayPipe) senders?: string[],
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -126,7 +126,7 @@ export class TransferController {
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      senders,
+      senders: sender,
       receivers: receiver,
       token,
       function: scFunction,

--- a/src/endpoints/transfers/transfer.controller.ts
+++ b/src/endpoints/transfers/transfer.controller.ts
@@ -1,7 +1,6 @@
-import { ParseAddressPipe, ParseBlockHashPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseAddressArrayPipe } from "@elrondnetwork/erdnest";
-import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Query } from "@nestjs/common";
+import { ParseBlockHashPipe, ParseEnumPipe, ParseIntPipe, ParseArrayPipe, ParseAddressArrayPipe } from "@elrondnetwork/erdnest";
+import { Controller, DefaultValuePipe, Get, Query } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
-import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { QueryPagination } from "src/common/entities/query.pagination";
 import { SortOrder } from "src/common/entities/sort.order";
 import { Transaction } from "../transactions/entities/transaction";
@@ -13,7 +12,6 @@ import { TransferService } from "./transfer.service";
 @ApiTags('transfers')
 export class TransferController {
   constructor(
-    private readonly apiConfigService: ApiConfigService,
     private readonly transferService: TransferService,
   ) { }
 
@@ -22,7 +20,7 @@ export class TransferController {
   @ApiOkResponse({ type: [Transaction] })
   @ApiQuery({ name: 'from', description: 'Number of items to skip for the result set', required: false })
   @ApiQuery({ name: 'size', description: 'Number of items to retrieve', required: false })
-  @ApiQuery({ name: 'sender', description: 'Address of the transfer sender', required: false })
+  @ApiQuery({ name: 'senders', description: 'Search by multiple sender addresses, comma-separated', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'token', description: 'Identifier of the token', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -37,8 +35,8 @@ export class TransferController {
   async getAccountTransfers(
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query('sender', ParseAddressPipe) sender?: string,
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
+    @Query('senders', ParseAddressArrayPipe) senders?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
     @Query('receiverShard', ParseIntPipe) receiverShard?: number,
@@ -50,12 +48,8 @@ export class TransferController {
     @Query('after', ParseIntPipe) after?: number,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Transaction[]> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfers(new TransactionFilter({
-      sender,
+      senders,
       receivers: receiver,
       token,
       senderShard,
@@ -73,7 +67,7 @@ export class TransferController {
   @Get("/transfers/count")
   @ApiOperation({ summary: 'Account transfer count', description: 'Return total count of tranfers triggerred by a user account (type = Transaction), as well as transfers triggerred by smart contracts (type = SmartContractResult)' })
   @ApiOkResponse({ type: Number })
-  @ApiQuery({ name: 'sender', description: 'Address of the transfer sender', required: false })
+  @ApiQuery({ name: 'senders', description: 'Search by multiple sender addresses, comma-separated', required: false })
   @ApiQuery({ name: 'receiver', description: 'Search by multiple receiver addresses, comma-separated', required: false })
   @ApiQuery({ name: 'token', description: 'Identifier of the token', required: false })
   @ApiQuery({ name: 'senderShard', description: 'Id of the shard the sender address belongs to', required: false })
@@ -86,7 +80,7 @@ export class TransferController {
   @ApiQuery({ name: 'before', description: 'Before timestamp', required: false })
   @ApiQuery({ name: 'after', description: 'After timestamp', required: false })
   async getAccountTransfersCount(
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('senders', ParseAddressArrayPipe) senders?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -99,12 +93,8 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      sender,
+      senders,
       receivers: receiver,
       token,
       function: scFunction,
@@ -122,7 +112,7 @@ export class TransferController {
   @Get("/transfers/c")
   @ApiExcludeEndpoint()
   async getAccountTransfersCountAlternative(
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('senders', ParseAddressArrayPipe) senders?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -135,12 +125,8 @@ export class TransferController {
     @Query('before', ParseIntPipe) before?: number,
     @Query('after', ParseIntPipe) after?: number,
   ): Promise<number> {
-    if (!this.apiConfigService.getIsIndexerV3FlagActive()) {
-      throw new HttpException('Endpoint not live yet', HttpStatus.NOT_IMPLEMENTED);
-    }
-
     return await this.transferService.getTransfersCount(new TransactionFilter({
-      sender,
+      senders,
       receivers: receiver,
       token,
       function: scFunction,


### PR DESCRIPTION
 
## Proposed Changes
- Add multiple sender addresses 

## How to test
Senders filter with one address
- `transfers?sender=erd1vtlpm6sxxvmgt43ldsrpswjrfcsudmradylpxn9jkp66ra3rkz4qruzvfw` -> should return a list of 25 transfers and all senders should be `erd1vtlpm6sxxvmgt43ldsrpswjrfcsudmradylpxn9jkp66ra3rkz4qruzvfw`

Senders filter with multiple addresses
- `transfers?sender=erd1vtlpm6sxxvmgt43ldsrpswjrfcsudmradylpxn9jkp66ra3rkz4qruzvfw,erd1v4ms58e22zjcp08suzqgm9ajmumwxcy4hfkdc23gvynnegjdflmsj6gmaq` -> should return a list of 25 transfers and all senders should contains `erd1vtlpm6sxxvmgt43ldsrpswjrfcsudmradylpxn9jkp66ra3rkz4qruzvfw` and `erd1v4ms58e22zjcp08suzqgm9ajmumwxcy4hfkdc23gvynnegjdflmsj6gmaq`
