### PR TITLE
Token assets TTL fix

### DIFF
--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -191,7 +191,7 @@ export class CacheInfo {
   static EsdtAssets(identifier: string): CacheInfo {
     return {
       key: `esdt:assets:${identifier}`,
-      ttl: Constants.oneDay(),
+      ttl: Constants.oneHour(),
     };
   }
 


### PR DESCRIPTION
## Reasoning
- Token assets refreshed every 24h, meaning every change in assets repo would be reflected after a lot of time
  
## Proposed Changes
- decrease ttl to one hour

## How to test
- make sure the assets are refreshed after 1h when changed in redis
