### PR TITLE
Fix nest modules

### DIFF
--- a/.github/workflows/chain-simulator-e2e-tests.yml
+++ b/.github/workflows/chain-simulator-e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+  workflow_dispatch:
 
 jobs:
   test-chainsimulator-e2e:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,6 +8,7 @@ on:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/load-tests.yml
+++ b/.github/workflows/load-tests.yml
@@ -3,6 +3,7 @@ name: Load Tests
 on:
   pull_request:
     branches: [main, development]
+  workflow_dispatch:
 
 jobs:
   test-base:

--- a/.github/workflows/unit.tests.yml
+++ b/.github/workflows/unit.tests.yml
@@ -8,6 +8,7 @@ on:
     branches: [main, development]
   pull_request:
     branches: [main, development]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/src/crons/nft/nft.cron.module.ts
+++ b/src/crons/nft/nft.cron.module.ts
@@ -1,5 +1,4 @@
 import { Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
 import { CollectionModule } from 'src/endpoints/collections/collection.module';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
@@ -9,7 +8,6 @@ import { NftAssetModule } from 'src/queue.worker/nft.worker/queue/job-services/a
 
 @Module({
   imports: [
-    ScheduleModule.forRoot(),
     NftWorkerModule,
     NftModule,
     CollectionModule,

--- a/src/endpoints/endpoints.controllers.module.ts
+++ b/src/endpoints/endpoints.controllers.module.ts
@@ -46,7 +46,7 @@ export class EndpointsControllersModule {
     const controllers: Type<any>[] = [
       AccountController, BlockController, CollectionController, DelegationController, DelegationLegacyController, IdentitiesController,
       KeysController, MiniBlockController, NetworkController, NftController, TagController, NodeController,
-      ProviderController, GatewayProxyController, RoundController, SmartContractResultController, ShardController, StakeController, StakeController,
+      ProviderController, GatewayProxyController, RoundController, SmartContractResultController, ShardController, StakeController,
       TokenController, TransactionController, UsernameController, VmQueryController, WaitingListController,
       HealthCheckController, DappConfigController, WebsocketController, TransferController,
       ProcessNftsPublicController, TransactionsBatchController, ApplicationController, EventsController,

--- a/src/endpoints/endpoints.services.module.ts
+++ b/src/endpoints/endpoints.services.module.ts
@@ -58,7 +58,6 @@ import { EventsModule } from "./events/events.module";
     ShardModule,
     StakeModule,
     TokenModule,
-    RoundModule,
     TransactionModule,
     UsernameModule,
     VmQueryModule,
@@ -81,7 +80,7 @@ import { EventsModule } from "./events/events.module";
   exports: [
     AccountModule, CollectionModule, BlockModule, DelegationModule, DelegationLegacyModule, IdentitiesModule, KeysModule,
     MiniBlockModule, NetworkModule, NftModule, NftMediaModule, TagModule, NodeModule, ProviderModule,
-    RoundModule, SmartContractResultModule, ShardModule, StakeModule, TokenModule, RoundModule, TransactionModule, UsernameModule, VmQueryModule,
+    RoundModule, SmartContractResultModule, ShardModule, StakeModule, TokenModule, TransactionModule, UsernameModule, VmQueryModule,
     WaitingListModule, EsdtModule, BlsModule, DappConfigModule, TransferModule, PoolModule, TransactionActionModule, WebsocketModule, MexModule,
     ProcessNftsModule, NftMarketplaceModule, TransactionsBatchModule, TpsModule, ApplicationModule, EventsModule,
   ],

--- a/src/endpoints/vm.query/vm.query.module.ts
+++ b/src/endpoints/vm.query/vm.query.module.ts
@@ -1,5 +1,4 @@
 import { Module } from "@nestjs/common";
-import { EventEmitterModule } from "@nestjs/event-emitter";
 import { ApiConfigModule } from "src/common/api-config/api.config.module";
 import { GatewayModule } from "src/common/gateway/gateway.module";
 import { ProtocolModule } from "src/common/protocol/protocol.module";
@@ -14,7 +13,6 @@ import { VmQueryService } from "./vm.query.service";
     ProtocolModule,
     ApiConfigModule,
     SettingsModule,
-    EventEmitterModule.forRoot({ maxListeners: 1 }),
   ],
   providers: [
     VmQueryService,

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -11,9 +11,11 @@ import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { LocalCacheController } from './endpoints/caching/local.cache.controller';
 import { RestrictedRoutesMiddleware } from './utils/restricted.routes.middleware';
 import { ApiMetricsModule } from './common/metrics/api.metrics.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
     LoggingModule,
     EndpointsServicesModule,
     EndpointsControllersModule.forRoot(),

--- a/src/test/chain-simulator/websocket.subscriptions.cs-e2e.ts
+++ b/src/test/chain-simulator/websocket.subscriptions.cs-e2e.ts
@@ -207,7 +207,7 @@ describe('Websocket subscriptions e2e tests', () => {
       await axios.post(`${config.chainSimulatorUrl}/simulator/generate-blocks/10`);
 
       log("Waiting for WS messages...");
-      await new Promise(resolve => setTimeout(resolve, 40000));
+      await new Promise(resolve => setTimeout(resolve, 30000));
 
     } catch (e: any) {
       console.error("Error in beforeAll:", e.message);


### PR DESCRIPTION
## Reasoning
- one single cron was registered multiple times in the same app
- modules problems causing failing e2e tests

## Proposed Changes
- Remove duplicate imports.
- Move `forRoot` imports to the root module only.

## How to test
- Start the app and verify it boots without import-related errors and diplicated cron runnings
- e2e chain simulator tests should pass