### PR TITLE
Cached dapp config

### DIFF
--- a/src/endpoints/dapp-config/dapp.config.controller.ts
+++ b/src/endpoints/dapp-config/dapp.config.controller.ts
@@ -14,8 +14,8 @@ export class DappConfigController {
   @ApiOperation({ summary: 'Dapp configuration', description: 'Returns configuration used in dapps' })
   @ApiOkResponse({ type: DappConfig })
   @ApiNotFoundResponse({ description: 'Network configuration not found' })
-  async getDappConfiguration(): Promise<DappConfig> {
-    const configuration = await this.dappConfigService.getDappConfiguration();
+  getDappConfiguration(): DappConfig {
+    const configuration = this.dappConfigService.getDappConfiguration();
     if (!configuration) {
       throw new HttpException(`Network configuration not found`, HttpStatus.NOT_FOUND);
     }

--- a/src/endpoints/dapp-config/dapp.config.controller.ts
+++ b/src/endpoints/dapp-config/dapp.config.controller.ts
@@ -14,8 +14,8 @@ export class DappConfigController {
   @ApiOperation({ summary: 'Dapp configuration', description: 'Returns configuration used in dapps' })
   @ApiOkResponse({ type: DappConfig })
   @ApiNotFoundResponse({ description: 'Network configuration not found' })
-  getDappConfiguration(): DappConfig {
-    const configuration = this.dappConfigService.getDappConfiguration();
+  async getDappConfiguration(): Promise<DappConfig> {
+    const configuration = await this.dappConfigService.getDappConfiguration();
     if (!configuration) {
       throw new HttpException(`Network configuration not found`, HttpStatus.NOT_FOUND);
     }

--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -1,22 +1,20 @@
-import { CachingService, Constants, FileUtils } from "@elrondnetwork/erdnest";
+import { FileUtils } from "@elrondnetwork/erdnest";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { DappConfig } from "./entities/dapp-config";
 
 @Injectable()
 export class DappConfigService {
+  private readonly dappConfig: DappConfig | undefined;
+
   constructor(
     private readonly apiConfigService: ApiConfigService,
-    private readonly cachingService: CachingService,
-  ) { }
+  ) {
+    this.dappConfig = this.getDappConfigurationRaw();
+  }
 
-  async getDappConfiguration(): Promise<DappConfig | undefined> {
-    return await this.cachingService.getOrSetCache(
-      'dappConfig',
-      async () => await this.getDappConfigurationRaw(),
-      Constants.oneHour(),
-      Constants.oneMinute()
-    );
+  getDappConfiguration(): DappConfig | undefined {
+    return this.dappConfig;
   }
 
   getDappConfigurationRaw(): DappConfig | undefined {

--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -1,4 +1,4 @@
-import { FileUtils } from "@elrondnetwork/erdnest";
+import { CachingService, Constants, FileUtils } from "@elrondnetwork/erdnest";
 import { Injectable } from "@nestjs/common";
 import { ApiConfigService } from "src/common/api-config/api.config.service";
 import { DappConfig } from "./entities/dapp-config";
@@ -6,10 +6,20 @@ import { DappConfig } from "./entities/dapp-config";
 @Injectable()
 export class DappConfigService {
   constructor(
-    private readonly apiConfigService: ApiConfigService
+    private readonly apiConfigService: ApiConfigService,
+    private readonly cachingService: CachingService,
   ) { }
 
-  getDappConfiguration(): DappConfig | undefined {
+  async getDappConfiguration(): Promise<DappConfig | undefined> {
+    return await this.cachingService.getOrSetCache(
+      'dappConfig',
+      async () => await this.getDappConfigurationRaw(),
+      Constants.oneHour(),
+      Constants.oneMinute()
+    );
+  }
+
+  getDappConfigurationRaw(): DappConfig | undefined {
     const network = this.apiConfigService.getNetwork();
     const configuration = FileUtils.parseJSONFile(`./config/dapp.config.${network}.json`);
 

--- a/src/graphql/entities/dapp.config/dapp.config.query.ts
+++ b/src/graphql/entities/dapp.config/dapp.config.query.ts
@@ -7,7 +7,7 @@ export class DappConfigQuery {
   constructor(protected readonly dappConfigService: DappConfigService) { }
 
   @Query(() => DappConfig, { name: "dappConfig", description: "Retrieve configuration used in dapp." })
-  public getDappConfig(): DappConfig | undefined {
-    return this.dappConfigService.getDappConfiguration();
+  public async getDappConfig(): Promise<DappConfig | undefined> {
+    return await this.dappConfigService.getDappConfiguration();
   }
 }


### PR DESCRIPTION
## Problem setting
- Dapp config is pretty static and api calls are accessing the disk directly
  
## Proposed Changes
- Fetch dapp config only once and keep it in memory

## How to test
- Make sure the dapp config route does not access disk any more
