### PR TITLE
Add support for custom transfers metrics

### DIFF
--- a/src/crons/websocket/websocket.cron.service.ts
+++ b/src/crons/websocket/websocket.cron.service.ts
@@ -179,6 +179,7 @@ export class WebsocketCronService implements OnModuleInit {
       { key: 'customTx', prefix: TransactionsCustomGateway.keyPrefix },
       { key: 'events', prefix: EventsGateway.keyPrefix },
       { key: 'customEvents', prefix: EventsCustomGateway.keyPrefix },
+      { key: 'customTransfers', prefix: TransfersCustomGateway.keyPrefix },
       { key: 'blocks', prefix: BlocksGateway.keyPrefix },
       { key: 'pool', prefix: PoolGateway.keyPrefix },
       { key: 'stats', room: 'statsRoom' },


### PR DESCRIPTION
## Reasoning
- custom transfers subscription doesn't appear in grafana metrics
  
## Proposed Changes
- add support for custom transfers metrics 

## How to test
- should appear on grafana