### PR TITLE
hardcode bon dapp config

### DIFF
--- a/src/endpoints/dapp-config/dapp.config.service.ts
+++ b/src/endpoints/dapp-config/dapp.config.service.ts
@@ -25,6 +25,16 @@ export class DappConfigService {
     const chainId = networkConfig.erd_chain_id;
 
     const overrides: Partial<DappConfig> = {};
+
+    //TODO: remove after battle of nodes
+    if (chainId === 'B') {
+      overrides.walletAddress = "https://bon-wallet.multiversx.com";
+      overrides.apiAddress = "https://api.battleofnodes.com";
+      overrides.explorerAddress = "https://bon-explorer.multiversx.com";
+      overrides.id = "bon";
+      overrides.name = "BattleOfNodes";
+    }
+
     if (refreshRate != null) {
       overrides.refreshRate = refreshRate;
     }


### PR DESCRIPTION
## Reasoning
- /dapp/config returns mainnet data on bon network
  
## Proposed Changes
- hardcode bon confings when chain id returned by gateway is "B"

## How to test
- /dapp/config should return bon configs when bon env is used
