### PR TITLE
Modules Import Refactor

### DIFF
--- a/src/common/metrics/api.metrics.module.ts
+++ b/src/common/metrics/api.metrics.module.ts
@@ -1,6 +1,5 @@
 import { MetricsModule } from "@multiversx/sdk-nestjs-monitoring";
 import { Global, Module } from "@nestjs/common";
-import { EventEmitterModule } from "@nestjs/event-emitter";
 import { ApiMetricsService } from "./api.metrics.service";
 import { ApiConfigModule } from "src/common/api-config/api.config.module";
 import { GatewayModule } from "src/common/gateway/gateway.module";
@@ -10,7 +9,6 @@ import { ProtocolModule } from "src/common/protocol/protocol.module";
 @Module({
   imports: [
     MetricsModule,
-    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiConfigModule,
     GatewayModule,
     ProtocolModule,

--- a/src/common/pubsub/pub.sub.listener.module.ts
+++ b/src/common/pubsub/pub.sub.listener.module.ts
@@ -4,12 +4,14 @@ import { PubSubListenerController } from './pub.sub.listener.controller';
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     DynamicModuleUtils.getCacheModule(),
     LoggingModule,
-    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiMetricsModule,
   ],
   controllers: [

--- a/src/common/pubsub/pub.sub.listener.module.ts
+++ b/src/common/pubsub/pub.sub.listener.module.ts
@@ -3,11 +3,13 @@ import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { PubSubListenerController } from './pub.sub.listener.controller';
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     DynamicModuleUtils.getCacheModule(),
     LoggingModule,
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiMetricsModule,
   ],
   controllers: [

--- a/src/common/rabbitmq/rabbitmq.module.ts
+++ b/src/common/rabbitmq/rabbitmq.module.ts
@@ -9,9 +9,13 @@ import { ApiConfigService } from '../api-config/api.config.service';
 import { RabbitMqConsumer } from './rabbitmq.consumer';
 import { RabbitMqNftHandlerService } from './rabbitmq.nft.handler.service';
 import { RabbitMqTokenHandlerService } from './rabbitmq.token.handler.service';
+import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiConfigModule,
     NftModule,
     NftWorkerModule,

--- a/src/common/websockets/web-socket-publisher-module.ts
+++ b/src/common/websockets/web-socket-publisher-module.ts
@@ -4,10 +4,12 @@ import { WebSocketPublisherService } from "./web-socket-publisher-service";
 import { WebSocketPublisherController } from "./web-socket-publisher-controller";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from "@nestjs/event-emitter";
 
 @Module({
   imports: [
     TransactionActionModule,
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiMetricsModule,
   ],
   controllers: [

--- a/src/common/websockets/web-socket-publisher-module.ts
+++ b/src/common/websockets/web-socket-publisher-module.ts
@@ -5,11 +5,13 @@ import { WebSocketPublisherController } from "./web-socket-publisher-controller"
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { EventEmitterModule } from "@nestjs/event-emitter";
+import { ScheduleModule } from "@nestjs/schedule";
 
 @Module({
   imports: [
-    TransactionActionModule,
+    ScheduleModule.forRoot(),
     EventEmitterModule.forRoot({ maxListeners: 1 }),
+    TransactionActionModule,
     ApiMetricsModule,
   ],
   controllers: [

--- a/src/crons/cache.warmer/cache.warmer.module.ts
+++ b/src/crons/cache.warmer/cache.warmer.module.ts
@@ -12,10 +12,12 @@ import { PluginModule } from 'src/plugins/plugin.module';
 import { TpsWarmerService } from '../tps/tps-warmer.service';
 import { TpsModule } from 'src/endpoints/tps/tps.module';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     EndpointsServicesModule,
     KeybaseModule,
     MexModule.forRoot(),

--- a/src/crons/elastic.updater/elastic.updater.module.ts
+++ b/src/crons/elastic.updater/elastic.updater.module.ts
@@ -5,10 +5,12 @@ import { PersistenceModule } from 'src/common/persistence/persistence.module';
 import { EndpointsServicesModule } from 'src/endpoints/endpoints.services.module';
 import { ElasticUpdaterService } from './elastic.updater.service';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     EndpointsServicesModule,
     AssetsModule,
     forwardRef(() => PersistenceModule),

--- a/src/crons/status.checker/status.checker.module.ts
+++ b/src/crons/status.checker/status.checker.module.ts
@@ -5,10 +5,12 @@ import { EndpointsServicesModule } from "src/endpoints/endpoints.services.module
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { StatusCheckerService } from "./status.checker.service";
 import { ApiMetricsModule } from "src/common/metrics/api.metrics.module";
+import { EventEmitterModule } from "@nestjs/event-emitter";
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     EndpointsServicesModule,
     ApiMetricsModule,
   ],

--- a/src/crons/transaction.processor/batch.transaction.processor.module.ts
+++ b/src/crons/transaction.processor/batch.transaction.processor.module.ts
@@ -6,10 +6,12 @@ import { TransactionModule } from "src/endpoints/transactions/transaction.module
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { BatchTransactionProcessorService } from "./batch.transaction.processor.service";
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from "@nestjs/event-emitter";
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiConfigModule,
     DynamicModuleUtils.getCacheModule(),
     TransactionsBatchModule,

--- a/src/crons/transaction.processor/transaction.completed.module.ts
+++ b/src/crons/transaction.processor/transaction.completed.module.ts
@@ -6,10 +6,12 @@ import { TransactionCompletedService } from './transaction.completed.service';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { GatewayModule } from 'src/common/gateway/gateway.module';
 import { ProtocolModule } from 'src/common/protocol/protocol.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiConfigModule,
     ApiMetricsModule,
     GatewayModule,

--- a/src/crons/transaction.processor/transaction.processor.module.ts
+++ b/src/crons/transaction.processor/transaction.processor.module.ts
@@ -8,10 +8,12 @@ import { NftWorkerModule } from 'src/queue.worker/nft.worker/nft.worker.module';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { TransactionProcessorService } from './transaction.processor.service';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     TransactionModule,
     ShardModule,
     NodeModule,

--- a/src/crons/websocket/websocket.subscription.module.ts
+++ b/src/crons/websocket/websocket.subscription.module.ts
@@ -19,10 +19,12 @@ import { ApiConfigModule } from 'src/common/api-config/api.config.module';
 import { TransfersCustomGateway } from './transfers.custom.gateway';
 import { TransferModule } from 'src/endpoints/transfers/transfer.module';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     TransactionModule,
     BlockModule,
     NetworkModule,

--- a/src/endpoints/vm.query/vm.query.module.ts
+++ b/src/endpoints/vm.query/vm.query.module.ts
@@ -5,7 +5,6 @@ import { ProtocolModule } from "src/common/protocol/protocol.module";
 import { SettingsModule } from "src/common/settings/settings.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { VmQueryService } from "./vm.query.service";
-import { EventEmitterModule } from "@nestjs/event-emitter";
 
 @Module({
   imports: [
@@ -14,7 +13,6 @@ import { EventEmitterModule } from "@nestjs/event-emitter";
     ProtocolModule,
     ApiConfigModule,
     SettingsModule,
-    EventEmitterModule.forRoot(),
   ],
   providers: [
     VmQueryService,

--- a/src/endpoints/vm.query/vm.query.module.ts
+++ b/src/endpoints/vm.query/vm.query.module.ts
@@ -5,6 +5,7 @@ import { ProtocolModule } from "src/common/protocol/protocol.module";
 import { SettingsModule } from "src/common/settings/settings.module";
 import { DynamicModuleUtils } from "src/utils/dynamic.module.utils";
 import { VmQueryService } from "./vm.query.service";
+import { EventEmitterModule } from "@nestjs/event-emitter";
 
 @Module({
   imports: [
@@ -13,6 +14,7 @@ import { VmQueryService } from "./vm.query.service";
     ProtocolModule,
     ApiConfigModule,
     SettingsModule,
+    EventEmitterModule.forRoot(),
   ],
   providers: [
     VmQueryService,

--- a/src/private.app.module.ts
+++ b/src/private.app.module.ts
@@ -7,10 +7,12 @@ import { ProcessNftsModule } from './endpoints/process-nfts/process.nfts.module'
 import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { ApiMetricsModule } from './common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     LoggingModule,
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ProcessNftsModule,
     ApiMetricsModule,
   ],

--- a/src/private.app.module.ts
+++ b/src/private.app.module.ts
@@ -8,11 +8,13 @@ import { LoggingModule } from '@multiversx/sdk-nestjs-common';
 import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { ApiMetricsModule } from './common/metrics/api.metrics.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
-    LoggingModule,
+    ScheduleModule.forRoot(),
     EventEmitterModule.forRoot({ maxListeners: 1 }),
+    LoggingModule,
     ProcessNftsModule,
     ApiMetricsModule,
   ],

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -12,10 +12,12 @@ import { LocalCacheController } from './endpoints/caching/local.cache.controller
 import { RestrictedRoutesMiddleware } from './utils/restricted.routes.middleware';
 import { ApiMetricsModule } from './common/metrics/api.metrics.module';
 import { ScheduleModule } from '@nestjs/schedule';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(), // for plugins, best practice not to have crons in public API
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     LoggingModule,
     EndpointsServicesModule,
     EndpointsControllersModule.forRoot(),

--- a/src/public.app.module.ts
+++ b/src/public.app.module.ts
@@ -11,9 +11,11 @@ import { DynamicModuleUtils } from './utils/dynamic.module.utils';
 import { LocalCacheController } from './endpoints/caching/local.cache.controller';
 import { RestrictedRoutesMiddleware } from './utils/restricted.routes.middleware';
 import { ApiMetricsModule } from './common/metrics/api.metrics.module';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(), // for plugins, best practice not to have crons in public API
     LoggingModule,
     EndpointsServicesModule,
     EndpointsControllersModule.forRoot(),

--- a/src/queue.worker/nft.worker/queue/nft.queue.module.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.module.ts
@@ -5,12 +5,14 @@ import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
+import { ScheduleModule } from '@nestjs/schedule';
 
 @Module({
   imports: [
+    ScheduleModule.forRoot(),
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     NftJobProcessorModule,
     NftModule,
-    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiMetricsModule,
   ],
   providers: [

--- a/src/queue.worker/nft.worker/queue/nft.queue.module.ts
+++ b/src/queue.worker/nft.worker/queue/nft.queue.module.ts
@@ -4,11 +4,13 @@ import { NftJobProcessorModule } from './job-services/nft.job.processor.module';
 import { NftModule } from 'src/endpoints/nfts/nft.module';
 import { DynamicModuleUtils } from 'src/utils/dynamic.module.utils';
 import { ApiMetricsModule } from 'src/common/metrics/api.metrics.module';
+import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
   imports: [
     NftJobProcessorModule,
     NftModule,
+    EventEmitterModule.forRoot({ maxListeners: 1 }),
     ApiMetricsModule,
   ],
   providers: [


### PR DESCRIPTION
## Reasoning
- each individual app must have its own `scheduler` imported at the root module
-  each individual app must have its `event emitter` imported at the root module
  
## Proposed Changes
- import `ScheduleModule` and `EventEmitter` at each individual app root module

## How to test
- dependency errors should disappear
