### PR TITLE
Load operations even if no sc results

### DIFF
--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -160,7 +160,7 @@ export class TransactionService {
       }
     }
 
-    if (queryOptions && (queryOptions.withScResults || queryOptions.withOperations || queryOptions.withLogs) && elasticTransactions.some(x => x.hasScResults === true)) {
+    if (queryOptions && (queryOptions.withScResults || queryOptions.withOperations || queryOptions.withLogs)) {
       queryOptions.withScResultLogs = queryOptions.withLogs;
 
       transactions = await this.getExtraDetailsForTransactions(elasticTransactions, transactions, queryOptions);


### PR DESCRIPTION
## Reasoning 
- The wrong heuristic is checked when determining whether to fetch logs / scResults for transaction list
  
## Proposed Changes
- Remove `hasScResults` flag for transactions with logs / scResults / operations

## How to test (mainnet)
- `/transactions?receiver=erd1qqqqqqqqqqqqqpgq0tajepcazernwt74820t8ef7t28vjfgukp2sw239f3&function=migrateOldTokens&status=fail&size=10&withLogs=true` should return logs