### PR TITLE
fix metrics

### DIFF
--- a/src/common/metrics/api.metrics.module.ts
+++ b/src/common/metrics/api.metrics.module.ts
@@ -2,12 +2,18 @@ import { MetricsModule } from "@multiversx/sdk-nestjs-monitoring";
 import { Global, Module } from "@nestjs/common";
 import { EventEmitterModule } from "@nestjs/event-emitter";
 import { ApiMetricsService } from "./api.metrics.service";
+import { ApiConfigModule } from "src/common/api-config/api.config.module";
+import { GatewayModule } from "src/common/gateway/gateway.module";
+import { ProtocolModule } from "src/common/protocol/protocol.module";
 
 @Global()
 @Module({
   imports: [
     MetricsModule,
     EventEmitterModule.forRoot({ maxListeners: 1 }),
+    ApiConfigModule,
+    GatewayModule,
+    ProtocolModule,
   ],
   providers: [
     ApiMetricsService,

--- a/src/common/metrics/api.metrics.service.ts
+++ b/src/common/metrics/api.metrics.service.ts
@@ -184,7 +184,6 @@ export class ApiMetricsService {
   @OnEvent(MetricsEvents.SetLastProcessedNonce)
   setLastProcessedNonce(payload: LogMetricsEvent) {
     const [shardId, nonce] = payload.args;
-    console.log(`Setting last processed nonce for shard ${shardId} to ${nonce}...`);
     ApiMetricsService.lastProcessedNonceGauge.set({ shardId }, nonce);
   }
 

--- a/src/common/pubsub/pub.sub.listener.module.ts
+++ b/src/common/pubsub/pub.sub.listener.module.ts
@@ -2,11 +2,13 @@ import { Module } from '@nestjs/common';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { PubSubListenerController } from './pub.sub.listener.controller';
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
     DynamicModuleUtils.getCacheModule(),
     LoggingModule,
+    ApiMetricsModule,
   ],
   controllers: [
     PubSubListenerController,

--- a/src/common/websockets/web-socket-publisher-module.ts
+++ b/src/common/websockets/web-socket-publisher-module.ts
@@ -3,10 +3,12 @@ import { TransactionActionModule } from "src/endpoints/transactions/transaction-
 import { WebSocketPublisherService } from "./web-socket-publisher-service";
 import { WebSocketPublisherController } from "./web-socket-publisher-controller";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
     TransactionActionModule,
+    ApiMetricsModule,
   ],
   controllers: [
     WebSocketPublisherController,

--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -11,6 +11,7 @@ import { GuestCacheWarmer } from '@multiversx/sdk-nestjs-cache';
 import { PluginModule } from 'src/plugins/plugin.module';
 import { TpsWarmerService } from '../tps/tps-warmer.service';
 import { TpsModule } from 'src/endpoints/tps/tps.module';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
@@ -23,6 +24,7 @@ import { TpsModule } from 'src/endpoints/tps/tps.module';
     NftCronModule,
     PluginModule,
     TpsModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/elastic.updater/elastic.updater.module.ts
+++ b/src/crons/elastic.updater/elastic.updater.module.ts
@@ -4,6 +4,7 @@ import { AssetsModule } from 'src/common/assets/assets.module';
 import { PersistenceModule } from 'src/common/persistence/persistence.module';
 import { EndpointsServicesModule } from 'src/endpoints/endpoints.services.module';
 import { ElasticUpdaterService } from './elastic.updater.service';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
@@ -11,6 +12,7 @@ import { ElasticUpdaterService } from './elastic.updater.service';
     EndpointsServicesModule,
     AssetsModule,
     forwardRef(() => PersistenceModule),
+    ApiMetricsModule,
   ],
   providers: [
     ElasticUpdaterService,

--- a/src/crons/status.checker/status.checker.module.ts
+++ b/src/crons/status.checker/status.checker.module.ts
@@ -4,11 +4,13 @@ import { ElasticIndexerService } from "src/common/indexer/elastic/elastic.indexe
 import { EndpointsServicesModule } from "src/endpoints/endpoints.services.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { StatusCheckerService } from "./status.checker.service";
+import { ApiMetricsModule } from "src/common/metrics/api.metrics.module";
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
     EndpointsServicesModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/batch.transaction.processor.module.ts
+++ b/src/crons/transaction.processor/batch.transaction.processor.module.ts
@@ -1,7 +1,6 @@
 import { Module } from "@nestjs/common";
 import { ScheduleModule } from "@nestjs/schedule";
 import { ApiConfigModule } from "src/common/api-config/api.config.module";
-import { ApiMetricsModule } from "src/common/metrics/api.metrics.module";
 import { TransactionsBatchModule } from "src/endpoints/transactions.batch/transactions.batch.module";
 import { TransactionModule } from "src/endpoints/transactions/transaction.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
@@ -14,7 +13,6 @@ import { BatchTransactionProcessorService } from "./batch.transaction.processor.
     DynamicModuleUtils.getCacheModule(),
     TransactionsBatchModule,
     TransactionModule,
-    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/batch.transaction.processor.module.ts
+++ b/src/crons/transaction.processor/batch.transaction.processor.module.ts
@@ -5,6 +5,7 @@ import { TransactionsBatchModule } from "src/endpoints/transactions.batch/transa
 import { TransactionModule } from "src/endpoints/transactions/transaction.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { BatchTransactionProcessorService } from "./batch.transaction.processor.service";
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { BatchTransactionProcessorService } from "./batch.transaction.processor.
     DynamicModuleUtils.getCacheModule(),
     TransactionsBatchModule,
     TransactionModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/batch.transaction.processor.module.ts
+++ b/src/crons/transaction.processor/batch.transaction.processor.module.ts
@@ -1,6 +1,7 @@
 import { Module } from "@nestjs/common";
 import { ScheduleModule } from "@nestjs/schedule";
 import { ApiConfigModule } from "src/common/api-config/api.config.module";
+import { ApiMetricsModule } from "src/common/metrics/api.metrics.module";
 import { TransactionsBatchModule } from "src/endpoints/transactions.batch/transactions.batch.module";
 import { TransactionModule } from "src/endpoints/transactions/transaction.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
@@ -13,6 +14,7 @@ import { BatchTransactionProcessorService } from "./batch.transaction.processor.
     DynamicModuleUtils.getCacheModule(),
     TransactionsBatchModule,
     TransactionModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/transaction.processor.module.ts
+++ b/src/crons/transaction.processor/transaction.processor.module.ts
@@ -4,9 +4,7 @@ import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { NodeModule } from 'src/endpoints/nodes/node.module';
 import { ShardModule } from 'src/endpoints/shards/shard.module';
 import { TransactionModule } from 'src/endpoints/transactions/transaction.module';
-import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
-import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
-import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module'; import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionProcessorService } from './transaction.processor.service';
 
 @Module({
@@ -17,7 +15,6 @@ import { TransactionProcessorService } from './transaction.processor.service';
     NodeModule,
     NftModule,
     NftWorkerModule,
-    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/transaction.processor.module.ts
+++ b/src/crons/transaction.processor/transaction.processor.module.ts
@@ -5,6 +5,7 @@ import { NodeModule } from 'src/endpoints/nodes/node.module';
 import { ShardModule } from 'src/endpoints/shards/shard.module';
 import { TransactionModule } from 'src/endpoints/transactions/transaction.module';
 import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionProcessorService } from './transaction.processor.service';
 
@@ -16,6 +17,7 @@ import { TransactionProcessorService } from './transaction.processor.service';
     NodeModule,
     NftModule,
     NftWorkerModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/transaction.processor.module.ts
+++ b/src/crons/transaction.processor/transaction.processor.module.ts
@@ -4,7 +4,9 @@ import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { NodeModule } from 'src/endpoints/nodes/node.module';
 import { ShardModule } from 'src/endpoints/shards/shard.module';
 import { TransactionModule } from 'src/endpoints/transactions/transaction.module';
-import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module'; import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionProcessorService } from './transaction.processor.service';
 
 @Module({
@@ -15,6 +17,7 @@ import { TransactionProcessorService } from './transaction.processor.service';
     NodeModule,
     NftModule,
     NftWorkerModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),

--- a/src/crons/transaction.processor/transaction.processor.service.ts
+++ b/src/crons/transaction.processor/transaction.processor.service.ts
@@ -71,7 +71,6 @@ export class TransactionProcessorService {
       },
       setLastProcessedNonce: async (shardId, nonce) => {
         const event = new LogMetricsEvent();
-        console.log(`Emitting event to set last processed nonce for shard ${shardId} to ${nonce}`);
         event.args = [shardId, nonce];
         this.eventEmitter.emit(
           MetricsEvents.SetLastProcessedNonce,

--- a/src/crons/websocket/websocket.subscription.module.ts
+++ b/src/crons/websocket/websocket.subscription.module.ts
@@ -18,6 +18,7 @@ import { EventsCustomGateway } from './events.custom.gateway';
 import { ApiConfigModule } from 'src/common/api-config/api.config.module';
 import { TransfersCustomGateway } from './transfers.custom.gateway';
 import { TransferModule } from 'src/endpoints/transfers/transfer.module';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
@@ -30,6 +31,7 @@ import { TransferModule } from 'src/endpoints/transfers/transfer.module';
     RoundModule,
     TransferModule,
     ApiConfigModule,
+    ApiMetricsModule,
   ],
   providers: [
     WebsocketCronService,

--- a/src/endpoints/mex/mex.module.ts
+++ b/src/endpoints/mex/mex.module.ts
@@ -10,7 +10,7 @@ import { MexTokenChartsService } from "./mex.token.charts.service";
 import { MexTokenService } from "./mex.token.service";
 import { MexWarmerService } from "./mex.warmer.service";
 @Module({
-  imports: [GraphQlModule], // mutat aici
+  imports: [GraphQlModule],
   providers: [
     MexEconomicsService,
     MexSettingsService,

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -10,6 +10,7 @@ import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { LocalCacheController } from './endpoints/caching/local.cache.controller';
 import { RestrictedRoutesMiddleware } from './utils/restricted.routes.middleware';
+import { ApiMetricsModule } from './common/metrics/api.metrics.module';
 
 @Module({
   imports: [
@@ -17,6 +18,7 @@ import { RestrictedRoutesMiddleware } from './utils/restricted.routes.middleware
     EndpointsServicesModule,
     EndpointsControllersModule.forRoot(),
     DynamicModuleUtils.getRedisCacheModule(),
+    ApiMetricsModule,
   ],
   controllers: [
     LocalCacheController,

--- a/src/queue.worker/nft.worker/queue/nft.queue.module.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.module.ts
@@ -3,11 +3,13 @@ import { NftQueueController } from './nft.queue.controller';
 import { NftJobProcessorModule } from './job-services/nft.job.processor.module';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
+import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 
 @Module({
   imports: [
     NftJobProcessorModule,
     NftModule,
+    ApiMetricsModule,
   ],
   providers: [
     DynamicModuleUtils.getPubSubService(),


### PR DESCRIPTION
# Reasoning
- Metrics `@OnEvent` listeners missed events because `ApiMetricsModule` wasn't loaded in some Nest application contexts.  
- `ApiMetricsService` produced DI errors when instantiated without its required providers.

# Proposed changes
- Load `ApiMetricsModule` in every Nest application context that is started indepedently
- Add required provider imports in the metrics module so DI resolves reliably.

# How to test
- Metrics should be displayed in grafana dashboard