### PR TITLE
Save metadata errors

### DIFF
--- a/src/test/integration/services/nft.extendedattributes.e2e-spec.ts
+++ b/src/test/integration/services/nft.extendedattributes.e2e-spec.ts
@@ -70,31 +70,6 @@ describe('Nft Extended Attributes Service', () => {
     //ToDo catch(error)
   });
 
-  describe("tryGetExtendedAttributesFromMetadata", () => {
-    it("should return extended attributes from metadata", async () => {
-      jest
-        .spyOn(CachingService.prototype, 'getOrSetCache')
-        // eslint-disable-next-line require-await
-        .mockImplementation(jest.fn(async (_metadata: string) => {
-          return Object.assign({}, attributes);
-        }));
-
-      const results = await nftExtendedAttributesService.tryGetExtendedAttributesFromMetadata('QmTB97vHLbGAfy1T2PdU2XNPuyWB7ufwwhSh5MpLCVn12m/395.json');
-      expect(results).toHaveProperties(['description', 'dna', 'edition', 'createdAt']);
-    });
-
-    it("should return undefined because test simulates that metadata is not defined", async () => {
-      jest
-        .spyOn(CachingService.prototype, 'getOrSetCache')
-        // eslint-disable-next-line require-await
-        .mockImplementation(jest.fn(async (_metadata: string) => undefined));
-
-      const results = await nftExtendedAttributesService.tryGetExtendedAttributesFromMetadata('');
-      expect(results).toBeUndefined();
-    });
-    //ToDo catch(error)
-  });
-
   describe("getTags", () => {
     it("should return tags based on attributes", () => {
       const attributes: string = "dGFnczpFbHJvbmQsUm9ib3RzLFJvYm90LGVSb2JvdHM=";


### PR DESCRIPTION
## Reasoning
- When metadata failed to fetch, there was no indication for API consumers of what the underlying problem was
  
## Proposed Changes
- When fetching NFT metadata fails, store inside the metadata directly the reason of failure

## How to test (mainnet)
- reindex metadata for `CRSK-07ca98-252f`, `BLOKICOR01-3f4e24-028d`, `PLANT2EARN-981e2f-99` should fail and store error
