### PR TITLE
Fix accounts isSmartContract filtering

### DIFF
--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -709,11 +709,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.isSmartContract !== undefined) {
-      if (filter.isSmartContract) {
-        elasticQuery = this.buildAccountTypeFilter(elasticQuery, AccountType.SMART_CONTRACT);
-      } else {
-        elasticQuery = this.buildAccountTypeFilter(elasticQuery, AccountType.WALLET);
-      }
+      elasticQuery = this.buildAccountTypeFilter(elasticQuery, filter.isSmartContract ? AccountType.SMART_CONTRACT : AccountType.WALLET);
     }
 
     if (filter.name) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -737,7 +737,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.addresses !== undefined && filter.addresses.length > 0) {
-      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.addresses, address => QueryType.Match('address.keyword', address));
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.addresses, address => QueryType.Match('address', address));
     }
 
     if (filter.search) {

--- a/src/common/indexer/elastic/elastic.indexer.helper.ts
+++ b/src/common/indexer/elastic/elastic.indexer.helper.ts
@@ -710,9 +710,9 @@ export class ElasticIndexerHelper {
 
     if (filter.isSmartContract !== undefined) {
       if (filter.isSmartContract) {
-        elasticQuery = elasticQuery.withMustExistCondition('currentOwner');
+        elasticQuery = this.buildAccountTypeFilter(elasticQuery, AccountType.SMART_CONTRACT);
       } else {
-        elasticQuery = elasticQuery.withMustNotExistCondition('currentOwner');
+        elasticQuery = this.buildAccountTypeFilter(elasticQuery, AccountType.WALLET);
       }
     }
 
@@ -737,7 +737,7 @@ export class ElasticIndexerHelper {
     }
 
     if (filter.addresses !== undefined && filter.addresses.length > 0) {
-      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.addresses, address => QueryType.Match('address', address));
+      elasticQuery = elasticQuery.withMustMultiShouldCondition(filter.addresses, address => QueryType.Match('address.keyword', address));
     }
 
     if (filter.search) {


### PR DESCRIPTION
## Reasoning
- smart contract accounts are filtered by `currentOwner` field on indexer, which is not always present on a smart contract address

## Proposed Changes
- use prefix filtering insted of `currentOwner` field on indexer

## How to test
- an address like `erd1qqqqqqqqqqqqqpgqg726qlw8xqtcndmu2g0m8a2veundvpe8usys6l5law` without currentOwner field on indexer, should be returned when fetching /accounts?isSmartContract=true&size=1000 , all SCs count being < 9500
