### PR TITLE
collection nfts withAssets queryOptions

### DIFF
--- a/src/endpoints/collections/collection.controller.ts
+++ b/src/endpoints/collections/collection.controller.ts
@@ -225,6 +225,7 @@ export class CollectionController {
   @ApiQuery({ name: 'nonceAfter', description: 'Return all NFTs with given nonce after the given number', required: false, type: Number })
   @ApiQuery({ name: 'withOwner', description: 'Return owner where type = NonFungibleESDT', required: false, type: Boolean })
   @ApiQuery({ name: 'withSupply', description: 'Return supply where type = SemiFungibleESDT', required: false, type: Boolean })
+  @ApiQuery({ name: 'withAssets', description: 'Return assets information (defaults to true)', required: false, type: Boolean })
   @ApiQuery({ name: 'sort', description: 'Sorting criteria', required: false, enum: SortCollectionNfts })
   @ApiQuery({ name: 'order', description: 'Sorting order (asc / desc)', required: false, enum: SortOrder })
   async getNfts(
@@ -244,6 +245,7 @@ export class CollectionController {
     @Query('nonceAfter', ParseIntPipe) nonceAfter?: number,
     @Query('withOwner', ParseBoolPipe) withOwner?: boolean,
     @Query('withSupply', ParseBoolPipe) withSupply?: boolean,
+    @Query('withAssets', ParseBoolPipe) withAssets?: boolean,
     @Query('sort', new ParseEnumPipe(SortCollectionNfts)) sort?: SortCollectionNfts,
     @Query('order', new ParseEnumPipe(SortOrder)) order?: SortOrder,
   ): Promise<Nft[]> {
@@ -255,7 +257,7 @@ export class CollectionController {
     return await this.nftService.getNfts(
       new QueryPagination({ from, size }),
       new NftFilter({ search, identifiers, collection, name, tags, creator, hasUris, isWhitelistedStorage, isNsfw, traits, nonceBefore, nonceAfter, sort, order }),
-      new NftQueryOptions({ withOwner, withSupply }),
+      new NftQueryOptions({ withOwner, withSupply, withAssets }),
     );
   }
 

--- a/src/endpoints/nfts/entities/nft.query.options.ts
+++ b/src/endpoints/nfts/entities/nft.query.options.ts
@@ -3,11 +3,16 @@ import { BadRequestException } from "@nestjs/common";
 export class NftQueryOptions {
   constructor(init?: Partial<NftQueryOptions>) {
     Object.assign(this, init);
+
+    if (this.withAssets === undefined) {
+      this.withAssets = true;
+    }
   }
 
   withOwner?: boolean;
   withSupply?: boolean;
   withReceivedAt?: boolean;
+  withAssets?: boolean;
 
   validate(size: number): void {
     if (this.withReceivedAt && size > 25) {

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -70,7 +70,7 @@ export class NftService {
     const nfts = await this.getNftsInternal({ from, size }, filter);
 
     await Promise.all([
-      this.batchApplyAssetsAndTicker(nfts),
+      this.conditionallyApplyAssetsAndTicker(nfts, undefined, queryOptions),
       this.conditionallyApplyOwners(nfts, queryOptions),
       this.conditionallyApplySupply(nfts, queryOptions),
       this.batchProcessNfts(nfts),
@@ -88,8 +88,12 @@ export class NftService {
     ]);
   }
 
-  private async batchApplyAssetsAndTicker(nfts: Nft[], fields?: string[]): Promise<void> {
+  private async conditionallyApplyAssetsAndTicker(nfts: Nft[], fields?: string[], queryOptions?: { withAssets?: boolean }): Promise<void> {
     if (fields && fields.includesNone(['ticker', 'assets'])) {
+      return;
+    }
+
+    if (queryOptions?.withAssets === false) {
       return;
     }
 


### PR DESCRIPTION
## Reasoning
- Collection NFT endpoints were returning massive amounts of asset data by default
- No way to control whether assets should be included in the response

## Proposed Changes
- Added withAssets query parameter to /collections/:collection/nfts endpoint with default value true

Ref: https://github.com/multiversx/mx-api-service/issues/1535#issuecomment-3293073635

## How to test
- Call /collections/EAPES-8f3c1f/nfts?size=2 - should return assets by default
- Call /collections/EAPES-8f3c1f/nfts?size=2&withAssets=false - should exclude assets details
