### PR TITLE
security-fixes

### DIFF
--- a/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/assets/nft.asset.service.ts
@@ -34,7 +34,7 @@ export class NftAssetService {
         description: `Uploading assets to S3 for NFT with identifier '${identifier}', file url '${fileUrl}'`,
         key: CacheInfo.PendingUploadAsset(cacheIdentifier).key,
         ttl: CacheInfo.PendingUploadAsset(cacheIdentifier).ttl,
-        action: async () => await this.apiService.get(mediaUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS }),
+        action: async () => await this.apiService.get(mediaUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS, skipRedirects: true }),
       });
 
       const file = fileResult.data;
@@ -57,7 +57,7 @@ export class NftAssetService {
       const url = TokenHelpers.computeNftUri(media.originalUrl, prefix);
 
       // eslint-disable-next-line require-await
-      const response = await this.apiService.head(url, undefined, async (error) => {
+      const response = await this.apiService.head(url, { skipRedirects: true }, async (error) => {
         const status = error.response?.status;
         if ([HttpStatus.FOUND, HttpStatus.NOT_FOUND, HttpStatus.FORBIDDEN].includes(status)) {
           return true;

--- a/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/media/nft.media.service.ts
@@ -12,6 +12,7 @@ import { TokenHelpers } from "src/utils/token.helpers";
 import { ClientProxy } from "@nestjs/microservices";
 import { OriginLogger } from "@multiversx/sdk-nestjs-common";
 import { CachingUtils } from "src/utils/caching.utils";
+import { isSafePublicUrl } from "src/utils/ip.utils";
 
 @Injectable()
 export class NftMediaService {
@@ -140,11 +141,11 @@ export class NftMediaService {
 
   private async getFilePropertiesFromHeaders(uri: string, prefix: string): Promise<{ contentType: string, contentLength: number } | null> {
     const url = this.getUrl(uri, prefix);
-    if (url.endsWith('.json')) {
+    if (url.endsWith('.json') || await isSafePublicUrl(url) === false) {
       return null;
     }
 
-    const response = await this.apiService.head(url, { timeout: this.IPFS_REQUEST_TIMEOUT });
+    const response = await this.apiService.head(url, { timeout: this.IPFS_REQUEST_TIMEOUT, skipRedirects: true });
 
     if (response.status !== HttpStatus.OK) {
       this.logger.error(`Unexpected http status code '${response.status}' while fetching file properties from url '${url}'`);

--- a/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
+++ b/src/queue.worker/nft.worker/queue/job-services/thumbnails/nft.thumbnail.service.ts
@@ -202,7 +202,7 @@ export class NftThumbnailService {
       description: `Generating thumbnail for NFT with identifier '${nftIdentifier}', url '${fileUrl}' and url hash '${urlHash}'`,
       key: CacheInfo.PendingGenerateThumbnail(cacheIdentifier).key,
       ttl: CacheInfo.PendingGenerateThumbnail(cacheIdentifier).ttl,
-      action: async () => await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS }),
+      action: async () => await this.apiService.get(fileUrl, { responseType: 'arraybuffer', timeout: this.API_TIMEOUT_MILLISECONDS, skipRedirects: true }),
     });
 
     if (!fileResult) {

--- a/src/test/unit/utils/ip.utils.spec.ts
+++ b/src/test/unit/utils/ip.utils.spec.ts
@@ -44,6 +44,13 @@ describe('IP Utils', () => {
     expect(mockLookup).toHaveBeenCalledTimes(privateAddresses.length);
   });
 
+  it('returns false for localhost resolving to a private ip', async () => {
+    mockLookup.mockResolvedValueOnce({ address: '127.0.0.1', family: 4 } as any);
+
+    await expect(isSafePublicUrl('http://localhost')).resolves.toBe(false);
+    expect(mockLookup).toHaveBeenCalledWith('localhost');
+  });
+
   it('returns true for public addresses', async () => {
     mockLookup.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 } as any);
 

--- a/src/test/unit/utils/ip.utils.spec.ts
+++ b/src/test/unit/utils/ip.utils.spec.ts
@@ -1,0 +1,59 @@
+import { promises as dns } from 'dns';
+import { isSafePublicUrl } from 'src/utils/ip.utils';
+
+jest.mock('dns', () => ({
+  promises: {
+    lookup: jest.fn(),
+  },
+}));
+
+describe('IP Utils', () => {
+  const mockLookup = dns.lookup as jest.MockedFunction<typeof dns.lookup>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns false for invalid urls and unsupported protocols', async () => {
+    await expect(isSafePublicUrl('not-a-url')).resolves.toBe(false);
+    await expect(isSafePublicUrl('ftp://example.com')).resolves.toBe(false);
+    expect(mockLookup).not.toHaveBeenCalled();
+  });
+
+  it('returns false for private ipv4 and ipv6 addresses', async () => {
+    const privateAddresses = [
+      '127.0.0.1',
+      '10.0.0.1',
+      '172.16.0.1',
+      '192.168.0.1',
+      '169.254.0.1',
+      '100.64.0.1',
+      '0.0.0.0',
+      '::1',
+      'fe80::1',
+      'fc00::1',
+      'fd00::1',
+    ];
+
+    for (const address of privateAddresses) {
+      mockLookup.mockResolvedValueOnce({ address, family: 4 } as any);
+
+      await expect(isSafePublicUrl('https://example.com')).resolves.toBe(false);
+    }
+
+    expect(mockLookup).toHaveBeenCalledTimes(privateAddresses.length);
+  });
+
+  it('returns true for public addresses', async () => {
+    mockLookup.mockResolvedValueOnce({ address: '93.184.216.34', family: 4 } as any);
+
+    await expect(isSafePublicUrl('https://example.com')).resolves.toBe(true);
+    expect(mockLookup).toHaveBeenCalledWith('example.com');
+  });
+
+  it('returns false when dns lookup fails', async () => {
+    mockLookup.mockRejectedValueOnce(new Error('DNS failure'));
+
+    await expect(isSafePublicUrl('https://example.com')).resolves.toBe(false);
+  });
+});

--- a/src/utils/ip.utils.ts
+++ b/src/utils/ip.utils.ts
@@ -1,17 +1,12 @@
 import { promises as dns } from 'dns';
 
-/**
- * Checks if an IP address (IPv4 or IPv6) belongs to a private or internal network.
- */
 function isPrivateIp(ip: string): boolean {
-  // IPv4 - Private classes, Loopback, Link-Local (AWS/GCP Metadata), and CGNAT
   const privateIpv4Regex = /^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\.|0\.)/;
 
   if (privateIpv4Regex.test(ip)) {
     return true;
   }
 
-  // IPv6 - Loopback (::1), Link-Local (fe80::), and Unique Local (fc00:: / fd00::)
   const normalizedIpv6 = ip.toLowerCase();
   if (
     normalizedIpv6 === '::1' ||
@@ -25,30 +20,22 @@ function isPrivateIp(ip: string): boolean {
   return false;
 }
 
-/**
- * Validates a URL string to prevent SSRF (Server-Side Request Forgery) attacks.
- * Returns `true` if the URL is safe (public) and `false` if it points to a private/invalid destination.
- */
 export async function isSafePublicUrl(urlString: string): Promise<boolean> {
   try {
-    // 1. Validate URL structure and scheme
     const parsedUrl = new URL(urlString);
 
     if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
-      return false; // Block unsupported protocols (e.g., file://, gopher://, ftp://)
+      return false;
     }
 
-    // 2. Resolve domain name (DNS) to its IP address
     const { address } = await dns.lookup(parsedUrl.hostname);
 
-    // 3. Check if the resolved IP is internal or private
     if (isPrivateIp(address)) {
-      return false; // Block access to cluster IPs, localhost, or cloud metadata endpoints
+      return false;
     }
 
-    return true; // The URL resolves to a safe public IP
+    return true;
   } catch {
-    // If the URL is malformed or DNS resolution fails, treat it as unsafe
     return false;
   }
 }

--- a/src/utils/ip.utils.ts
+++ b/src/utils/ip.utils.ts
@@ -1,0 +1,54 @@
+import { promises as dns } from 'dns';
+
+/**
+ * Checks if an IP address (IPv4 or IPv6) belongs to a private or internal network.
+ */
+function isPrivateIp(ip: string): boolean {
+  // IPv4 - Private classes, Loopback, Link-Local (AWS/GCP Metadata), and CGNAT
+  const privateIpv4Regex = /^(127\.|10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|169\.254\.|100\.(6[4-9]|[7-9][0-9]|1[0-1][0-9]|12[0-7])\.|0\.)/;
+
+  if (privateIpv4Regex.test(ip)) {
+    return true;
+  }
+
+  // IPv6 - Loopback (::1), Link-Local (fe80::), and Unique Local (fc00:: / fd00::)
+  const normalizedIpv6 = ip.toLowerCase();
+  if (
+    normalizedIpv6 === '::1' ||
+    normalizedIpv6.startsWith('fe80:') ||
+    normalizedIpv6.startsWith('fc00:') ||
+    normalizedIpv6.startsWith('fd00:')
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Validates a URL string to prevent SSRF (Server-Side Request Forgery) attacks.
+ * Returns `true` if the URL is safe (public) and `false` if it points to a private/invalid destination.
+ */
+export async function isSafePublicUrl(urlString: string): Promise<boolean> {
+  try {
+    // 1. Validate URL structure and scheme
+    const parsedUrl = new URL(urlString);
+
+    if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+      return false; // Block unsupported protocols (e.g., file://, gopher://, ftp://)
+    }
+
+    // 2. Resolve domain name (DNS) to its IP address
+    const { address } = await dns.lookup(parsedUrl.hostname);
+
+    // 3. Check if the resolved IP is internal or private
+    if (isPrivateIp(address)) {
+      return false; // Block access to cluster IPs, localhost, or cloud metadata endpoints
+    }
+
+    return true; // The URL resolves to a safe public IP
+  } catch {
+    // If the URL is malformed or DNS resolution fails, treat it as unsafe
+    return false;
+  }
+}


### PR DESCRIPTION
## Reasoning
- Improve security around NFT media processing.
- Reduce the risk of unsafe redirects and SSRF-style requests.

## Proposed Changes
- Added URL safety checks to validate public versus internal destinations.
- Updated NFT asset, media, and thumbnail requests to skip redirects.

## How to test
- Verify NFT uploads and thumbnail generation still work for normal public URLs.
- Confirm unsafe or internal URLs are handled safely and rejected.