### PR TITLE
fix elastic searching

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -99,16 +99,7 @@ export class ElasticIndexerHelper {
       ));
     }
 
-    if (filter.before || filter.after) {
-      if (filter.before) {
-        const timestampBeforeIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-        elasticQuery = elasticQuery.withRangeFilter(timestampBeforeIdentifier, new RangeLowerThanOrEqual(filter.before));
-      }
-      if (filter.after) {
-        const timestampAfterIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-        elasticQuery = elasticQuery.withRangeFilter(timestampAfterIdentifier, new RangeGreaterThanOrEqual(filter.after));
-      }
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     if (filter.canCreate !== undefined) {
       elasticQuery = this.getRoleCondition(elasticQuery, 'ESDTRoleNFTCreate', address, filter.canCreate);
@@ -175,6 +166,38 @@ export class ElasticIndexerHelper {
     const targetAddress = typeof value === 'string' ? value : address;
 
     return query.withCondition(condition, QueryType.Nested('roles', [new MatchQuery(`roles.${name}`, targetAddress)]));
+  }
+
+  private applyTimestampRangeFilter(query: ElasticQuery, before?: number, after?: number): ElasticQuery {
+    if (before === undefined && after === undefined) {
+      return query;
+    }
+
+    const legacyMustQueries: AbstractQuery[] = [];
+    const modernMustQueries: AbstractQuery[] = [QueryType.Exists('timestampMs')];
+
+    if (before !== undefined) {
+      legacyMustQueries.push(QueryType.Range('timestamp', new RangeLowerThanOrEqual(this.toTimestampSeconds(before))));
+      modernMustQueries.push(QueryType.Range('timestampMs', new RangeLowerThanOrEqual(this.toTimestampMilliseconds(before))));
+    }
+
+    if (after !== undefined) {
+      legacyMustQueries.push(QueryType.Range('timestamp', new RangeGreaterThanOrEqual(this.toTimestampSeconds(after))));
+      modernMustQueries.push(QueryType.Range('timestampMs', new RangeGreaterThanOrEqual(this.toTimestampMilliseconds(after))));
+    }
+
+    return query.withMustCondition(QueryType.Should([
+      QueryType.Must(modernMustQueries),
+      QueryType.Must(legacyMustQueries, [QueryType.Exists('timestampMs')]),
+    ]));
+  }
+
+  private toTimestampSeconds(value: number): number {
+    return TimeUtils.isTimestampInSeconds(value) ? value : Math.floor(value / 1000);
+  }
+
+  private toTimestampMilliseconds(value: number): number {
+    return TimeUtils.isTimestampInSeconds(value) ? value * 1000 : value;
   }
 
   public buildElasticNftFilter(filter: NftFilter, identifier?: string, address?: string): ElasticQuery {
@@ -286,14 +309,7 @@ export class ElasticIndexerHelper {
       }
     }
 
-    if (filter.before) {
-      const timestampBeforeIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampBeforeIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
-    if (filter.after) {
-      const timestampAfterIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampAfterIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     if (filter.nonceBefore) {
       elasticQuery = elasticQuery.withRangeFilter('nonce', new RangeLowerThanOrEqual(filter.nonceBefore));
@@ -421,14 +437,7 @@ export class ElasticIndexerHelper {
       elasticQuery = elasticQuery.withCondition(QueryConditionOptions.must, QueryType.Match('status', filter.status));
     }
 
-    if (filter.before) {
-      const timestampBeforeIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampBeforeIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
-    if (filter.after) {
-      const timestampAfterIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampAfterIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     if (filter.senderOrReceiver) {
       elasticQuery = elasticQuery
@@ -572,14 +581,7 @@ export class ElasticIndexerHelper {
       .withMustMatchCondition('status', filter.status)
       .withMustMultiShouldCondition(filter.tokens, token => QueryType.Match('tokens', token, QueryOperator.AND));
 
-    if (filter.before) {
-      const timestampBeforeIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampBeforeIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
-    if (filter.after) {
-      const timestampAfterIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampAfterIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     if (filter.functions && filter.functions.length > 0) {
       if (filter.functions.length === 1 && filter.functions[0] === '') {
@@ -684,14 +686,7 @@ export class ElasticIndexerHelper {
 
     let elasticQuery = ElasticQuery.create().withCondition(QueryConditionOptions.must, mustQueries);
 
-    if (filter && filter.before) {
-      const timestampBeforeIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampBeforeIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
-    if (filter && filter.after) {
-      const timestampAfterIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampAfterIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter?.before, filter?.after);
 
     if (filter && filter.identifiers) {
       elasticQuery = elasticQuery.withMustCondition(QueryType.Should(
@@ -794,15 +789,7 @@ export class ElasticIndexerHelper {
   buildApplicationFilter(filter: ApplicationFilter): ElasticQuery {
     let elasticQuery = ElasticQuery.create();
 
-    if (filter.after) {
-      const timestampIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
-
-    if (filter.before) {
-      const timestampIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     return elasticQuery;
   }
@@ -823,15 +810,7 @@ export class ElasticIndexerHelper {
   public buildEventsFilter(filter: EventsFilter): ElasticQuery {
     let elasticQuery = ElasticQuery.create();
 
-    if (filter.before) {
-      const timestampIdentifier = TimeUtils.isTimestampInSeconds(filter.before) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampIdentifier, new RangeLowerThanOrEqual(filter.before));
-    }
-
-    if (filter.after) {
-      const timestampIdentifier = TimeUtils.isTimestampInSeconds(filter.after) ? 'timestamp' : 'timestampMs';
-      elasticQuery = elasticQuery.withRangeFilter(timestampIdentifier, new RangeGreaterThanOrEqual(filter.after));
-    }
+    elasticQuery = this.applyTimestampRangeFilter(elasticQuery, filter.before, filter.after);
 
     if (filter.identifier) {
       elasticQuery = elasticQuery.withMustMatchCondition('identifier', filter.identifier);

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -1065,8 +1065,8 @@ export class ElasticIndexerService implements IndexerInterface {
       .withMustCondition(timestampQuery)
       .withCondition(QueryConditionOptions.must, [QueryType.Match('shardId', shardId, QueryOperator.AND)])
       .withSort([
-        { name: 'timestampMs', order: ElasticSortOrder.ascending },
         { name: 'timestamp', order: ElasticSortOrder.ascending },
+        { name: 'timestampMs', order: ElasticSortOrder.ascending },
       ]);
 
     const blocks: Block[] = await this.elasticService.getList('blocks', '_search', elasticQuery);

--- a/src/common/indexer/elastic/elastic.indexer.service.ts
+++ b/src/common/indexer/elastic/elastic.indexer.service.ts
@@ -1048,11 +1048,26 @@ export class ElasticIndexerService implements IndexerInterface {
   }
 
   async getBlockByTimestampAndShardId(timestamp: number, shardId: number): Promise<Block | undefined> {
-    const timestampIdentifier = TimeUtils.isTimestampInSeconds(timestamp) ? 'timestamp' : 'timestampMs';
+    const timestampInSeconds = TimeUtils.isTimestampInSeconds(timestamp) ? timestamp : Math.floor(timestamp / 1000);
+    const timestampInMilliseconds = TimeUtils.isTimestampInSeconds(timestamp) ? timestamp * 1000 : timestamp;
+
+    const timestampQuery = QueryType.Should([
+      QueryType.Must([
+        QueryType.Exists('timestampMs'),
+        QueryType.Range('timestampMs', new RangeGreaterThanOrEqual(timestampInMilliseconds)),
+      ]),
+      QueryType.Must([
+        QueryType.Range('timestamp', new RangeGreaterThanOrEqual(timestampInSeconds)),
+      ], [QueryType.Exists('timestampMs')]),
+    ]);
+
     const elasticQuery = ElasticQuery.create()
-      .withRangeFilter(timestampIdentifier, new RangeGreaterThanOrEqual(timestamp))
+      .withMustCondition(timestampQuery)
       .withCondition(QueryConditionOptions.must, [QueryType.Match('shardId', shardId, QueryOperator.AND)])
-      .withSort([{ name: 'timestamp', order: ElasticSortOrder.ascending }]);
+      .withSort([
+        { name: 'timestampMs', order: ElasticSortOrder.ascending },
+        { name: 'timestamp', order: ElasticSortOrder.ascending },
+      ]);
 
     const blocks: Block[] = await this.elasticService.getList('blocks', '_search', elasticQuery);
 


### PR DESCRIPTION
## Reasoning
- We found an edge case in transactions timeframe filtering when combining `after` and `before` across legacy and modern data.
- Specifically, if `after` pointed to an older period (legacy docs using `timestamp`) and `before` pointed to a newer period (docs using `timestampMs`), queries could miss results when the dataset in that interval contained only documents without `timestampMs`.
- In that scenario, legacy documents were unintentionally excluded because the mixed condition favored the modern path in a way that did not consistently preserve fallback behavior.

## Proposed Changes
- Normalize timeframe filtering to first query by `timestampMs` when present.
- Keep explicit fallback to `timestamp` for documents that do not have `timestampMs`.
- Apply the same priority/fallback approach consistently so mixed historical ranges return both modern and legacy documents correctly.

## How to test
- Query a range that includes mixed data (documents with and without `timestampMs`) and verify results are still returned correctly.
- Validate ordering for block lookup: records with `timestampMs` should be sorted by `timestampMs`, with legacy records correctly ordered via `timestamp`.
- Run the existing lint/type checks (or targeted tests for indexer queries) and confirm no regressions.