### PR TITLE
Do not compute scam info if withScamInfo parameter is false

### DIFF
--- a/src/endpoints/nfts/entities/nft.query.options.ts
+++ b/src/endpoints/nfts/entities/nft.query.options.ts
@@ -6,16 +6,18 @@ export class NftQueryOptions {
     Object.assign(this, init);
   }
 
-  withOwner?: boolean = false;
-  withSupply?: boolean = false;
-  withScamInfo?: boolean = false;
-  computeScamInfo?: boolean = false;
+  withOwner?: boolean;
+  withSupply?: boolean;
+  withScamInfo?: boolean;
+  computeScamInfo?: boolean;
 
   //TODO: Remove this function when enforce is no longer needed
   static enforceScamInfoFlag(size: number, options: NftQueryOptions): NftQueryOptions {
     if (size <= NftQueryOptions.SIZE_LIMIT) {
-      options.withScamInfo = true;
-      options.computeScamInfo = true;
+      if (options.withScamInfo === undefined && options.computeScamInfo === undefined) {
+        options.withScamInfo = true;
+        options.computeScamInfo = true;
+      }
     }
 
     return options;


### PR DESCRIPTION
## Reasoning
- Scam info was computed even if `withScamInfo=false` parameter was set
  
## Proposed Changes
- Improve heuristic for determining whether to load scamInfo or not based on the parameters

## How to test
- `/nfts?collection=LOTTERY-7cae2f&withScamInfo=false` should not return `scamInfo` field
