### PR TITLE
fix nft attributes source

### DIFF
--- a/src/common/api-config/mxnest-config-service-impl.service.ts
+++ b/src/common/api-config/mxnest-config-service-impl.service.ts
@@ -25,6 +25,9 @@ export class MxnestConfigServiceImpl implements MxnestConfigService {
   }
 
   getNativeAuthAcceptedOrigins(): string[] {
-    return this.apiConfigService.getNativeAuthAcceptedOrigins();
+    const acceptedOrigins = this.apiConfigService.getNativeAuthAcceptedOrigins();
+    console.log(`Accepted origins are: ${acceptedOrigins}`);
+
+    return acceptedOrigins;
   }
 }

--- a/src/common/api-config/mxnest-config-service-impl.service.ts
+++ b/src/common/api-config/mxnest-config-service-impl.service.ts
@@ -25,9 +25,6 @@ export class MxnestConfigServiceImpl implements MxnestConfigService {
   }
 
   getNativeAuthAcceptedOrigins(): string[] {
-    const acceptedOrigins = this.apiConfigService.getNativeAuthAcceptedOrigins();
-    console.log(`Accepted origins are: ${acceptedOrigins}`);
-
-    return acceptedOrigins;
+    return this.apiConfigService.getNativeAuthAcceptedOrigins();
   }
 }

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -324,12 +324,20 @@ export class NftService {
       return;
     }
 
-    const nftsForAddress = await this.esdtAddressService.getNftsForAddress(nft.owner, new NftFilter({ identifiers: [nft.identifier] }), new QueryPagination({ from: 0, size: 1 }));
-    if (nftsForAddress.length === 0) {
-      return;
+    let attributes = nft.attributes;
+    if (!attributes || attributes.length === 0) {
+      const nftsForAddress = await this.esdtAddressService.getNftsForAddress(nft.owner, new NftFilter({identifiers: [nft.identifier]}), new QueryPagination({
+        from: 0,
+        size: 1
+      }));
+      if (nftsForAddress.length === 0) {
+        return;
+      }
+
+      attributes = nftsForAddress[0].attributes;
     }
 
-    nft.attributes = nftsForAddress[0].attributes;
+    nft.attributes = attributes;
   }
 
   private async applyMedia(nft: Nft) {

--- a/src/endpoints/nfts/nft.service.ts
+++ b/src/endpoints/nfts/nft.service.ts
@@ -328,7 +328,7 @@ export class NftService {
     if (!attributes || attributes.length === 0) {
       const nftsForAddress = await this.esdtAddressService.getNftsForAddress(nft.owner, new NftFilter({identifiers: [nft.identifier]}), new QueryPagination({
         from: 0,
-        size: 1
+        size: 1,
       }));
       if (nftsForAddress.length === 0) {
         return;

--- a/src/endpoints/process-nfts/process.nfts.service.ts
+++ b/src/endpoints/process-nfts/process.nfts.service.ts
@@ -97,6 +97,9 @@ export class ProcessNftsService {
   }
 
   private async isCollectionOwner(address: string, collection: string): Promise<boolean> {
+    if (this.apiConfigService.getSecurityAdmins().includes(address)) {
+      return true;
+    }
     const collectionOwner = await this.getCollectionNonScOwner(collection);
 
     return address === collectionOwner;


### PR DESCRIPTION
## Reasoning
- In case of dynamic NFTs, the attributes should be fetched from the ES `tokens` index rather than `accountsesdt`
  
## Proposed Changes
- If the `attributes` field from `tokens` index isn't empty, then use it, instead of trying to fetch it from `accountsesdt`

## How to test
- 
- 
- 
