### PR TITLE
Token can transfer flag

### DIFF
--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -182,10 +182,22 @@ export class CollectionService {
 
     collection.type = elasticCollection.type as NftType;
     collection.timestamp = elasticCollection.timestamp;
-    collection.roles = await this.getNftCollectionRoles(elasticCollection);
     collection.traits = await this.persistenceService.getCollectionTraits(identifier) ?? [];
 
+    await this.applyCollectionRoles(collection, elasticCollection);
+
     return collection;
+  }
+
+  async applyCollectionRoles(collection: NftCollection, elasticCollection: any) {
+    collection.roles = await this.getNftCollectionRoles(elasticCollection);
+    const isTransferProhibitedByDefault = collection.roles?.some(x => x.canTransfer === true) === true;
+    collection.canTransfer = !isTransferProhibitedByDefault;
+    if (collection.canTransfer) {
+      for (const role of collection.roles) {
+        role.canTransfer = undefined;
+      }
+    }
   }
 
   async getNftCollectionRoles(elasticCollection: any): Promise<CollectionRoles[]> {

--- a/src/endpoints/collections/entities/nft.collection.ts
+++ b/src/endpoints/collections/entities/nft.collection.ts
@@ -64,6 +64,10 @@ export class NftCollection {
   @ApiProperty({ type: CollectionRoles, isArray: true })
   roles: CollectionRoles[] = [];
 
+  @Field(() => Boolean, { description: 'If the given NFT collection can transfer the underlying tokens by default.', nullable: true })
+  @ApiProperty({ type: Boolean, default: false })
+  canTransfer: boolean = false;
+
   @Field(() => [CollectionTrait], { description: 'Trait list for the given NFT collection.', nullable: true })
   @ApiProperty({ type: CollectionTrait, isArray: true })
   traits: CollectionTrait[] = [];

--- a/src/endpoints/tokens/entities/collection.roles.ts
+++ b/src/endpoints/tokens/entities/collection.roles.ts
@@ -35,6 +35,10 @@ export class CollectionRoles {
   @ApiProperty({ type: Boolean, default: false })
   canTransferRole: boolean = false;
 
+  @Field(() => Boolean, { description: 'If tokens from the given collections are allowed to be transferred by the given account.' })
+  @ApiProperty({ type: Boolean, default: false })
+  canTransfer: boolean = false;
+
   @Field(() => [String], { description: 'Roles list for the given collection roles.' })
   @ApiProperty({ type: [String] })
   roles: string[] = [];

--- a/src/endpoints/tokens/entities/collection.roles.ts
+++ b/src/endpoints/tokens/entities/collection.roles.ts
@@ -33,7 +33,7 @@ export class CollectionRoles {
 
   @Field(() => Boolean, { description: 'If tokens from the given collections are allowed to be transferred by the given account.' })
   @ApiProperty({ type: Boolean, default: false })
-  canTransfer: boolean = false;
+  canTransfer: boolean | undefined = undefined;
 
   @Field(() => [String], { description: 'Roles list for the given collection roles.' })
   @ApiProperty({ type: [String] })

--- a/src/endpoints/tokens/entities/collection.roles.ts
+++ b/src/endpoints/tokens/entities/collection.roles.ts
@@ -31,10 +31,6 @@ export class CollectionRoles {
   @ApiProperty({ type: Boolean, default: false })
   canAddUri: boolean = false;
 
-  @Field(() => Boolean, { description: 'If the given collection role can transfer role.' })
-  @ApiProperty({ type: Boolean, default: false })
-  canTransferRole: boolean = false;
-
   @Field(() => Boolean, { description: 'If tokens from the given collections are allowed to be transferred by the given account.' })
   @ApiProperty({ type: Boolean, default: false })
   canTransfer: boolean = false;

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -276,9 +276,6 @@ type CollectionRoles {
   """
   canTransfer: Boolean!
 
-  """If the given collection role can transfer role."""
-  canTransferRole: Boolean!
-
   """If the given collection role can update attributes."""
   canUpdateAttributes: Boolean!
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -271,6 +271,11 @@ type CollectionRoles {
   """If the given collection role can create."""
   canCreate: Boolean!
 
+  """
+  If tokens from the given collections are allowed to be transferred by the given account.
+  """
+  canTransfer: Boolean!
+
   """If the given collection role can transfer role."""
   canTransferRole: Boolean!
 

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -1847,6 +1847,11 @@ type NftCollection {
   """If the given NFT collection can pause."""
   canPause: Boolean
 
+  """
+  If the given NFT collection can transfer the underlying tokens by default.
+  """
+  canTransfer: Boolean
+
   """If the given NFT collection can transfer NFT create role."""
   canTransferNftCreateRole: Boolean
 
@@ -1891,6 +1896,11 @@ type NftCollectionAccount {
 
   """If the given NFT collection can pause."""
   canPause: Boolean
+
+  """
+  If the given NFT collection can transfer the underlying tokens by default.
+  """
+  canTransfer: Boolean
 
   """If the given NFT collection can transfer NFT create role."""
   canTransferNftCreateRole: Boolean
@@ -1938,6 +1948,11 @@ type NftCollectionAccountFlat {
 
   """If the given NFT collection can pause."""
   canPause: Boolean
+
+  """
+  If the given NFT collection can transfer the underlying tokens by default.
+  """
+  canTransfer: Boolean
 
   """If the given NFT collection can transfer NFT create role."""
   canTransferNftCreateRole: Boolean

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -79,9 +79,6 @@ export class TokenHelpers {
       case 'ESDTRoleNFTAddURI':
         tokenRoles.canAddUri = true;
         break;
-      case 'ESDTTransferRole':
-        tokenRoles.canTransferRole = true;
-        break;
       case 'ESDTRoleNFTUpdateAttributes':
         tokenRoles.canUpdateAttributes = true;
         break;

--- a/src/utils/token.helpers.ts
+++ b/src/utils/token.helpers.ts
@@ -77,13 +77,16 @@ export class TokenHelpers {
         tokenRoles.canAddQuantity = true;
         break;
       case 'ESDTRoleNFTAddURI':
-        tokenRoles.canAddQuantity = true;
+        tokenRoles.canAddUri = true;
         break;
       case 'ESDTTransferRole':
-        tokenRoles.canAddQuantity = true;
+        tokenRoles.canTransferRole = true;
         break;
       case 'ESDTRoleNFTUpdateAttributes':
-        tokenRoles.canAddQuantity = true;
+        tokenRoles.canUpdateAttributes = true;
+        break;
+      case 'ESDTTransferRole':
+        tokenRoles.canTransfer = true;
         break;
     }
   }


### PR DESCRIPTION
## Proposed Changes
- Token canTransfer flag

## How to test (mainnet)
- `/collections/LKASH-10bd00` should have `canTransfer: false`, while in the `roles` section for the addresses `erd1qqqqqqqqqqqqqpgqawujux7w60sjhm8xdx3n0ed8v9h7kpqu2jpsecw6ek` and `erd18mnsygujdglgj2xmnshqcegc7d0ye0gt8cyltq3xsle97ft0wnhsva0dhv` should have `canTransfer: true`
