### PR TITLE
Scam engine version in about endpoint

### DIFF
--- a/src/common/plugins/plugin.service.ts
+++ b/src/common/plugins/plugin.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from "@nestjs/common";
 import { NestExpressApplication } from "@nestjs/platform-express";
 import { AccountDetailed } from "src/endpoints/accounts/entities/account.detailed";
 import { NftCollection } from "src/endpoints/collections/entities/nft.collection";
+import { About } from "src/endpoints/network/entities/about";
 import { Nft } from "src/endpoints/nfts/entities/nft";
 import { Transaction } from "src/endpoints/transactions/entities/transaction";
 
@@ -20,4 +21,6 @@ export class PluginService {
   async bootstrapPublicApp(_application: NestExpressApplication): Promise<void> { }
 
   async batchProcessNfts(_nfts: Nft[], _withScamInfo?: boolean): Promise<void> { }
+
+  async processAbout(_about: About): Promise<void> { }
 }

--- a/src/endpoints/network/entities/about.ts
+++ b/src/endpoints/network/entities/about.ts
@@ -19,6 +19,7 @@ export class About {
   @ApiProperty({ type: String })
   network: string = '';
 
+  @Field(() => String, { description: "Deployment cluster." })
   @ApiProperty({ type: String })
   cluster: string = '';
 
@@ -26,6 +27,7 @@ export class About {
   @ApiProperty({ type: String })
   version: string = '';
 
-  @ApiProperty({ type: String })
-  scamEngineVersion: string = '';
+  @Field(() => String, { description: "Scam engine version.", nullable: true })
+  @ApiProperty({ type: String, nullable: true })
+  scamEngineVersion: string | undefined = undefined;
 }

--- a/src/endpoints/network/network.module.ts
+++ b/src/endpoints/network/network.module.ts
@@ -1,4 +1,5 @@
 import { forwardRef, Module } from "@nestjs/common";
+import { PluginModule } from "src/plugins/plugin.module";
 import { AccountModule } from "../accounts/account.module";
 import { BlockModule } from "../blocks/block.module";
 import { EsdtModule } from "../esdt/esdt.module";
@@ -15,6 +16,7 @@ import { NetworkService } from "./network.service";
     forwardRef(() => TransactionModule),
     forwardRef(() => StakeModule),
     forwardRef(() => EsdtModule),
+    forwardRef(() => PluginModule),
   ],
   providers: [
     NetworkService,

--- a/src/graphql/schema/schema.gql
+++ b/src/graphql/schema/schema.gql
@@ -7,11 +7,17 @@ type About {
   """Application Version details."""
   appVersion: String!
 
+  """Deployment cluster."""
+  cluster: String!
+
   """Current network details."""
   network: String!
 
   """Plugins Version details."""
   pluginsVersion: String!
+
+  """Scam engine version."""
+  scamEngineVersion: String
 
   """API deployment version."""
   version: String!


### PR DESCRIPTION
## Proposed Changes
- Return scam engine version in about endpoint

## How to test
- handle `processAbout` function in plugin by setting `scamEngineVersion`, then see that information returned in the `/about` endpoint
