### PR TITLE
apply supply attribute to account/:account/nfts only for SemiFungibleEsdt and MetaEsdt

### DIFF
--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -89,8 +89,8 @@ export class NftService {
     }
 
     if (queryOptions && queryOptions.withSupply) {
-      const nftType = nfts.filter((obj) => obj.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
-      await this.batchApplySupply(nftType);
+      const supplyNfts = nfts.filter(nft => nft.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
+      await this.batchApplySupply(supplyNfts);
     }
 
     await this.batchProcessNfts(nfts);
@@ -421,8 +421,8 @@ export class NftService {
     }
 
     if (queryOptions && queryOptions.withSupply) {
-      const nftType = nfts.filter((obj) => obj.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
-      await this.batchApplySupply(nftType);
+      const supplyNfts = nfts.filter(nft => nft.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
+      await this.batchApplySupply(supplyNfts);
     }
 
     await this.batchProcessNfts(nfts);

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -420,7 +420,8 @@ export class NftService {
     }
 
     if (queryOptions && queryOptions.withSupply) {
-      await this.batchApplySupply(nfts);
+      const nftType = nfts.filter((obj) => obj.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
+      await this.batchApplySupply(nftType);
     }
 
     await this.batchProcessNfts(nfts);

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -89,7 +89,8 @@ export class NftService {
     }
 
     if (queryOptions && queryOptions.withSupply) {
-      await this.batchApplySupply(nfts);
+      const nftType = nfts.filter((obj) => obj.type.in(NftType.SemiFungibleESDT, NftType.MetaESDT));
+      await this.batchApplySupply(nftType);
     }
 
     await this.batchProcessNfts(nfts);

--- a/src/test/integration/controllers/nfts.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/nfts.controller.e2e-spec.ts
@@ -139,7 +139,26 @@ describe("NFT Controller", () => {
         });
     });
 
-    it('should return a list of 25 NFTs that have supply = 1', async () => {
+    it('should return a list of 25 SFTs that have supply when withSupply is true', async () => {
+      const params = new URLSearchParams({
+        'withSupply': 'true',
+        'type': 'SemiFungibleESDT',
+      });
+
+      await request(app.getHttpServer())
+        .get(`${path}?${params}`)
+        .expect(200)
+        .then(res => {
+          expect(res.body).toHaveLength(25);
+
+          for (const response of res.body) {
+            expect(response.type).toStrictEqual('SemiFungibleESDT');
+            expect(response.supply).toBeDefined();
+          }
+        });
+    });
+
+    it('should return a list of 25 NFTs and supply attribute should not be defined even with withSupply true', async () => {
       const params = new URLSearchParams({
         'withSupply': 'true',
         'type': 'NonFungibleESDT',
@@ -153,7 +172,24 @@ describe("NFT Controller", () => {
 
           for (const response of res.body) {
             expect(response.type).toStrictEqual('NonFungibleESDT');
-            expect(response.supply).toStrictEqual('1');
+            expect(response.supply).not.toBeDefined();
+          }
+        });
+    });
+
+    it('should return a list of 25 tokens without supply even if withSupply option is false', async () => {
+      const params = new URLSearchParams({
+        'withSupply': 'false',
+      });
+
+      await request(app.getHttpServer())
+        .get(`${path}?${params}`)
+        .expect(200)
+        .then(res => {
+          expect(res.body).toHaveLength(25);
+
+          for (const response of res.body) {
+            expect(response.supply).not.toBeDefined();
           }
         });
     });

--- a/src/test/integration/services/nft.e2e-spec.ts
+++ b/src/test/integration/services/nft.e2e-spec.ts
@@ -433,8 +433,8 @@ describe('Nft Service', () => {
       }
     });
 
-    it("should return a list of NonFungible tokens for a specific address and applied filter withSupply = true", async () => {
-      const address: string = "erd1fs7dp439gw2at58a2pqn3hdnxqh5vskq5uzjdf9kajkxy3p0vy7qeh7k00";
+    it("should return a list of NonFungibleESDT for a specific address without supply even if withSupply property is true", async () => {
+      const address: string = "erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv";
       const options = new NftQueryOptions();
       options.withSupply = true;
 
@@ -442,6 +442,54 @@ describe('Nft Service', () => {
 
       for (const result of results) {
         expect(result.type).toStrictEqual(NftType.NonFungibleESDT);
+        expect(result.supply).not.toBeDefined();
+      }
+    });
+
+    it("when withSupply property is false should return a list of tokens (NonFungible, SemiFungibleESDT, MetaESDT) without supply attribute applied", async () => {
+      const address: string = "erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv";
+      const options = new NftQueryOptions();
+      options.withSupply = false;
+
+      const nftResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.NonFungibleESDT }, options);
+      for (const result of nftResults) {
+        expect(result.type).toStrictEqual(NftType.NonFungibleESDT);
+        expect(result.supply).not.toBeDefined();
+      }
+
+      const sftResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.SemiFungibleESDT }, options);
+      for (const result of sftResults) {
+        expect(result.type).toStrictEqual(NftType.SemiFungibleESDT);
+        expect(result.supply).not.toBeDefined();
+      }
+
+      const metaEsdtResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.MetaESDT }, options);
+      for (const result of metaEsdtResults) {
+        expect(result.type).toStrictEqual(NftType.MetaESDT);
+        expect(result.supply).not.toBeDefined();
+      }
+    });
+
+    it("should return a list of nfts for a specific address with supply attribute applied only for SemiFungibleESDT and MetaESDT", async () => {
+      const address: string = "erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv";
+      const options = new NftQueryOptions();
+      options.withSupply = true;
+
+      const nftResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.NonFungibleESDT }, options);
+      for (const result of nftResults) {
+        expect(result.type).toStrictEqual(NftType.NonFungibleESDT);
+        expect(result.supply).not.toBeDefined();
+      }
+
+      const sftResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.SemiFungibleESDT }, options);
+      for (const result of sftResults) {
+        expect(result.type).toStrictEqual(NftType.SemiFungibleESDT);
+        expect(result.supply).toBeDefined();
+      }
+
+      const metaEsdtResults = await nftService.getNftsForAddress(address, { from: 0, size: 5 }, { type: NftType.MetaESDT }, options);
+      for (const result of metaEsdtResults) {
+        expect(result.type).toStrictEqual(NftType.MetaESDT);
         expect(result.supply).toBeDefined();
       }
     });


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- when `withSupply` option was applied, account NonFungibleESDTs had the supply attribute applied
  
## Proposed Changes
- Apply supply attribute only for SemiFungibleESDT and MetaESDT when `withSupply` option is enabled

## How to test
`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?withSupply=true&type=SemiFungibleESDT` -> all SFT tokens should have supply attribute applied

`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?withSupply=true&type=NonFungibleESDT`-> all NFT tokens does not contain supply attribute

`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?withSupply=true&type=MetaESDT` -> all MetaESDT tokens should have supply attribute applied

`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?size=100` -> all returned tokens should not have supply attribute applied

`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?size=100&withSupply=false` -> all returned tokens should not have supply attribute applied when `withSupply=false`

`accounts/erd1yl6f7cq9gpuprwthxf0c2gsvmnuezwqkqmzf8e40u87t7592af7qpl05cv/nfts?size=100&withSupply=true` -> when `withSupply=true`, returned SemiFungibleESDTs and MetaESDTs should contain supply

`nfts?withSupply=true&type=SemiFungibleESDT` -> all returned tokens should have supply attribute applied

`nfts?withSupply=true&type=NonFungibleESDT ` -> all returned tokens should not have supply attribute applied
