### PR TITLE
use DappConfig type instead of any

### DIFF
--- a/src/endpoints/dapp-config/dapp.config.controller.ts
+++ b/src/endpoints/dapp-config/dapp.config.controller.ts
@@ -14,7 +14,7 @@ export class DappConfigController {
   @ApiOperation({ summary: 'Dapp configuration', description: 'Returns configuration used in dapps' })
   @ApiOkResponse({ type: DappConfig })
   @ApiNotFoundResponse({ description: 'Network configuration not found' })
-  getDappConfiguration(): any {
+  getDappConfiguration(): DappConfig {
     const configuration = this.dappConfigService.getDappConfiguration();
     if (!configuration) {
       throw new HttpException(`Network configuration not found`, HttpStatus.NOT_FOUND);

--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -1,6 +1,7 @@
 import { FileUtils } from "@elrondnetwork/erdnest";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { DappConfig } from "./entities/dapp-config";
 
 @Injectable()
 export class DappConfigService {
@@ -8,7 +9,7 @@ export class DappConfigService {
     private readonly apiConfigService: ApiConfigService
   ) { }
 
-  getDappConfiguration(): any | undefined {
+  getDappConfiguration(): DappConfig | undefined {
     const network = this.apiConfigService.getNetwork();
     const configuration = FileUtils.parseJSONFile(`./config/dapp.config.${network}.json`);
 

--- a/src/graphql/entities/dapp.config/dapp.config.query.ts
+++ b/src/graphql/entities/dapp.config/dapp.config.query.ts
@@ -7,7 +7,7 @@ export class DappConfigQuery {
   constructor(protected readonly dappConfigService: DappConfigService) { }
 
   @Query(() => DappConfig, { name: "dappConfig", description: "Retrieve configuration used in dapp." })
-  public async getDappConfig(): Promise<DappConfig> {
-    return await this.dappConfigService.getDappConfiguration();
+  public getDappConfig(): DappConfig | undefined {
+    return this.dappConfigService.getDappConfiguration();
   }
 }

--- a/src/test/integration/services/api.config.e2e-spec.ts
+++ b/src/test/integration/services/api.config.e2e-spec.ts
@@ -1,8 +1,8 @@
 import { Test } from "@nestjs/testing";
 import { ConfigService } from "@nestjs/config";
 import { ApiConfigModule } from "src/common/api-config/api.config.module";
-import { DatabaseConnectionOptions } from "src/common/persistence/database/entities/connection.options";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
+import { DatabaseConnectionOptions } from "src/common/persistence/entities/connection.options";
 
 describe('API Config', () => {
   let apiConfigService: ApiConfigService;

--- a/src/test/integration/services/dapp.config.e2e-spec.ts
+++ b/src/test/integration/services/dapp.config.e2e-spec.ts
@@ -1,23 +1,18 @@
 import { ApiConfigService } from 'src/common/api-config/api.config.service';
 import { Test } from '@nestjs/testing';
 import { PublicAppModule } from 'src/public.app.module';
-import Initializer from './e2e-init';
-import { Constants } from '@elrondnetwork/erdnest';
 import { DappConfigService } from 'src/endpoints/dapp-config/dapp.config.service';
 
 describe('Dapp Config Service', () => {
   let dappConfigService: DappConfigService;
 
   beforeAll(async () => {
-    await Initializer.initialize();
-
     const moduleRef = await Test.createTestingModule({
       imports: [PublicAppModule],
     }).compile();
 
     dappConfigService = moduleRef.get<DappConfigService>(DappConfigService);
-
-  }, Constants.oneHour() * 1000);
+  });
 
   beforeEach(() => { jest.restoreAllMocks(); });
 
@@ -28,6 +23,10 @@ describe('Dapp Config Service', () => {
         .mockImplementation(jest.fn(() => 'mainnet'));
 
       const config = dappConfigService.getDappConfiguration();
+
+      if (!config) {
+        throw new Error('Properties are not defined');
+      }
 
       expect(config.id).toStrictEqual('mainnet');
       expect(config.name).toStrictEqual('Mainnet');
@@ -41,6 +40,10 @@ describe('Dapp Config Service', () => {
 
       const config = dappConfigService.getDappConfiguration();
 
+      if (!config) {
+        throw new Error('Properties are not defined');
+      }
+
       expect(config.id).toStrictEqual('devnet');
       expect(config.name).toStrictEqual('Devnet');
       expect(config.chainId).toStrictEqual('D');
@@ -52,6 +55,10 @@ describe('Dapp Config Service', () => {
         .mockImplementation(jest.fn(() => 'testnet'));
 
       const config = dappConfigService.getDappConfiguration();
+
+      if (!config) {
+        throw new Error('Properties are not defined');
+      }
 
       expect(config.id).toStrictEqual('testnet');
       expect(config.name).toStrictEqual('Testnet');

--- a/src/test/integration/services/network.e2e-spec.ts
+++ b/src/test/integration/services/network.e2e-spec.ts
@@ -222,12 +222,13 @@ describe('Network Service', () => {
       jest
         .spyOn(NetworkService.prototype, 'getAboutRaw')
         // eslint-disable-next-line require-await
-        .mockImplementation(jest.fn(() => {
+        .mockImplementation(jest.fn(async () => {
           return new About({
             appVersion: '8f2b49d',
             pluginsVersion: 'e0a77bc',
             network: 'mainnet',
             cluster: undefined,
+            scamEngineVersion: '1.0.0',
           });
         }));
 


### PR DESCRIPTION
  
## Proposed Changes
- use DappConfig type instead of any type

## How to test
-  /dapp/config should return all dapp configuration 
-  npm run test:e2e dapp.*
-  npm run test:graphql dapp.*
