### PR TITLE
Identity apr take queued nodes into account

### DIFF
--- a/src/endpoints/identities/entities/stake.info.ts
+++ b/src/endpoints/identities/entities/stake.info.ts
@@ -5,6 +5,7 @@ export class StakeInfo {
 
   score?: number;
   validators?: number;
+  queued?: number;
   stake?: string;
   topUp?: string;
   locked: string = '0';

--- a/src/endpoints/identities/identities.service.ts
+++ b/src/endpoints/identities/identities.service.ts
@@ -11,6 +11,8 @@ import { NodesInfos } from "../providers/entities/nodes.infos";
 import { Identity } from "./entities/identity";
 import { IdentityDetailed } from "./entities/identity.detailed";
 import { StakeInfo } from "./entities/stake.info";
+import { NodeType } from "../nodes/entities/node.type";
+import { NodeStatus } from "../nodes/entities/node.status";
 
 @Injectable()
 export class IdentitiesService {
@@ -120,40 +122,25 @@ export class IdentitiesService {
     return distribution;
   }
 
-  private getStakeInfoForIdentity(identity: any, totalLocked: bigint): StakeInfo {
-    const stakeInfo = new StakeInfo();
+  private getStakeInfoForIdentity(identity: IdentityDetailed, totalLocked: bigint): StakeInfo {
+    const nodes = identity.nodes ?? [];
 
-    const score: number = identity.nodes
-      .map((x: Node) => x.ratingModifier)
-      .reduce((acumulator: number, current: number) => acumulator + current);
-    stakeInfo.score = Math.floor(score * 100);
-
-    const stake: bigint = identity.nodes
-      .map((x: Node) => (x.stake ? x.stake : '0'))
-      .reduce((acumulator: bigint, current: string) => acumulator + BigInt(current), BigInt(0));
-    stakeInfo.stake = stake.toString();
-
-    const topUp: bigint = identity.nodes
-      .map((x: Node) => (x.topUp ? x.topUp : '0'))
-      .reduce((acumulator: bigint, current: string) => acumulator + BigInt(current), BigInt(0));
-    stakeInfo.topUp = topUp.toString();
-
-    const locked = stake + topUp;
-    stakeInfo.locked = locked.toString();
-
+    const stake = nodes.filter(x => x.status !== NodeStatus.queued).sumBigInt(x => BigInt(x.stake ? x.stake : '0'));
+    const topUp = nodes.filter(x => x.status !== NodeStatus.queued).sumBigInt(x => BigInt(x.topUp ? x.topUp : '0'));
+    const locked = nodes.sumBigInt(x => BigInt(x.locked ? x.locked : '0'));
     const stakePercent = totalLocked > 0 ? (locked * BigInt(10000)) / totalLocked : 0;
-    stakeInfo.stakePercent = parseFloat(stakePercent.toString()) / 100;
 
-    const providers = identity.nodes
-      .map((x: Node) => x.provider)
-      .filter((provider: string | null) => !!provider);
-    stakeInfo.providers = providers.distinct();
+    const stakeInfo = new StakeInfo({
+      score: nodes.sum(x => x.ratingModifier),
+      stake: stake.toString(),
+      topUp: topUp.toString(),
+      locked: locked.toString(),
+      stakePercent: parseFloat(stakePercent.toString()) / 100,
+      providers: nodes.map(x => x.provider).filter(provider => !!provider).distinct(),
+      distribution: this.getStakeDistributionForIdentity(locked, identity),
+      validators: nodes.filter(x => x.type === NodeType.validator && x.status !== NodeStatus.inactive).length,
+    });
 
-    stakeInfo.distribution = this.getStakeDistributionForIdentity(locked, identity);
-
-    stakeInfo.validators = identity.nodes.filter(
-      (x: any) => x.type === 'validator' && x.status !== 'inactive'
-    ).length;
     stakeInfo.sort = stakeInfo.locked && stakeInfo.locked !== '0' ? parseInt(stakeInfo.locked.slice(0, -18)) : 0;
 
     return stakeInfo;


### PR DESCRIPTION
## Proposed Changes
- Decrease APR with a value proportional to the non-queued validators vs all validators

## How to test (mainnet)
- `/identities/aurentum` should have APR closer to 10%, rather than the existing 11.x%
