### PR TITLE
Fix query with logs

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -424,10 +424,15 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getScResultsForTransactions(elasticTransactions: any[]): Promise<any[]> {
+    const hashes = elasticTransactions.filter(x => x.hasScResults === true).map(x => x.txHash);
+    if (hashes.length === 0) {
+      return [];
+    }
+
     const elasticQuery = ElasticQuery.create()
       .withPagination({ from: 0, size: 10000 })
       .withSort([{ name: 'timestamp', order: ElasticSortOrder.ascending }])
-      .withTerms(new TermsQuery('originalTxHash', elasticTransactions.filter(x => x.hasScResults === true).map(x => x.txHash)));
+      .withTerms(new TermsQuery('originalTxHash', hashes));
 
     return await this.elasticService.getList('scresults', 'scHash', elasticQuery);
   }


### PR DESCRIPTION
## Proposed Changes
- check transaction hashes with SC Results length before performing query on ES

## How to test (mainnet)
- `/transactions?receiver=erd1qqqqqqqqqqqqqpgq0tajepcazernwt74820t8ef7t28vjfgukp2sw239f3&function=migrateOldTokens&status=fail&size=10&withLogs=true` should not fail
