### PR TITLE
Token assets extra info cron fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@aws-sdk/client-s3": "^3.54.0",
         "@elrondnetwork/erdjs": "^11.0.0",
         "@elrondnetwork/erdjs-dex": "^0.0.8",
-        "@elrondnetwork/erdnest": "^0.2.2",
+        "@elrondnetwork/erdnest": "^0.2.13",
         "@elrondnetwork/native-auth": "^0.1.19",
         "@elrondnetwork/transaction-processor": "^0.1.26",
         "@golevelup/nestjs-rabbitmq": "^2.2.0",
@@ -2552,9 +2552,9 @@
       }
     },
     "node_modules/@elrondnetwork/erdnest": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.3.tgz",
-      "integrity": "sha512-oqQdYBZDsFY8FA6dLi/Yf4eWUypFwzBE8RL19/LsXx+Zmr2TMG8vawLorRyW367WBsfMiZqgAptv1/JtARqGRQ==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.13.tgz",
+      "integrity": "sha512-eT9/pxI17NFj2NbNoSoIVwSLpDDaSSGfDMM5qQsbYfhlxFpjWs2r2SSV/dH+udLiT2DeGfodwJG3kkpreLQh/g==",
       "dependencies": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",
@@ -17532,9 +17532,9 @@
       }
     },
     "@elrondnetwork/erdnest": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.3.tgz",
-      "integrity": "sha512-oqQdYBZDsFY8FA6dLi/Yf4eWUypFwzBE8RL19/LsXx+Zmr2TMG8vawLorRyW367WBsfMiZqgAptv1/JtARqGRQ==",
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/@elrondnetwork/erdnest/-/erdnest-0.2.13.tgz",
+      "integrity": "sha512-eT9/pxI17NFj2NbNoSoIVwSLpDDaSSGfDMM5qQsbYfhlxFpjWs2r2SSV/dH+udLiT2DeGfodwJG3kkpreLQh/g==",
       "requires": {
         "@elrondnetwork/native-auth-client": "^0.1.0",
         "@elrondnetwork/native-auth-server": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@aws-sdk/client-s3": "^3.54.0",
     "@elrondnetwork/erdjs": "^11.0.0",
     "@elrondnetwork/erdjs-dex": "^0.0.8",
-    "@elrondnetwork/erdnest": "^0.2.2",
+    "@elrondnetwork/erdnest": "^0.2.13",
     "@elrondnetwork/native-auth": "^0.1.19",
     "@elrondnetwork/transaction-processor": "^0.1.26",
     "@golevelup/nestjs-rabbitmq": "^2.2.0",

--- a/src/crons/cache.warmer/cache.warmer.service.ts
+++ b/src/crons/cache.warmer/cache.warmer.service.ts
@@ -249,7 +249,7 @@ export class CacheWarmerService {
     }, true);
   }
 
-  @Cron(CronExpression.EVERY_MINUTE)
+  @Cron(CronExpression.EVERY_10_MINUTES)
   async handleTokenAssetsExtraInfoInvalidations() {
     await Locker.lock('Token assets extra info invalidations', async () => {
       const assets = await this.assetsService.getAllTokenAssets();


### PR DESCRIPTION
## Reasoning
- Token assets extra info was refreshed too often, reaching the upper bound for number of active scrolls in ElasticSearch
  
## Proposed Changes
- Run Token assets extra info invalidations every 10 minutes instead of 1 minute
- Update erdnest to latest version, which clears ES scrolls after they have been fully utilized

## How to test
- Run Token assets extra info invalidations as often as possible, check whether ES scroll limit is reached (should not reach limit any more)
