### PR TITLE
update cache for network enable epochs

### DIFF
--- a/src/utils/cache.info.ts
+++ b/src/utils/cache.info.ts
@@ -419,8 +419,8 @@ export class CacheInfo {
   };
 
   static NetworkEnableEpochs: CacheInfo = {
-    key: "networkEnableEpochs",
-    ttl: Constants.oneHour() * 10,
+    key: "gatewayNetworkEnableEpochs",
+    ttl: Constants.oneMinute() * 5,
   };
 
   static MexPairs: CacheInfo = {


### PR DESCRIPTION
## Reasoning
- a too long TTL of 10 hours made some testing environments cache pre-supernova enable epochs
  
## Proposed Changes
- update the enable epochs cache

## How to test
- the `miniblocks` field of the blocks should contain the execution results, rather than the proposed miniblocks. 
