### PR TITLE
Supernova execution results mb

### DIFF
--- a/src/common/gateway/entities/gateway.component.request.ts
+++ b/src/common/gateway/entities/gateway.component.request.ts
@@ -1,5 +1,7 @@
 export enum GatewayComponentRequest {
   networkConfig = 'networkConfig',
+  networkEnableEpochs = 'networkEnableEpochs',
+  networkEnableEpochsV2 = 'networkEnableEpochsV2',
   networkStatus = 'networkStatus',
   networkEsdt = 'networkEsdt',
   networkEconomics = 'networkEconomics',

--- a/src/common/gateway/gateway.service.ts
+++ b/src/common/gateway/gateway.service.ts
@@ -91,6 +91,16 @@ export class GatewayService {
     });
   }
 
+  async getNetworkEnableEpochs(): Promise<Record<string,number>> {
+    const result = await this.get(`network/enable-epochs`, GatewayComponentRequest.networkEnableEpochs);
+    return result.enableEpochs;
+  }
+
+  async getNetworkEnableEpochsV2(): Promise<Record<string,number>> {
+    const result = await this.get(`network/enable-epochs-v2`, GatewayComponentRequest.networkEnableEpochsV2);
+    return result.enableEpochs;
+  }
+
   async getAddressDetails(address: string): Promise<Account> {
     const result = await this.get(`address/${address}`, GatewayComponentRequest.addressDetails);
     return result;

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -251,6 +251,10 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getItem('blocks', 'hash', hash);
   }
 
+  async getExecutionResults(hash: string): Promise<Block> {
+    return await this.elasticService.getItem('executionresults', 'hash', hash);
+  }
+
   async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
     const elasticQuery = ElasticQuery.create()
       .withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlocksHashes', miniBlockHash)])

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -74,6 +74,8 @@ export interface IndexerInterface {
 
   getBlock(hash: string): Promise<Block>
 
+  getExecutionResults(hash: string): Promise<Block>
+
   getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined>
 
   getMiniBlock(miniBlockHash: string): Promise<MiniBlock>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -168,7 +168,7 @@ export class IndexerService implements IndexerInterface {
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getExecutionResults(hash: string): Promise<Block> {
-    return await this.indexerInterface.getBlock(hash);
+    return await this.indexerInterface.getExecutionResults(hash);
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -167,6 +167,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getExecutionResults(hash: string): Promise<Block> {
+    return await this.indexerInterface.getBlock(hash);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
     return await this.indexerInterface.getBlockByMiniBlockHash(miniBlockHash);
   }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -131,7 +131,7 @@ export class BlockService {
         result.proposer = publicKeys[result.proposer];
       }
       if (!isChainAndromedaEnabled) {
-        result.validators = result.validators.map((validator: number) => publicKeys[validator]);
+        result.validators = result.validators?.map((validator: number) => publicKeys[validator]);
       } else {
         result.validators = publicKeys;
       }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -182,8 +182,8 @@ export class BlockService {
   async getNetworkEnableEpochs(): Promise<Record<string, number>> {
     return await this.cachingService.getOrSet(
       CacheInfo.NetworkEnableEpochs.key,
-      async () => this.gatewayService.getNetworkEnableEpochs(),
+      async () => await this.gatewayService.getNetworkEnableEpochs(),
       CacheInfo.NetworkEnableEpochs.ttl,
-    )
+    );
   }
 }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -12,6 +12,7 @@ import { IdentitiesService } from "../identities/identities.service";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { ConcurrencyUtils } from "src/utils/concurrency.utils";
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
+import { GatewayService } from "../../common/gateway/gateway.service";
 
 @Injectable()
 export class BlockService {
@@ -24,6 +25,7 @@ export class BlockService {
     @Inject(forwardRef(() => IdentitiesService))
     private readonly identitiesService: IdentitiesService,
     private readonly apiConfigService: ApiConfigService,
+    private readonly gatewayService: GatewayService,
   ) { }
 
   async getBlocksCount(filter: BlockFilter): Promise<number> {
@@ -115,7 +117,8 @@ export class BlockService {
     const isChainAndromedaEnabled = this.apiConfigService.isChainAndromedaEnabled()
       && result.epoch >= this.apiConfigService.getChainAndromedaActivationEpoch();
 
-    const isSupernovaEnabled = result.epoch >= await this.getSupernovaEnableEpoch();
+    const supernovaEnableEpoch = await this.getSupernovaEnableEpoch();
+    const isSupernovaEnabled = supernovaEnableEpoch !== -1 && result.epoch >= supernovaEnableEpoch;
     if (isSupernovaEnabled) {
       const executionResults = await this.indexerService.getExecutionResults(hash);
       if (executionResults) {
@@ -172,7 +175,15 @@ export class BlockService {
   }
 
   async getSupernovaEnableEpoch(): Promise<number> {
-    // TODO: fetch it from proxy /network/enable-epochs -> erd_supernova_enable_epoch
-    return await Promise.resolve(2);
+    const enableEpochs = await this.getNetworkEnableEpochs();
+    return enableEpochs["erd_supernova_enable_epoch"] ?? -1;
+  }
+
+  async getNetworkEnableEpochs(): Promise<Record<string, number>> {
+    return await this.cachingService.getOrSet(
+      CacheInfo.NetworkEnableEpochs.key,
+      async () => this.gatewayService.getNetworkEnableEpochs(),
+      CacheInfo.NetworkEnableEpochs.ttl,
+    )
   }
 }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -11,6 +11,7 @@ import { NodeService } from "../nodes/node.service";
 import { IdentitiesService } from "../identities/identities.service";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { ConcurrencyUtils } from "src/utils/concurrency.utils";
+import { ApiUtils } from "@multiversx/sdk-nestjs-http";
 
 @Injectable()
 export class BlockService {
@@ -109,10 +110,18 @@ export class BlockService {
   }
 
   async getBlock(hash: string): Promise<BlockDetailed> {
-    const result = await this.indexerService.getBlock(hash) as any;
+    let result = await this.indexerService.getBlock(hash) as any;
 
     const isChainAndromedaEnabled = this.apiConfigService.isChainAndromedaEnabled()
       && result.epoch >= this.apiConfigService.getChainAndromedaActivationEpoch();
+
+    const isSupernovaEnabled = result.epoch >= await this.getSupernovaEnableEpoch();
+    if (isSupernovaEnabled) {
+      const executionResults = await this.indexerService.getExecutionResults(hash);
+      if (executionResults) {
+        result = ApiUtils.mergeObjects(result, executionResults);
+      }
+    }
 
     if (result.round > 0) {
       const publicKeys = await this.blsService.getPublicKeys(result.shardId, result.epoch);
@@ -160,5 +169,10 @@ export class BlockService {
       return undefined;
     }
     return blocks[0];
+  }
+
+  async getSupernovaEnableEpoch(): Promise<number> {
+    // TODO: fetch it from proxy /network/enable-epochs -> erd_supernova_enable_epoch
+    return await Promise.resolve(2);
   }
 }

--- a/src/endpoints/proxy/gateway.proxy.controller.ts
+++ b/src/endpoints/proxy/gateway.proxy.controller.ts
@@ -233,6 +233,16 @@ export class GatewayProxyController {
     return await this.gatewayGet('network/config', GatewayComponentRequest.networkConfig);
   }
 
+  @Get('/network/enable-epochs')
+  async getNetworkEnableEpochs() {
+    return await this.gatewayGet('network/enable-epochs', GatewayComponentRequest.networkEnableEpochs);
+  }
+
+  @Get('/network/enable-epochs-v2')
+  async getNetworkEnabledEpochsV2() {
+    return await this.gatewayGet('network/enable-epochs-v2', GatewayComponentRequest.networkEnableEpochsV2);
+  }
+
   @Get('/network/economics')
   async getNetworkEconomics() {
     return await this.gatewayGet('network/economics', GatewayComponentRequest.networkEconomics);

--- a/src/test/unit/services/blocks.spec.ts
+++ b/src/test/unit/services/blocks.spec.ts
@@ -11,6 +11,7 @@ import { NodeService } from "src/endpoints/nodes/node.service";
 import { CacheInfo } from "src/utils/cache.info";
 import { BlockProofDto } from "../../../endpoints/blocks/entities/block.proof";
 import { ApiConfigService } from "../../../common/api-config/api.config.service";
+import { GatewayService } from "../../../common/gateway/gateway.service";
 
 describe('Block Service', () => {
   let blockService: BlockService;
@@ -63,6 +64,12 @@ describe('Block Service', () => {
           useValue: {
             isChainAndromedaEnabled: jest.fn(),
             getChainAndromedaActivationEpoch: jest.fn(),
+          },
+        },
+        {
+          provide: GatewayService,
+          useValue: {
+            getNetworkEnableEpochs: jest.fn(),
           },
         },
       ],

--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -418,6 +418,11 @@ export class CacheInfo {
     ttl: Constants.oneMinute() * 10,
   };
 
+  static NetworkEnableEpochs: CacheInfo = {
+    key: "networkEnableEpochs",
+    ttl: Constants.oneHour() * 10,
+  };
+
   static MexPairs: CacheInfo = {
     key: "mexPairs",
     ttl: Constants.oneMinute() * 10,


### PR DESCRIPTION
## Reasoning
- starting with supernova, the miniblock details + other items should be fetched from a new Elasticsearch index named `executionresults`
  
## Proposed Changes
- fetch new data from the new index
- merge the 2 objects (the execution results block has a better prio)
- add support for gateway enable epochs endpoints
- check if supernova flag exists and is activated 
