### PR TITLE
Add support for multiple senders in account transfers endpoint

### DIFF
--- a/src/endpoints/accounts/account.controller.ts
+++ b/src/endpoints/accounts/account.controller.ts
@@ -670,7 +670,7 @@ export class AccountController {
     @Param('address', ParseAddressPipe) address: string,
     @Query('from', new DefaultValuePipe(0), ParseIntPipe) from: number,
     @Query('size', new DefaultValuePipe(25), ParseIntPipe) size: number,
-    @Query('sender', ParseAddressPipe) sender?: string,
+    @Query('sender', ParseAddressArrayPipe) sender?: string[],
     @Query('receiver', ParseAddressArrayPipe) receiver?: string[],
     @Query('token') token?: string,
     @Query('senderShard', ParseIntPipe) senderShard?: number,
@@ -690,7 +690,7 @@ export class AccountController {
 
     return await this.transferService.getTransfers(new TransactionFilter({
       address,
-      sender,
+      senders: sender,
       receivers: receiver,
       token,
       function: scFunction,


### PR DESCRIPTION
## Proposed Changes
- Add support for multiple senders in account transfers endpoint

## How to test (devnet)
- `accounts/erd1l453hd0gt5gzdp7czpuall8ggt2dcv5zwmfdf3sd3lguxseux2fsmsgldz/transfers?sender=erd16h8vnd2x89cll66ezeclpvdf7kfzy44unr9x90gt6535u0rmr78svakp9r,erd1ttm5tlrvm7s6used9audyxwpwt6p55ef5h0wcakx7vew9fn207aqetn7u7` should return transfers associated with both accounts as sender
