### PR TITLE
Handle Inactive node status 

### DIFF
--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -257,7 +257,7 @@ export class NodeService {
   }
 
   private async getNodesOwnerAndProvider(nodes: Node[]) {
-    const blses = nodes.filter(node => node.type === NodeType.validator).map(node => node.bls);
+    const blses = nodes.map(node => node.bls);
     const epoch = await this.blockService.getCurrentEpoch();
     const owners = await this.getOwners(blses, epoch);
 
@@ -271,16 +271,14 @@ export class NodeService {
     const providers = await this.providerService.getAllProviders();
 
     for (const node of nodes) {
-      if (node.type === NodeType.validator) {
-        const provider = providers.find(({ provider }) => provider === node.owner);
+      const provider = providers.find(({ provider }) => provider === node.owner);
 
-        if (provider) {
-          node.provider = provider.provider;
-          node.owner = provider.owner ?? '';
+      if (provider) {
+        node.provider = provider.provider;
+        node.owner = provider.owner ?? '';
 
-          if (provider.identity) {
-            node.identity = provider.identity;
-          }
+        if (provider.identity) {
+          node.identity = provider.identity;
         }
       }
     }
@@ -529,6 +527,9 @@ export class NodeService {
       } else if (validatorStatus && validatorStatus.includes('leaving')) {
         nodeType = NodeType.validator;
         nodeStatus = NodeStatus.leaving;
+      } else if (validatorStatus === 'inactive') {
+        nodeType = peerType === 'validator' ? NodeType.validator : NodeType.observer;
+        nodeStatus = NodeStatus.inactive;
       } else if (peerType === 'observer') {
         nodeType = NodeType.observer;
         nodeStatus = undefined;

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -530,7 +530,7 @@ export class NodeService {
         nodeType = NodeType.validator;
         nodeStatus = NodeStatus.leaving;
       } else if (validatorStatus === 'inactive') {
-        nodeType = peerType === 'validator' ? NodeType.validator : NodeType.observer;
+        nodeType = NodeType.validator;
         nodeStatus = NodeStatus.inactive;
       } else if (peerType === 'observer') {
         nodeType = NodeType.observer;

--- a/src/endpoints/nodes/node.service.ts
+++ b/src/endpoints/nodes/node.service.ts
@@ -271,14 +271,16 @@ export class NodeService {
     const providers = await this.providerService.getAllProviders();
 
     for (const node of nodes) {
-      const provider = providers.find(({ provider }) => provider === node.owner);
+      if (node.type === NodeType.validator) {
+        const provider = providers.find(({ provider }) => provider === node.owner);
 
-      if (provider) {
-        node.provider = provider.provider;
-        node.owner = provider.owner ?? '';
+        if (provider) {
+          node.provider = provider.provider;
+          node.owner = provider.owner ?? '';
 
-        if (provider.identity) {
-          node.identity = provider.identity;
+          if (provider.identity) {
+            node.identity = provider.identity;
+          }
         }
       }
     }

--- a/src/test/integration/controllers/proxy.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/proxy.controller.e2e-spec.ts
@@ -46,11 +46,7 @@ describe('Proxy Controller', () => {
       const address: string = "erd1qga7ze0l03chfgru0a32wxqf2226nzrxnyhzer9lmudqhjgy7ycqjjyknz";
       const result = await proxyController.getAddressNonce(address);
 
-      expect(result).toEqual(expect.objectContaining({
-        data: expect.objectContaining({
-          nonce: 42,
-        }),
-      }));
+      expect(result.data.nonce).toStrictEqual(45);
     });
   });
 

--- a/src/test/integration/controllers/tokens.controller.e2e-spec.ts
+++ b/src/test/integration/controllers/tokens.controller.e2e-spec.ts
@@ -205,7 +205,7 @@ describe("Tokens Controller", () => {
         .expect(200)
         .then(res => {
           expect(res.body).toHaveLength(25);
-          expect(res.body[0].address).toStrictEqual('erd1qqqqqqqqqqqqqpgq7qhsw8kffad85jtt79t9ym0a4ycvan9a2jps0zkpen');
+          expect(res.body[0].address).toStrictEqual('erd1qqqqqqqqqqqqqpgqa0fsfshnff4n76jhcye6k7uvd7qacsq42jpsp6shh2');
         });
     });
 

--- a/src/test/integration/graphql/tokens.graph-spec.ts
+++ b/src/test/integration/graphql/tokens.graph-spec.ts
@@ -243,7 +243,7 @@ describe('Tokens', () => {
         .expect(200)
         .then(res => {
           expect(res.body.data.tokenAccounts[0]).toEqual(expect.objectContaining({
-            address: "erd1qqqqqqqqqqqqqpgq7qhsw8kffad85jtt79t9ym0a4ycvan9a2jps0zkpen",
+            address: "erd1qqqqqqqqqqqqqpgqa0fsfshnff4n76jhcye6k7uvd7qacsq42jpsp6shh2",
             balance: res.body.data.tokenAccounts[0].balance,
           }));
         });

--- a/src/test/integration/services/providers.e2e-spec.ts
+++ b/src/test/integration/services/providers.e2e-spec.ts
@@ -63,7 +63,7 @@ describe('Provider Service', () => {
       }
 
       expect(result.identity).toBeDefined();
-      expect(result.identity).toStrictEqual("justminingfr");
+      expect(result.identity).toStrictEqual("meria");
       expect(result.provider).toStrictEqual("erd1qqqqqqqqqqqqqqqpqqqqqqqqqqqqqqqqqqqqqqqqqqqqq8hlllls7a6h85");
     });
 

--- a/src/test/integration/services/tokens.e2e-spec.ts
+++ b/src/test/integration/services/tokens.e2e-spec.ts
@@ -647,7 +647,7 @@ describe('Token Service', () => {
       const address: string = "erd1qqqqqqqqqqqqqpgq6wegs2xkypfpync8mn2sa5cmpqjlvrhwz5nqgepyg8";
 
       const filter: TokenFilter = new TokenFilter();
-      filter.identifiers = ["WATER-9ed400", "RIDE-7d18e9"];
+      filter.identifiers = ["WEGLD-bd4d79", "RIDE-7d18e9"];
 
       jest
         .spyOn(ElasticService.prototype, 'get')
@@ -659,7 +659,7 @@ describe('Token Service', () => {
 
       expect(results).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ identifier: "WATER-9ed400" }),
+          expect.objectContaining({ identifier: "WEGLD-bd4d79" }),
           expect.objectContaining({ identifier: "RIDE-7d18e9" }),
         ])
       );


### PR DESCRIPTION
## Reasoning
- Inactive observer nodes status was not reflected in node information
- Also, owner was not set for observer nodes
  
## Proposed Changes
- Explicitly handle inactive status from validator statistics
- Resolve owner also for observer node type

## How to test (mainnet)
- `/nodes/586c6642e1f5350d790c9b0067a4fd0f8a49e3c929143fb820634fb412a22bc5100a425bfb7ee269fa047466493cde0a048068ce11680b072b1b1463c65ac4e3ba82615a348cd9d490cc28b0c9ca7832f40a48af7fc0f75139d735b694d73298` should have status `inactive` and `owner` attribute set
