### PR TITLE
Run nft cron in cache warmer

### DIFF
--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -6,6 +6,7 @@ import { KeybaseModule } from 'src/common/keybase/keybase.module';
 import { MexModule } from 'src/endpoints/mex/mex.module';
 import { AssetsModule } from 'src/common/assets/assets.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { NftCronModule } from '../nft/nft.cron.module';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
     KeybaseModule,
     MexModule,
     AssetsModule,
+    NftCronModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/queue.worker/nft.worker/queue/nft.queue.module.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.module.ts
@@ -1,14 +1,12 @@
 import { Module } from '@nestjs/common';
 import { NftQueueController } from './nft.queue.controller';
 import { NftJobProcessorModule } from './job-services/nft.job.processor.module';
-import { NftCronModule } from 'src/crons/nft/nft.cron.module';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 
 @Module({
   imports: [
     NftJobProcessorModule,
-    NftCronModule,
     NftModule,
   ],
   providers: [


### PR DESCRIPTION
## Reasoning
- NFT cron was running with the `queue worker` condition, meaning there could have been multiple nft crons running at the same time, which is undesirable

## Proposed Changes
- Run nft cron in the cache warmer module

## How to test
- when setting cache warmer feature active, nft cron should work, otherwise it should not
