### PR TITLE
override dapp config chain id from network config

### DIFF
--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -22,15 +22,20 @@ export class DappConfigService {
 
     const networkConfig = await this.gatewayService.getNetworkConfig();
     const refreshRate = networkConfig.erd_round_duration;
+    const chainId = networkConfig.erd_chain_id;
 
-    if (refreshRate) {
-      return {
-        ...this.dappConfig,
-        refreshRate,
-      };
+    const overrides: Partial<DappConfig> = {};
+    if (refreshRate !== undefined && refreshRate !== null) {
+      overrides.refreshRate = refreshRate;
+    }
+    if (chainId) {
+      overrides.chainId = chainId;
     }
 
-    return this.dappConfig;
+    return {
+      ...this.dappConfig,
+      ...overrides,
+    };
   }
 
   getDappConfigurationRaw(): DappConfig | undefined {

--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -25,10 +25,10 @@ export class DappConfigService {
     const chainId = networkConfig.erd_chain_id;
 
     const overrides: Partial<DappConfig> = {};
-    if (refreshRate !== undefined && refreshRate !== null) {
+    if (refreshRate != null) {
       overrides.refreshRate = refreshRate;
     }
-    if (chainId) {
+    if (chainId != null) {
       overrides.chainId = chainId;
     }
 


### PR DESCRIPTION
## Reasoning
- chain ID was static in the dapp config files
  
## Proposed Changes
- update it continuously via the values from the network config 

## How to test
- `localhost:3001/dapp/config` should reflect network value, rather the configured one in the json file
