### PR TITLE
add new supernova fields

### DIFF
--- a/src/endpoints/blocks/entities/block.ts
+++ b/src/endpoints/blocks/entities/block.ts
@@ -74,6 +74,12 @@ export class Block {
   @ApiProperty({ type: String })
   reserved: string = '';
 
+  @ApiProperty({ type: String })
+  lastExecutionResultHash: string = '';
+
+  @ApiProperty({ type: Number })
+  lastExecutionResultNonce: number = 0;
+
   @ApiProperty({ type: BlockProofDto, nullable: true, required: false })
   proof: BlockProofDto | undefined = undefined;
 

--- a/src/test/unit/services/blocks.spec.ts
+++ b/src/test/unit/services/blocks.spec.ts
@@ -146,6 +146,8 @@ describe('Block Service', () => {
       reserved: '',
       scheduledRootHash: undefined,
       proof: undefined,
+      lastExecutionResultHash: '414d526161587ae9f53453aa0392971272c48dbb3cc54a33448972d388e0deeb',
+      lastExecutionResultNonce: 14553814,
       previousHeaderProof: new BlockProofDto({
         pubKeysBitmap: '7702',
         aggregatedSignature: '50224d66a42a019991d16f25dba375b581f279d4394d4c254876c1484f61bed90fb20456f8af107c54e4eed1763e2a92',


### PR DESCRIPTION
## Reasoning
- starting with supernova, new fields are added to the block elasticsearch entity
  
## Proposed Changes
- add `lastExecutionResultHash` and `lastExecutionResultNonce` fields

## How to test
- 
- 
- 
