### PR TITLE
Executionresults blocks list

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -264,7 +264,6 @@ export class ElasticIndexerService implements IndexerInterface {
       .withPagination({ from: 0, size: hashes.length + 1 })
       .withShouldCondition(hashes.map(h => QueryType.Match('_id', h)));
 
-    // Map _id into "hash" on the response objects for easy joining
     return await this.elasticService.getList('executionresults', 'hash', elasticQuery);
   }
 

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -255,6 +255,19 @@ export class ElasticIndexerService implements IndexerInterface {
     return await this.elasticService.getItem('executionresults', 'hash', hash);
   }
 
+  async getExecutionResultsForHashes(hashes: string[]): Promise<Block[]> {
+    if (!hashes || hashes.length === 0) {
+      return [];
+    }
+
+    const elasticQuery = ElasticQuery.create()
+      .withPagination({ from: 0, size: hashes.length + 1 })
+      .withShouldCondition(hashes.map(h => QueryType.Match('_id', h)));
+
+    // Map _id into "hash" on the response objects for easy joining
+    return await this.elasticService.getList('executionresults', 'hash', elasticQuery);
+  }
+
   async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
     const elasticQuery = ElasticQuery.create()
       .withCondition(QueryConditionOptions.must, [QueryType.Match('miniBlocksHashes', miniBlockHash)])

--- a/src/common/indexer/indexer.interface.ts
+++ b/src/common/indexer/indexer.interface.ts
@@ -76,6 +76,8 @@ export interface IndexerInterface {
 
   getExecutionResults(hash: string): Promise<Block>
 
+  getExecutionResultsForHashes(hashes: string[]): Promise<Block[]>
+
   getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined>
 
   getMiniBlock(miniBlockHash: string): Promise<MiniBlock>

--- a/src/common/indexer/indexer.service.ts
+++ b/src/common/indexer/indexer.service.ts
@@ -172,6 +172,11 @@ export class IndexerService implements IndexerInterface {
   }
 
   @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
+  async getExecutionResultsForHashes(hashes: string[]): Promise<Block[]> {
+    return await this.indexerInterface.getExecutionResultsForHashes(hashes);
+  }
+
+  @LogPerformanceAsync(MetricsEvents.SetIndexerDuration)
   async getBlockByMiniBlockHash(miniBlockHash: string): Promise<Block | undefined> {
     return await this.indexerInterface.getBlockByMiniBlockHash(miniBlockHash);
   }

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -42,13 +42,12 @@ export class BlockService {
   async getBlocks(filter: BlockFilter, queryPagination: QueryPagination, withProposerIdentity?: boolean): Promise<Block[]> {
     const result = await this.indexerService.getBlocks(filter, queryPagination);
 
-    // If Supernova is enabled for any of these blocks, bulk fetch execution results and merge them
-    const execMap = await this.fetchExecutionResultsForBlocks(result as any[]);
-    if (execMap.size > 0) {
+    const executionResultsMap = await this.fetchExecutionResultsForBlocks(result as any[]);
+    if (executionResultsMap.size > 0) {
       for (const item of result as any[]) {
-        const er = execMap.get(item.hash);
-        if (er) {
-          ApiUtils.mergeObjects(item, er);
+        const executionResult = executionResultsMap.get(item.hash);
+        if (executionResult) {
+          ApiUtils.mergeObjects(item, executionResult);
         }
       }
     }
@@ -102,7 +101,6 @@ export class BlockService {
       }
       this.logger.log(`Applied executionresults for ${map.size} blocks out of ${eligible.length}.`);
     } catch {
-      // Keep endpoint resilient if executionresults index is unavailable
       return map;
     }
 

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -12,10 +12,13 @@ import { IdentitiesService } from "../identities/identities.service";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { ConcurrencyUtils } from "src/utils/concurrency.utils";
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
+import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { GatewayService } from "../../common/gateway/gateway.service";
 
 @Injectable()
 export class BlockService {
+  private readonly logger = new OriginLogger(BlockService.name);
+
   constructor(
     private readonly indexerService: IndexerService,
     private readonly cachingService: CacheService,
@@ -39,6 +42,17 @@ export class BlockService {
   async getBlocks(filter: BlockFilter, queryPagination: QueryPagination, withProposerIdentity?: boolean): Promise<Block[]> {
     const result = await this.indexerService.getBlocks(filter, queryPagination);
 
+    // If Supernova is enabled for any of these blocks, bulk fetch execution results and merge them
+    const execMap = await this.fetchExecutionResultsForBlocks(result as any[]);
+    if (execMap.size > 0) {
+      for (const item of result as any[]) {
+        const er = execMap.get(item.hash);
+        if (er) {
+          ApiUtils.mergeObjects(item, er);
+        }
+      }
+    }
+
     const blocks = await Promise.all(result.map(async (item) => {
       const blockRaw = await this.computeProposerAndValidators(item);
 
@@ -56,6 +70,43 @@ export class BlockService {
     }
 
     return blocks;
+  }
+
+  private async fetchExecutionResultsForBlocks(items: any[]): Promise<Map<string, any>> {
+    const map = new Map<string, any>();
+    if (!items || items.length === 0) {
+      return map;
+    }
+
+    const supernovaEnableEpoch = await this.getSupernovaEnableEpoch();
+    if (supernovaEnableEpoch === -1) {
+      return map;
+    }
+
+    const eligible = items.filter((r: any) => (r?.epoch ?? -1) >= supernovaEnableEpoch);
+    if (eligible.length === 0) {
+      return map;
+    }
+
+    const hashes = eligible.map((r: any) => r.hash).filter(Boolean);
+    if (hashes.length === 0) {
+      return map;
+    }
+
+    try {
+      const executionResults = await this.indexerService.getExecutionResultsForHashes(hashes);
+      for (const er of executionResults as any[]) {
+        if (er?.hash) {
+          map.set(er.hash, er);
+        }
+      }
+      this.logger.log(`Applied executionresults for ${map.size} blocks out of ${eligible.length}.`);
+    } catch {
+      // Keep endpoint resilient if executionresults index is unavailable
+      return map;
+    }
+
+    return map;
   }
 
   private async applyProposerIdentity(blocks: Block[]): Promise<void> {
@@ -176,7 +227,7 @@ export class BlockService {
 
   async getSupernovaEnableEpoch(): Promise<number> {
     const enableEpochs = await this.getNetworkEnableEpochs();
-    return enableEpochs["erd_supernova_enable_epoch"] ?? -1;
+    return enableEpochs?.["erd_supernova_enable_epoch"] ?? -1;
   }
 
   async getNetworkEnableEpochs(): Promise<Record<string, number>> {

--- a/src/endpoints/blocks/block.service.ts
+++ b/src/endpoints/blocks/block.service.ts
@@ -12,13 +12,10 @@ import { IdentitiesService } from "../identities/identities.service";
 import { ApiConfigService } from "../../common/api-config/api.config.service";
 import { ConcurrencyUtils } from "src/utils/concurrency.utils";
 import { ApiUtils } from "@multiversx/sdk-nestjs-http";
-import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { GatewayService } from "../../common/gateway/gateway.service";
 
 @Injectable()
 export class BlockService {
-  private readonly logger = new OriginLogger(BlockService.name);
-
   constructor(
     private readonly indexerService: IndexerService,
     private readonly cachingService: CacheService,
@@ -99,7 +96,6 @@ export class BlockService {
           map.set(er.hash, er);
         }
       }
-      this.logger.log(`Applied executionresults for ${map.size} blocks out of ${eligible.length}.`);
     } catch {
       return map;
     }


### PR DESCRIPTION
## Reasoning
- the `executionresults` fields merging was only done for single blocks
  
## Proposed Changes
- fetch `executionresults` for a list of block and apply new field where possible
- performed in bulk operations to keep the number of ES calls low

## How to test
- 
- 
- 
