### PR TITLE
thumbnail resolver for collection

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, Param, Query } from "@nestjs/common";
+import { Controller, DefaultValuePipe, Get, HttpException, HttpStatus, NotFoundException, Param, Query, Res } from "@nestjs/common";
 import { ApiExcludeEndpoint, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { NftCollection } from "./entities/nft.collection";
 import { NftType } from "../nfts/entities/nft.type";
@@ -21,6 +21,7 @@ import { TransactionFilter } from "../transactions/entities/transaction.filter";
 import { NftRank } from "src/common/assets/entities/nft.rank";
 import { SortCollectionNfts } from "./entities/sort.collection.nfts";
 import { NftCollectionDetailed } from "./entities/nft.collection.detailed";
+import { Response } from "express";
 
 @Controller()
 @ApiTags('collections')
@@ -416,5 +417,43 @@ export class CollectionController {
       before,
       after,
     }));
+  }
+
+  @Get('/collections/:identifier/logo/png')
+  @ApiOperation({ summary: 'Collection png logo', description: 'Returns collection PNG logo ', deprecated: true })
+  async getCollectionLogoPng(
+    @Param('identifier', ParseCollectionPipe) identifier: string,
+    @Res() response: Response
+  ): Promise<void> {
+    const isCollection = await this.collectionService.isCollection(identifier);
+    if (!isCollection) {
+      throw new NotFoundException('Collection not found');
+    }
+
+    const url = await this.collectionService.getLogoPng(identifier);
+    if (url === undefined) {
+      throw new NotFoundException('Assets not found');
+    }
+
+    response.redirect(url);
+  }
+
+  @Get('/collections/:identifier/logo/svg')
+  @ApiOperation({ summary: 'Collection png logo', description: 'Returns collection SVG logo ', deprecated: true })
+  async getTokenLogoSvg(
+    @Param('identifier', ParseCollectionPipe) identifier: string,
+    @Res() response: Response
+  ): Promise<void> {
+    const isCollection = await this.collectionService.isCollection(identifier);
+    if (!isCollection) {
+      throw new NotFoundException('Collection not found');
+    }
+
+    const url = await this.collectionService.getLogoSvg(identifier);
+    if (url === undefined) {
+      throw new NotFoundException('Assets not found');
+    }
+
+    response.redirect(url);
   }
 }

--- a/src/endpoints/collections/collection.service.ts
+++ b/src/endpoints/collections/collection.service.ts
@@ -24,6 +24,7 @@ import { NftRankAlgorithm } from "src/common/assets/entities/nft.rank.algorithm"
 import { NftRank } from "src/common/assets/entities/nft.rank";
 import { TokenDetailed } from "../tokens/entities/token.detailed";
 import { NftCollectionDetailed } from "./entities/nft.collection.detailed";
+import { CollectionLogo } from "./entities/collection.logo";
 
 @Injectable()
 export class CollectionService {
@@ -339,5 +340,32 @@ export class CollectionService {
 
   async getCollectionCountForAddressWithRoles(address: string, filter: CollectionFilter): Promise<number> {
     return await this.esdtAddressService.getCollectionCountForAddressFromElastic(address, filter);
+  }
+
+  private async getCollectionLogo(identifier: string): Promise<CollectionLogo | undefined> {
+    const assets = await this.assetsService.getTokenAssets(identifier);
+    if (!assets) {
+      return;
+    }
+
+    return new CollectionLogo({ pngUrl: assets.pngUrl, svgUrl: assets.svgUrl });
+  }
+
+  async getLogoPng(identifier: string): Promise<string | undefined> {
+    const collectionLogo = await this.getCollectionLogo(identifier);
+    if (!collectionLogo) {
+      return;
+    }
+
+    return collectionLogo.pngUrl;
+  }
+
+  async getLogoSvg(identifier: string): Promise<string | undefined> {
+    const collectionLogo = await this.getCollectionLogo(identifier);
+    if (!collectionLogo) {
+      return;
+    }
+
+    return collectionLogo.svgUrl;
   }
 }

--- a/src/endpoints/collections/entities/collection.logo.ts
+++ b/src/endpoints/collections/entities/collection.logo.ts
@@ -1,0 +1,8 @@
+export class CollectionLogo {
+  constructor(init?: Partial<CollectionLogo>) {
+    Object.assign(this, init);
+  }
+
+  pngUrl?: string;
+  svgUrl?: string;
+}


### PR DESCRIPTION
## Reasoning
- No collection endpoint was available to return PNG or SVG logo 
  
## Proposed Changes
- Create endpoint that return from assets collection PNG or SVG logo

## How to test
- collections/ASHEGLDD-ca7c13/logo/png -> should return collection PNG logo
- collections/ASHEGLDD-ca7c13/logo/svg -> should return collection SVG logo
- collections/ASHEGLDD-ca7c/logo/svg -> should throw error with `status code 400 ` and error `Bad Request`
- collections/PRIMO-8473d0/logo/svg -> should return `Assets Not Found `
- collections/PRIMO-8173d0/logo/svg -> should return `Collection not found`
