### PR TITLE
remove default values for events and tx filters

### DIFF
--- a/src/endpoints/events/entities/events.filter.ts
+++ b/src/endpoints/events/entities/events.filter.ts
@@ -4,13 +4,13 @@ export class EventsFilter {
     Object.assign(this, init);
   }
 
-  identifier: string = '';
-  address: string = '';
-  txHash: string = '';
-  shard: number = 0;
-  before: number = 0;
-  after: number = 0;
-  order: number = 0;
-  logAddress: string = '';
-  topics: string[] = [];
+  identifier?: string;
+  address?: string;
+  txHash?: string;
+  shard?: number;
+  before?: number;
+  after?: number;
+  order?: number;
+  logAddress?: string;
+  topics?: string[];
 }

--- a/src/endpoints/transactions/entities/transaction.filter.ts
+++ b/src/endpoints/transactions/entities/transaction.filter.ts
@@ -7,10 +7,10 @@ import { BadRequestException } from "@nestjs/common";
 export class TransactionFilter {
   address?: string;
   sender?: string;
-  senders?: string[] = [];
-  receivers?: string[] = [];
+  senders?: string[];
+  receivers?: string[];
   token?: string;
-  functions?: string[] = [];
+  functions?: string[];
   senderShard?: number;
   receiverShard?: number;
   miniBlockHash?: string;

--- a/src/test/unit/controllers/collections.controller.spec.ts
+++ b/src/test/unit/controllers/collections.controller.spec.ts
@@ -1022,7 +1022,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, functions: [] })
+        createTransactionFilter({ token: collection })
       );
     });
 

--- a/src/test/unit/controllers/collections.controller.spec.ts
+++ b/src/test/unit/controllers/collections.controller.spec.ts
@@ -1036,7 +1036,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?sender=${sender}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, sender: sender, functions: [] })
+        createTransactionFilter({ token: collection, sender: sender })
       );
     });
 
@@ -1050,7 +1050,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?senderShard=${senderShard}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, senderShard: senderShard, functions: [] })
+        createTransactionFilter({ token: collection, senderShard: senderShard })
       );
     });
 
@@ -1064,7 +1064,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?receiverShard=${receiverShard}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, receiverShard: receiverShard, functions: [] })
+        createTransactionFilter({ token: collection, receiverShard: receiverShard })
       );
     });
 
@@ -1078,7 +1078,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?miniBlockHash=${miniBlockHash}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, miniBlockHash: miniBlockHash, functions: [] })
+        createTransactionFilter({ token: collection, miniBlockHash: miniBlockHash })
       );
     });
 
@@ -1092,7 +1092,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?status=${status}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, status: status, functions: [] })
+        createTransactionFilter({ token: collection, status: status })
       );
     });
 
@@ -1106,7 +1106,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?before=${before}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, before: before, functions: [] })
+        createTransactionFilter({ token: collection, before: before })
       );
     });
 
@@ -1120,7 +1120,7 @@ describe('CollectionController', () => {
         .get(`${path}/${collection}/transactions/count?after=${after}`)
         .expect(200);
       expect(transactionServiceMocks.getTransactionCount).toHaveBeenCalledWith(
-        createTransactionFilter({ token: collection, after: after, functions: [] })
+        createTransactionFilter({ token: collection, after: after })
       );
     });
   });

--- a/src/test/unit/services/accounts.spec.ts
+++ b/src/test/unit/services/accounts.spec.ts
@@ -323,7 +323,7 @@ describe('Account Service', () => {
       const result = await service.getAccountTxCount(address);
 
       expect(transferService.getTransfersCount).toHaveBeenCalledWith(new TransactionFilter(
-        { address: address, functions: [], receivers: [], senders: [], type: TransactionType.Transaction }));
+        { address: address, type: TransactionType.Transaction }));
 
       expect(transactionService.getTransactionCountForAddress).not.toHaveBeenCalled();
       expect(result).toStrictEqual(expectedTxCount);
@@ -341,7 +341,7 @@ describe('Account Service', () => {
         const result = await service.getAccountScResults(address);
 
         expect(transferService.getTransfersCount).toHaveBeenCalledWith(new TransactionFilter(
-          { address: address, functions: [], receivers: [], senders: [], type: TransactionType.SmartContractResult }));
+          { address: address, type: TransactionType.SmartContractResult }));
 
         expect(smartContractResultService.getAccountScResultsCount).not.toHaveBeenCalledWith(address);
         expect(result).toStrictEqual(expectedTxCount);


### PR DESCRIPTION
## Reasoning
- using default values on filters leads to bad ES queries filtering with wrong data 
  
## Proposed Changes
- let filter fields be undefined if they are not explicitly defined

## How to test
- events ws subscriptions should emit data 