### PR TITLE
 keybase lookup folder multiversx alongside elrond

### DIFF
--- a/src/common/keybase/keybase.service.ts
+++ b/src/common/keybase/keybase.service.ts
@@ -180,7 +180,7 @@ export class KeybaseService {
       return;
     }
 
-    const html = multiversxResults.data || elrondResults.data;
+    const html = multiversxResults?.data || elrondResults?.data;
 
     const networkRegex = network !== "mainnet" ? `${network}\/` : '';
 


### PR DESCRIPTION
## Reasoning
-  the domain migration from Elrond to MultiversX must have also impact on the github / keybase validations
  
## Proposed Changes
- Lookup `multiversx` folder before looking up `elrond` folder when validating keybase / github

## How to test
- make sure identities with `multiversx` subfolder are fetched
