### PR TITLE
Fix nfts thumbnail processing

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -52,6 +52,11 @@ export class NftThumbnailService {
       ffmpeg(videoPath)
         .seek(seek)
         .takeFrames(1)
+        // Force YUV420P format to ensure compatibility with the MJPEG encoder.
+        .videoFilters('format=yuv420p')
+        // Set strictness to 'unofficial' to allow 'limited range' color inputs, 
+        // which prevents the encoder from rejecting standard video streams.
+        .outputOptions(['-strict', 'unofficial'])
         .saveToFile(outputPath)
         .on('start', (commandLine) => {
           this.logger.log('Spawned ffmpeg with command: ' + commandLine);


### PR DESCRIPTION
## Reasoning
- The current FFmpeg configuration fails for standard "limited range" video streams, causing an "Invalid argument" error in the MJPEG encoder.
- The encoder requires explicit pixel format and strictness settings to accept standard H.264/YUV420p video inputs.

## Proposed Changes
- Added `.videoFilters('format=yuv420p')` to ensure consistent color space compatibility.
- Added `.outputOptions(['-strict', 'unofficial'])` to allow processing of standard video color ranges.

## How to test
- Run the thumbnail generation service on an NFT asset that previously triggered the "Non full-range YUV" error.
- Verify that the thumbnail is correctly generated and saved to the output path without FFmpeg errors.