### PR TITLE
transaction operations field should select logs results

### DIFF
--- a/src/endpoints/transactions/transaction.get.service.ts
+++ b/src/endpoints/transactions/transaction.get.service.ts
@@ -77,6 +77,13 @@ export class TransactionGetService {
       hashes.push(txHash);
       const previousHashes: Record<string, string> = {};
 
+      if (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.operations)) {
+        const logs = await this.getTransactionLogsFromElastic(hashes);
+
+        transactionDetailed.operations = await this.tokenTransferService.getOperationsForTransaction(transactionDetailed, logs);
+        transactionDetailed.operations = TransactionUtils.trimOperations(transactionDetailed.sender, transactionDetailed.operations, previousHashes);
+      }
+
       if (transaction.hasScResults === true && (!fields || fields.length === 0 || fields.includes(TransactionOptionalFieldOption.results))) {
         transactionDetailed.results = await this.getTransactionScResultsFromElastic(transactionDetailed.txHash);
 


### PR DESCRIPTION
## Description of the reasoning behind the pull request (what feature was missing / how the problem was manifesting itself / what was the motive behind the refactoring)
- In transaction details endpoint, available fields was logs and results and operation fields was added
  
## Proposed Changes
- When performing a request selecting the operations field, internally fetch logs & results as well

## How to test
- transactions/4302d0af550e47a21e5d183f0918af7dbc015f1e7dea6d2ab2025ee675bf8517?fields=operations -> should return operation attribute details