### PR TITLE
Account collection roles endpoint return also where owner

### DIFF
--- a/src/endpoints/esdt/esdt.address.service.ts
+++ b/src/endpoints/esdt/esdt.address.service.ts
@@ -143,9 +143,9 @@ export class EsdtAddressService {
           delete clonedRoles.canTransfer;
 
           Object.assign(collectionWithRoles, clonedRoles);
-
-          collectionsWithRoles.push(collectionWithRoles);
         }
+
+        collectionsWithRoles.push(collectionWithRoles);
       }
     }
 


### PR DESCRIPTION
## Reasoning
- the account collection roles endpoint did not return the ones where the account was only owner and had no special roles attached to it
  
## Proposed Changes
- Push into the collectionWithRoles array regardless of whether the roles tag exists or not

## How to test (devnet)
- `/accounts/erd1wh9c0sjr2xn8hzf02lwwcr4jk2s84tat9ud2kaq6zr7xzpvl9l5q8awmex/roles/collections` should return, among others, the `NEWSFTCOLL-e8fbe1` collection
