### PR TITLE
Fix result when no token roles

### DIFF
--- a/src/endpoints/tokens/token.service.ts
+++ b/src/endpoints/tokens/token.service.ts
@@ -345,7 +345,7 @@ export class TokenService {
     }
 
     if (!token.roles) {
-      return undefined;
+      return [];
     }
 
     const roles: TokenRoles[] = [];

--- a/src/test/integration/controllers/tokens.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/tokens.controller.e2e-spec.ts
@@ -227,7 +227,7 @@ describe("Tokens Controller", () => {
         .get(`${path}/${identifier}/roles`)
         .expect(200)
         .then(res => {
-          expect(res.body).toHaveLength(16);
+          expect(res.body).toHaveLength(17);
 
           for (const item of res.body) {
             expect(item.address).toBeDefined();

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -937,7 +937,7 @@ describe('Token Service', () => {
 
       const results = await tokenService.getTokenRoles('');
 
-      expect(results).toBeUndefined();
+      expect(results).toStrictEqual([]);
     });
 
     it("should return undefined because test simulates that roles are not defined for token", async () => {


### PR DESCRIPTION
## Reasoning
- holoride roles endpoint was returning 404 not found
  
## Proposed Changes
- When token has no accounts with roles, return empty array instead of returning 404

## How to test (mainnet)
- `/tokens/RIDE-7d18e9/roles` should return `[]` (empty array)
