### PR TITLE
Handle alternative ES keyword mapping

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -663,9 +663,7 @@ export class ElasticIndexerService implements IndexerInterface {
     const mappingsResult = await this.apiService.get(`${this.apiConfigService.getElasticUrl()}/tokens/_mappings`);
     const mappings = mappingsResult.data?.tokens?.mappings?.properties ?? mappingsResult.data['tokens-000001']?.mappings?.properties;
 
-    const currentOwnerType = mappings?.currentOwner?.type;
-
-    this.indexerV5Active = currentOwnerType === 'keyword';
+    this.indexerV5Active = mappings?.currentOwner?.type === 'keyword' || mappings?.currentOwner?.fields?.keyword?.type === 'keyword';
     return this.indexerV5Active;
   }
 


### PR DESCRIPTION
## Reasoning
- mapping of type `keyword` can also be set inside a `text` mapping, thus `indexerV5Active` was returning false although it was returning true
  
## Proposed Changes
- Handle this situation as well inside the indexer v5 detection algorithm

## How to test
- Test with a mainnet ES with text mappings of type keyword
