### PR TITLE
Recognize SaveKeyValue function

### DIFF
--- a/src/endpoints/transactions/transaction-action/recognizers/sc-calls/transaction.action.sc-calls.recognizer.service.ts
+++ b/src/endpoints/transactions/transaction-action/recognizers/sc-calls/transaction.action.sc-calls.recognizer.service.ts
@@ -14,6 +14,7 @@ export class SCCallActionRecognizerService implements TransactionActionRecognize
     'ESDTNFTAddQuantity',
     'ESDTNFTAddURI',
     'ESDTNFTUpdateAttributes',
+    'SaveKeyValue',
   ];
 
   // eslint-disable-next-line require-await


### PR DESCRIPTION
## Proposed Changes
- Take into account `SaveKeyValue` function as self built-in function

## How to test (devnet)
- `/transactions/37774f4d5f545bfd95dbdef05d4ceedf8f0ddbb77348f5a99f46958c09936419` should have `action` of type `scCall`
