### PR TITLE
Fix account stake endpoint crash

### DIFF
--- a/src/endpoints/stake/stake.service.ts
+++ b/src/endpoints/stake/stake.service.ts
@@ -175,6 +175,8 @@ export class StakeService {
   }
 
   async getStakeForAddress(address: string) {
+    const hexAddress = AddressUtils.bech32Decode(address);
+
     const [totalStakedEncoded, unStakedTokensListEncoded] = await Promise.all([
       this.vmQueryService.vmQuery(
         this.apiConfigService.getAuctionContractAddress(),
@@ -185,7 +187,7 @@ export class StakeService {
         this.apiConfigService.getAuctionContractAddress(),
         'getUnStakedTokensList',
         address,
-        [AddressUtils.bech32Decode(address)],
+        [hexAddress],
       ),
     ]);
 


### PR DESCRIPTION
## Reasoning
- When the account stake endpoint is called with a certain address parameter bypassing the AddressPipe, the whole nodejs process crashes
  
## Proposed Changes
- Perform the bech32 to hex transform outside Promise.all to avoid a previous Promise to start executing outside Promise.all

## How to test
- to be announced
