### PR TITLE
Get nft supply only if SFT or MetaESDT

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -203,7 +203,9 @@ export class NftService {
       return undefined;
     }
 
-    await this.applySupply(nft);
+    if (nft.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT)) {
+      await this.applySupply(nft);
+    }
 
     await this.applyNftOwner(nft);
 


### PR DESCRIPTION
## Proposed Changes
- Get nft supply only if SFT or MetaESDT

## How to test 
- the `/nfts/:identifier` endpoint should only call the internal get supply function if type is SFT / MetaESDT
