### PR TITLE
use latest chainsim

### DIFF
--- a/src/test/chain-simulator/docker/docker-compose.yml
+++ b/src/test/chain-simulator/docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   chainsimulator:
     container_name: chainsimulator
-    image: multiversx/chainsimulator:v1.8.4-barnard-test2
+    image: multiversx/chainsimulator:latest
     command: ["--node-override-config", "./overridable-config.toml"]
     volumes:
       - ./overridable-config.toml:/multiversx/overridable-config.toml


### PR DESCRIPTION
## Reasoning
- Previously, we had to use a custom tag for chainsimulator that included all the fixes we needed for e2e tests
- But latest chainsimulator release already includes all the fixes
  
## Proposed Changes
- set `latest` version of chainsimulator

## How to test
- E2E chain simulator tests should pass
