### PR TITLE
Deprecate relayed v1/v2

### DIFF
--- a/config/config.devnet.yaml
+++ b/config/config.devnet.yaml
@@ -73,6 +73,9 @@ features:
   stakingV5:
     enabled: true
     activationEpoch: 4817
+  deprecatedRelayedV1V2:
+    enabled: true
+    activationEpoch: 4569
   nodeEpochsLeft:
     enabled: false
   transactionProcessor:

--- a/config/config.mainnet.yaml
+++ b/config/config.mainnet.yaml
@@ -71,6 +71,9 @@ features:
   stakingV5:
     enabled: true
     activationEpoch: 1951
+  deprecatedRelayedV1V2:
+    enabled: true
+    activationEpoch: 1918
   nodeEpochsLeft:
     enabled: false
   transactionProcessor:

--- a/config/config.testnet.yaml
+++ b/config/config.testnet.yaml
@@ -70,6 +70,9 @@ features:
   stakingV5:
     enabled: true
     activationEpoch: 2519
+  deprecatedRelayedV1V2:
+    enabled: true
+    activationEpoch: 2038
   nodeEpochsLeft:
     enabled: false
   transactionProcessor:

--- a/src/common/api-config/api.config.service.ts
+++ b/src/common/api-config/api.config.service.ts
@@ -907,6 +907,23 @@ export class ApiConfigService {
     return this.configService.get<number>('features.stakingV5.activationEpoch') ?? 99999;
   }
 
+  isDeprecatedRelayedV1V2Enabled(): boolean {
+    return this.configService.get<boolean>('features.deprecatedRelayedV1V2.enabled') ?? false;
+  }
+
+  getDeprecatedRelayedV1V2ActivationEpoch(): number {
+    return this.configService.get<number>('features.deprecatedRelayedV1V2.activationEpoch') ?? 99999;
+  }
+
+  shouldDeprecateRelayedV1V2(epoch: number): boolean {
+    const isEnabled = this.isDeprecatedRelayedV1V2Enabled();
+    if (!isEnabled) {
+      return false;
+    }
+
+    return epoch >= this.getDeprecatedRelayedV1V2ActivationEpoch();
+  }
+
   isAssetsCdnFeatureEnabled(): boolean {
     return this.configService.get<boolean>('features.assetsFetch.enabled') ?? false;
   }

--- a/src/endpoints/transactions/transaction-action/entities/transaction.action.category.ts
+++ b/src/endpoints/transactions/transaction-action/entities/transaction.action.category.ts
@@ -4,4 +4,5 @@ export enum TransactionActionCategory {
   stake = 'stake',
   scCall = 'scCall',
   scDeploy = 'scDeploy',
+  deprecatedRelayedV1V2 = 'deprecatedRelayedV1V2',
 }

--- a/src/endpoints/transactions/transaction.service.ts
+++ b/src/endpoints/transactions/transaction.service.ts
@@ -42,6 +42,8 @@ import { NetworkService } from 'src/endpoints/network/network.service';
 import { TransactionWithPpu } from './entities/transaction.with.ppu';
 import { GasBucket } from './entities/gas.bucket';
 import { GasBucketConstants } from './constants/gas.bucket.constants';
+import { TransactionAction } from "./transaction-action/entities/transaction.action";
+import { TransactionActionCategory } from "./transaction-action/entities/transaction.action.category";
 
 @Injectable()
 export class TransactionService {
@@ -193,7 +195,6 @@ export class TransactionService {
 
     for (const transaction of transactions) {
       transaction.type = undefined;
-      transaction.relayedVersion = this.extractRelayedVersion(transaction);
     }
 
     await this.processTransactions(transactions, {
@@ -201,6 +202,8 @@ export class TransactionService {
       withUsername: queryOptions?.withUsername ?? false,
       withActionTransferValue: queryOptions?.withActionTransferValue ?? false,
     });
+
+    this.processRelayedInfo(transactions);
 
     return transactions;
   }
@@ -225,9 +228,9 @@ export class TransactionService {
 
     if (transaction !== null) {
       transaction.price = await this.getTransactionPrice(transaction);
-      transaction.relayedVersion = this.extractRelayedVersion(transaction);
 
       await this.processTransactions([transaction], { withScamInfo: true, withUsername: true, withActionTransferValue });
+      this.processRelayedInfo([transaction]);
 
       if (transaction.pendingResults === true && transaction.results) {
         for (const result of transaction.results) {
@@ -344,6 +347,25 @@ export class TransactionService {
       this.logger.error(`Error when fetching transaction price for transaction with hash '${transaction.txHash}'`);
       this.logger.error(error);
       return;
+    }
+  }
+
+  private processRelayedInfo(transactions: TransactionDetailed[]) {
+    for (const transaction of transactions) {
+      transaction.relayedVersion = this.extractRelayedVersion(transaction);
+      if (transaction.relayedVersion && ["v1", "v2"].includes(transaction.relayedVersion)) {
+        const shouldSkip = this.apiConfigService.shouldDeprecateRelayedV1V2(transaction.epoch ?? 0);
+        if (shouldSkip) {
+          transaction.action = new TransactionAction({
+            category: TransactionActionCategory.deprecatedRelayedV1V2,
+            name: "Deprecated transaction action",
+            description: `Relayed v1/v2 transactions are deprecated`,
+          });
+        }
+      }
+      if (!transaction.isRelayed) {
+        transaction.relayedVersion = undefined;
+      }
     }
   }
 
@@ -587,7 +609,7 @@ export class TransactionService {
   }
 
   private extractRelayedVersion(transaction: TransactionDetailed): string | undefined {
-    if (transaction.isRelayed == true && transaction.data) {
+    if (transaction.data) {
       const decodedData = BinaryUtils.base64Decode(transaction.data);
 
       if (decodedData.startsWith('relayedTx@')) {


### PR DESCRIPTION
## Reasoning
- relayed transactions v1/v2 were deprecated but no info/warning was being displayed on explorer or returned via api
  
## Proposed Changes
- added a new transaction action that indicates this and replaces other parsing of the transaction which is not valid

## How to test
- https://devnet-api.multiversx.com/transactions/b378463f86de2db9815068f1c3bbfd0dadfe664df5c96bf3a4375c9daf2f2b6e 
should contain
```
"action": {
    "category": "deprecatedRelayedV1V2",
    "name": "Deprecated transaction action",
    "description": "Relayed v1/v2 transactions are deprecated"
  },
```
but other legit relayed transactions should not. examples (devnet): 
- cb6132311f4835ebcaf63b7bf2f3b687acb172ca6fc8c6514651393d019366eb
- 6416644b42c4b69703fe506e7c7ca6d07cfcf445565dcc5de92c2356b4aef48f
