### PR TITLE
Disable index controller

### DIFF
--- a/src/endpoints/proxy/proxy.module.ts
+++ b/src/endpoints/proxy/proxy.module.ts
@@ -2,7 +2,6 @@ import { Module } from "@nestjs/common";
 import { PluginModule } from "src/plugins/plugin.module";
 import { VmQueryModule } from "../vm.query/vm.query.module";
 import { GatewayProxyController } from "./gateway.proxy.controller";
-import { IndexProxyController } from "./index.proxy.controller";
 
 @Module({
   imports: [
@@ -11,7 +10,6 @@ import { IndexProxyController } from "./index.proxy.controller";
   ],
   controllers: [
     GatewayProxyController,
-    IndexProxyController,
   ],
 })
 export class ProxyModule { }


### PR DESCRIPTION
## Reasoning
- routes are already available through public indexer
  
## Proposed Changes
- removed controller from module

## How to test
- no `/index` routes available at startup