### PR TITLE
Upgrade cs e2e elastic version

### DIFF
--- a/.github/workflows/chain-simulator-e2e-tests.yml
+++ b/.github/workflows/chain-simulator-e2e-tests.yml
@@ -25,6 +25,10 @@ jobs:
       - name: Build and start chain simulator
         run: npm run start-chain-simulator
 
+      - name: Show logs if chain simulator fails to start
+        if: failure()
+        run: docker logs es-container && docker logs chainsimulator
+
       - name: Wait for services to be ready
         run: |
           echo "Waiting for services to be healthy..."

--- a/src/test/chain-simulator/docker/docker-compose.yml
+++ b/src/test/chain-simulator/docker/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     ports:
       - "9200:9200"
     container_name: es-container
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.16.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.18
     environment:
       - "discovery.type=single-node"
       - "xpack.security.enabled=false"

--- a/src/test/chain-simulator/websocket.subscriptions.cs-e2e.ts
+++ b/src/test/chain-simulator/websocket.subscriptions.cs-e2e.ts
@@ -207,7 +207,7 @@ describe('Websocket subscriptions e2e tests', () => {
       await axios.post(`${config.chainSimulatorUrl}/simulator/generate-blocks/10`);
 
       log("Waiting for WS messages...");
-      await new Promise(resolve => setTimeout(resolve, 20000));
+      await new Promise(resolve => setTimeout(resolve, 30000));
 
     } catch (e: any) {
       console.error("Error in beforeAll:", e.message);


### PR DESCRIPTION
## Reasoning
- The CI/CD pipeline (GitHub Actions) was failing to start the test environment because the Elasticsearch container was crashing instantly upon initialization (`exited (1)`).
- The root cause was an incompatibility issue (a `NullPointerException` related to `cgroup v2`) between the older Java version bundled with Elasticsearch 7.16.1 and the modern operating systems used by GitHub Actions runners (e.g., `ubuntu-latest`).
- Debugging Docker errors in the automated environment was difficult due to the lack of explicit logs when containers failed.

## Proposed Changes
- Updated the Elasticsearch image version in `docker-compose.yml` from `7.16.1` to `7.17.18`. This minor version update resolves the `cgroup v2` compatibility issue without affecting the application's functionality.
- Added a fallback step (`Show logs if chain simulator fails to start`) using the `if: failure()` condition in the workflow file. This will automatically print the logs for both `es-container` and `chainsimulator` if the setup fails in the future, reducing investigation time.

## How to test
- Wait for the GitHub Actions pipeline to finish running on this PR; the chain simulator startup step should now pass successfully (green).
- Run `npm run start-chain-simulator` locally to confirm that your development environment works correctly and remains stable with the new Elasticsearch image (`7.17.18`).
- (Optional) To validate the new log extraction step, you can temporarily force an error (e.g., by misspelling a service name in `depends_on`) to verify that the container logs are correctly printed in the GitHub Actions console before the job is canceled.